### PR TITLE
fix(ci): move Docker image cleanup to after build step

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -161,10 +161,10 @@
 - [x] Write medication and adherence tests
 
 ### 2.7 Today Feed API
-- [ ] `GET /api/v1/feed/today` — aggregated daily tasks (meds + obligations from all providers)
-- [ ] Include source provider info for each task
-- [ ] Calculate which tasks are pending/completed/missed
-- [ ] Write feed tests
+- [x] `GET /api/v1/feed/today` — aggregated daily tasks (meds + obligations from all providers)
+- [x] Include source provider info for each task
+- [x] Calculate which tasks are pending/completed/missed
+- [x] Write feed tests
 
 ---
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -45,9 +45,16 @@ jobs:
             --location=${REGION} \
             --policy=backend/cleanup-policy.json || true
 
+      - name: Build Docker Image
+        run: |
+          IMAGE_PATH="${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME}:latest"
+          docker build -t $IMAGE_PATH ./backend
+          docker push $IMAGE_PATH
+
       - name: Clean up old images
         run: |
           # List all images and delete old ones (keep only latest)
+          # This runs AFTER the new image is pushed, so old images no longer have the "latest" tag
           gcloud artifacts docker images list \
             ${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME} \
             --format="get(version)" \
@@ -57,12 +64,6 @@ jobs:
                 "${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME}@${digest}" \
                 --quiet || true
           done
-
-      - name: Build Docker Image
-        run: |
-          IMAGE_PATH="${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME}:latest"
-          docker build -t $IMAGE_PATH ./backend
-          docker push $IMAGE_PATH
 
       - name: Deploy to Cloud Run
         run: |


### PR DESCRIPTION
## Problem
The Docker image cleanup step was failing because it ran BEFORE the new image was built and pushed.

**Error from logs:**
```
ERROR: Cannot delete image because it is tagged. Existing tags are:
- mediagent-backend:latest
```

## Root Cause
1. Cleanup runs first → tries to delete images without 'latest' tag
2. But the old image STILL has the 'latest' tag at this point
3. New image is built → gets tagged as 'latest'
4. Old image loses 'latest' tag, but cleanup already ran
5. Result: 2 images remain in the registry

## Solution
Move the cleanup step to run AFTER the new image is built and pushed:
1. Build new image → tag as 'latest'
2. Old image automatically loses 'latest' tag
3. Cleanup runs → successfully deletes old images without 'latest' tag

## Changes
- Reordered steps in `.github/workflows/deploy-backend.yml`
- Added comment explaining why cleanup runs after build
- Also updated `TASKS.md` to mark Today Feed API as complete

## Testing
Next deployment will verify the cleanup works correctly.

## Checklist
- [x] I have read the CODING_STANDARDS
- [x] My code matches existing architecture
- [x] I have verified the workflow order is correct
- [x] There are no new warnings or secrets