### PR TITLE
feat(ingestion): complete Phase 4 — Ingestion Agent pipeline

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -269,11 +269,20 @@
 
 ### 4.4 Testing
 - [x] Create synthetic test documents (discharge summary, lab report, prescription, diagnostic report)
+  - [x] `backend/tests/fixtures/discharge_summary.txt`
+  - [x] `backend/tests/fixtures/lab_report.txt`
+  - [x] `backend/tests/fixtures/prescription.txt`
+  - [x] `backend/tests/fixtures/diagnostic_report.txt`
 - [x] Golden-set evaluation: expected parsing output for each test document
+  - [x] `backend/tests/fixtures/discharge_summary_expected.json`
+  - [x] `backend/tests/fixtures/lab_report_expected.json`
+  - [x] `backend/tests/fixtures/prescription_expected.json`
+  - [x] `backend/tests/fixtures/diagnostic_report_expected.json`
+- [x] Golden-set integration test: load fixture → run pipeline → assert against expected JSON
 - [x] Unit tests for FHIR builder and normalizer
 - [x] Integration test: upload → parse → database → Today Feed
 
-### 4.4 Patient Portal Integration
+### 4.5 Patient Portal Integration
 - [x] Wire up document upload → API → Ingestion Agent → DB
 - [x] Today Feed auto-populates after document parsing
 - [x] "Explain This" calls AI and displays summary
@@ -288,6 +297,7 @@
 - [ ] Message persistence to `chat_messages` table
 - [ ] Conversation history retrieval (sliding window + summary)
 - [ ] Patient context injection (active meds, recent symptoms, conditions)
+- [ ] Document context injection: "Ask about this document" → chat opens with document summary pre-loaded
 
 ### 5.2 Triage Agent
 - [ ] Intent classification (symptom, medication_question, schedule, general, urgent)
@@ -315,6 +325,8 @@
 - [ ] Voice-to-voice pipeline: mic → STT → Triage Agent → response → TTS → speaker
 - [ ] Language detection from audio
 - [ ] Audio message storage (Supabase Storage, URL in chat_messages)
+- [ ] Voice readback of document summaries: 🔊 button on Records modal → TTS in selected language
+- [ ] Multilingual TTS beyond EN/ES (Hindi, Chinese, Vietnamese, Tagalog — top US non-English medical populations)
 
 ### 5.6 Patient Portal — Chat UI
 - [ ] Chat page layout (WhatsApp-style)
@@ -326,11 +338,18 @@
 - [ ] Real-time message streaming (typing indicator, progressive display)
 - [ ] Language indicator
 
-### 5.7 Testing
+### 5.7 Records → Chat Bridge
+- [ ] "Ask about this document" button in Records modal
+- [ ] Navigate to `/chat?context=doc:{document_id}`
+- [ ] Chat page reads query param → loads document AI summary as system context
+- [ ] Triage Agent uses document data for medication_question intent responses
+
+### 5.8 Testing
 - [ ] Golden-set for Triage Agent: 20+ test messages with expected intent + route
 - [ ] Golden-set for Symptom Agent: 10+ symptom conversations with expected structured output
 - [ ] Voice pipeline end-to-end test
 - [ ] Load test for WebSocket connections
+- [ ] Document→Chat context injection test: open chat from document → verify context available
 
 ---
 
@@ -365,6 +384,12 @@
 - [ ] Bidirectional sync: clinician upload → patient sees in My Records
 - [ ] Patient upload → clinician review queue
 - [ ] Trigger AI parsing on clinician uploads
+
+### 6.5 Structured Document Summary UI
+- [ ] Parse AI summary into sections: Medications | Watch For | Follow-up Dates
+- [ ] Display as accordion/cards instead of plain text blob
+- [ ] Each medication links to its Today Feed task
+- [ ] Clinician annotations: clinician adds notes that patient sees alongside AI summary
 
 ---
 

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -254,9 +254,9 @@
 - [x] Codebase cleanup (remove duplicates and unnecessary files)
 
 ### 4.2 Tools
-- [ ] FHIR Resource Builder (MedicationRequest, Condition, AllergyIntolerance, Appointment)
-- [ ] RxNorm API client (brand → generic → RxCUI normalization)
-- [ ] Medication normalizer (parse dosage strings, frequency extraction)
+- [x] FHIR Resource Builder (MedicationRequest, Condition, AllergyIntolerance, Appointment)
+- [x] RxNorm API client (brand → generic → RxCUI normalization)
+- [x] Medication normalizer (parse dosage strings, frequency extraction)
 
 ### 4.3 MedGemma Evaluation
 - [x] Deploy MedGemma 27B on Vertex AI Model Garden
@@ -271,13 +271,13 @@
 - [x] Create synthetic test documents (discharge summary, lab report, prescription, diagnostic report)
 - [x] Golden-set evaluation: expected parsing output for each test document
 - [x] Unit tests for FHIR builder and normalizer
-- [ ] Integration test: upload → parse → database → Today Feed
+- [x] Integration test: upload → parse → database → Today Feed
 
 ### 4.4 Patient Portal Integration
-- [ ] Wire up document upload → API → Ingestion Agent → DB
-- [ ] Today Feed auto-populates after document parsing
-- [ ] "Explain This" calls AI and displays summary
-- [ ] Handle parsing errors gracefully (show status, allow retry)
+- [x] Wire up document upload → API → Ingestion Agent → DB
+- [x] Today Feed auto-populates after document parsing
+- [x] "Explain This" calls AI and displays summary
+- [x] Handle parsing errors gracefully (show status, allow retry)
 
 ---
 

--- a/apps/patient-portal/next.config.ts
+++ b/apps/patient-portal/next.config.ts
@@ -1,7 +1,21 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadEnvConfig } from "@next/env";
 import type { NextConfig } from "next";
 
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(currentDir, "../..");
+
+loadEnvConfig(workspaceRoot);
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  outputFileTracingRoot: workspaceRoot,
+  env: {
+    NEXT_PUBLIC_SUPABASE_ANON_KEY:
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_SUPABASE_URL:
+      process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL,
+  },
 };
 
 export default nextConfig;

--- a/apps/patient-portal/package-lock.json
+++ b/apps/patient-portal/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@deepgram/sdk": "^5.0.0",
         "@reduxjs/toolkit": "^2.11.2",
+        "@supabase/supabase-js": "^2.102.1",
         "next": "16.1.7",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -2279,6 +2280,92 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.102.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.102.1.tgz",
+      "integrity": "sha512-2uH2WB0H98TOGDtaFWhxIcR42Dro/VB7VDZanz/4bVJsqioIue1m3TUqu3xciDm2W9r+1LXQvYNsYbQfWmD+uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.102.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.102.1.tgz",
+      "integrity": "sha512-UcrcKTPnAIo+Yp9Jjq9XXwFbsmgRYY637mwka9ZjmTIWcX/xr1pote4OVvaGQycVY1KTiQgjMvpC0Q0yJhRq3w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.102.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.102.1.tgz",
+      "integrity": "sha512-InLvXKAYf8BIqiv9jWOYudWB3rU8A9uMbcip5BQ5sLLNPrbO1Ekkr79OvlhZBgMNSppxVyC7wPPGzLxMcTZhlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.102.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.102.1.tgz",
+      "integrity": "sha512-h2fCumib/v6u7XMwSPgxnpfimjX4xCEayUHrxWLC7UurfQjUZJ0pmJDgm6yj80DnUerxuulRghwm5zXYysFG/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.102.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.102.1.tgz",
+      "integrity": "sha512-eCL9T4Xpe40nmKlkUJ7Zq/hk34db1xPiT0WL3Iv5MbJqHuCAe5TxhV8Rjqd6DNZrzjtfYObZtYl9jKJaHrivqw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.102.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.102.1.tgz",
+      "integrity": "sha512-bChxPVeLDnYN9M2d/u4fXsvylwSQG5grAl+HN8f+ZD9a9PuVU+Ru+xGmEsk+b9Iz3rJC9ZQnQUJYQ28fApdWYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.102.1",
+        "@supabase/functions-js": "2.102.1",
+        "@supabase/postgrest-js": "2.102.1",
+        "@supabase/realtime-js": "2.102.1",
+        "@supabase/storage-js": "2.102.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2708,7 +2795,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2739,6 +2825,15 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -5413,6 +5508,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -8258,7 +8362,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/apps/patient-portal/package.json
+++ b/apps/patient-portal/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@deepgram/sdk": "^5.0.0",
     "@reduxjs/toolkit": "^2.11.2",
+    "@supabase/supabase-js": "^2.102.1",
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -1,46 +1,203 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { DocumentCard } from "@/components/features";
 import { PageHeader } from "@/components/layouts";
-import { Button, EmptyState, Modal, ProgressBar } from "@/components/ui";
+import { Button, EmptyState, ErrorState, Modal, ProgressBar } from "@/components/ui";
 import { api } from "@/services/api";
+import { uploadDocumentToStorage } from "@/services/storage";
 import type { RootState } from "@/store/store";
 import { DocumentType, type Document } from "@/types";
 import { useSelector } from "react-redux";
 
 type PortalDocument = Document & { icon: string; provider: string };
 
-const initialDocuments: PortalDocument[] = [
-    {
-        aiSummary: "Your blood pressure is stable. LDL is slightly elevated, so keep taking your medication as directed.",
-        createdAt: "2026-03-15T00:00:00Z",
-        documentType: DocumentType.LAB_REPORT,
-        fileName: "Blood Panel Results",
-        fileSizeBytes: 120000,
-        fileUrl: "#",
-        icon: "🩸",
-        id: "doc-1",
-        mimeType: "application/pdf",
-        parsed: true,
-        patientId: "demo-patient",
-        provider: "Dr. Smith",
-        uploadedBy: "demo-patient",
-        uploadedByRole: "patient",
-        visibility: "all_providers",
-    },
-];
+interface DocumentApiRecord {
+    id: string;
+    patient_id: string;
+    uploaded_by: string;
+    uploaded_by_role: "patient" | "clinician";
+    document_type: DocumentType;
+    file_name: string;
+    file_url: string;
+    mime_type: string;
+    file_size_bytes: number;
+    parsed: boolean;
+    ai_summary?: string | null;
+    parse_status?: "none" | "pending" | "processing" | "completed" | "failed";
+    parse_error?: string | null;
+    parse_attempts?: number;
+    source_clinic?: string | null;
+    visibility: "all_providers" | "specific_provider";
+    created_at: string;
+}
+
+function getDocumentIcon(documentType: DocumentType) {
+    switch (documentType) {
+        case DocumentType.LAB_REPORT:
+            return "🩸";
+        case DocumentType.PRESCRIPTION:
+            return "💊";
+        case DocumentType.DISCHARGE_SUMMARY:
+            return "🏥";
+        case DocumentType.DIAGNOSTIC_REPORT:
+            return "🧪";
+        default:
+            return "📄";
+    }
+}
+
+function mapDocument(record: DocumentApiRecord): PortalDocument {
+    return {
+        aiSummary: record.ai_summary ?? undefined,
+        createdAt: record.created_at,
+        documentType: record.document_type,
+        fileName: record.file_name,
+        fileSizeBytes: record.file_size_bytes,
+        fileUrl: record.file_url,
+        icon: getDocumentIcon(record.document_type),
+        id: record.id,
+        mimeType: record.mime_type,
+        parseAttempts: record.parse_attempts ?? 0,
+        parseError: record.parse_error ?? undefined,
+        parseStatus: record.parse_status ?? (record.parsed ? "completed" : "none"),
+        parsed: record.parsed,
+        patientId: record.patient_id,
+        provider: record.source_clinic ?? "Care team",
+        sourceClinic: record.source_clinic ?? undefined,
+        uploadedBy: record.uploaded_by,
+        uploadedByRole: record.uploaded_by_role,
+        visibility: record.visibility,
+    };
+}
+
+function getDocumentStatus(document: PortalDocument) {
+    if (document.parseStatus === "processing" || document.parseStatus === "pending") {
+        return { label: "Processing...", variant: "warning" as const };
+    }
+    if (document.parseStatus === "failed") {
+        return { label: "Parse failed", variant: "danger" as const };
+    }
+    if (document.parsed && document.aiSummary) {
+        return { label: "AI Summary", variant: "info" as const };
+    }
+    return null;
+}
+
+function inferDocumentType(file: File): DocumentType {
+    const normalizedName = file.name.toLowerCase();
+    const normalizedType = file.type.toLowerCase();
+
+    if (normalizedType.includes("pdf") || normalizedName.endsWith(".pdf")) {
+        return DocumentType.LAB_REPORT;
+    }
+    if (normalizedType.startsWith("image/")) {
+        return DocumentType.DIAGNOSTIC_REPORT;
+    }
+    if (normalizedType === "text/csv" || normalizedName.endsWith(".csv")) {
+        return DocumentType.LAB_REPORT;
+    }
+    if (normalizedType === "text/plain" || normalizedName.endsWith(".txt")) {
+        return DocumentType.DISCHARGE_SUMMARY;
+    }
+    return DocumentType.OTHER;
+}
 
 export default function RecordsPage() {
-    const [documents, setDocuments] = useState(initialDocuments);
+    const [documents, setDocuments] = useState<PortalDocument[]>([]);
     const [selectedDocument, setSelectedDocument] = useState<PortalDocument | null>(null);
     const [explanationLang, setExplanationLang] = useState<"en" | "es">("en");
     const [explanationText, setExplanationText] = useState<string | null>(null);
     const [explanationLoading, setExplanationLoading] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [pageError, setPageError] = useState<string | null>(null);
+    const [parseError, setParseError] = useState<string | null>(null);
+    const [parsingDocIds, setParsingDocIds] = useState<Set<string>>(new Set());
     const [uploadProgress, setUploadProgress] = useState(0);
     const [uploading, setUploading] = useState(false);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
-    const token = useSelector((state: RootState) => state.auth.token);
+    const { token, user } = useSelector((state: RootState) => state.auth);
+
+    const loadDocuments = useCallback(async () => {
+        if (!token) {
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const result = await api.get<DocumentApiRecord[]>("/api/v1/documents/", {
+                token,
+            });
+            setDocuments(result.map(mapDocument));
+            setPageError(null);
+        } catch (error) {
+            setPageError((error as Error).message);
+        } finally {
+            setLoading(false);
+        }
+    }, [token]);
+
+    useEffect(() => {
+        if (!token) {
+            return;
+        }
+
+        void loadDocuments();
+    }, [loadDocuments, token]);
+
+    async function pollForParsedStatus(docId: string) {
+        setParsingDocIds((current) => new Set(current).add(docId));
+
+        for (let attempt = 0; attempt < 10; attempt += 1) {
+            await new Promise((resolve) => window.setTimeout(resolve, 3000));
+
+            try {
+                const record = await api.get<DocumentApiRecord>(
+                    `/api/v1/documents/${docId}`,
+                    { token: token ?? undefined },
+                );
+                const nextDocument = mapDocument(record);
+
+                setDocuments((current) =>
+                    current.map((document) =>
+                        document.id === docId ? nextDocument : document,
+                    ),
+                );
+
+                if (nextDocument.parsed || nextDocument.parseStatus === "completed") {
+                    setParsingDocIds((current) => {
+                        const next = new Set(current);
+                        next.delete(docId);
+                        return next;
+                    });
+                    return;
+                }
+
+                if (nextDocument.parseStatus === "failed") {
+                    setParseError(
+                        nextDocument.parseError
+                            ? `Failed to process document: ${nextDocument.parseError}`
+                            : "Failed to process document.",
+                    );
+                    setParsingDocIds((current) => {
+                        const next = new Set(current);
+                        next.delete(docId);
+                        return next;
+                    });
+                    return;
+                }
+            } catch {
+                // Keep polling until attempts are exhausted.
+            }
+        }
+
+        setParsingDocIds((current) => {
+            const next = new Set(current);
+            next.delete(docId);
+            return next;
+        });
+        setParseError("Timed out while waiting for document processing to finish.");
+    }
 
     async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
         const file = event.target.files?.[0];
@@ -48,6 +205,13 @@ export default function RecordsPage() {
             return;
         }
 
+        if (!token || !user) {
+            setPageError("Please sign in again before uploading a document.");
+            return;
+        }
+
+        setPageError(null);
+        setParseError(null);
         setUploading(true);
         for (const value of [20, 45, 70, 100]) {
             setUploadProgress(value);
@@ -55,47 +219,41 @@ export default function RecordsPage() {
         }
 
         try {
-            await api.post(
+            const filePath = await uploadDocumentToStorage({
+                file,
+                patientId: user.id,
+                token,
+            });
+            const created = await api.post<DocumentApiRecord>(
                 "/api/v1/documents/",
                 {
-                    document_type: "other",
+                    document_type: inferDocumentType(file),
                     file_name: file.name,
-                    file_path: `uploads/${file.name}`,
+                    file_path: filePath,
                     file_size_bytes: file.size,
                     mime_type: file.type || "application/octet-stream",
                 },
-                { token: token ?? undefined },
+                { token },
             );
-        } catch {
-            // Allow local-only demo uploads while backend/storage wiring is incomplete.
+            const nextDocument = mapDocument(created);
+            setDocuments((current) => [nextDocument, ...current]);
+            void pollForParsedStatus(nextDocument.id);
+        } catch (error) {
+            setPageError((error as Error).message || "Upload failed. Please try again.");
+        } finally {
+            setUploading(false);
+            setUploadProgress(0);
+            event.target.value = "";
         }
-
-        setDocuments((current) => [
-            {
-                createdAt: new Date().toISOString(),
-                documentType: DocumentType.OTHER,
-                fileName: file.name,
-                fileSizeBytes: file.size,
-                fileUrl: "#",
-                icon: "📄",
-                id: `${Date.now()}`,
-                mimeType: file.type || "application/octet-stream",
-                parsed: false,
-                patientId: "demo-patient",
-                provider: "Recently uploaded",
-                uploadedBy: "demo-patient",
-                uploadedByRole: "patient",
-                visibility: "all_providers",
-            },
-            ...current,
-        ]);
-        setUploading(false);
-        setUploadProgress(0);
     }
 
     async function handleLanguageChange(lang: "en" | "es") {
         setExplanationLang(lang);
         if (!selectedDocument) {
+            return;
+        }
+
+        if (selectedDocument.parseStatus !== "completed") {
             return;
         }
 
@@ -119,6 +277,13 @@ export default function RecordsPage() {
         }
     }
 
+    const processingCount = documents.filter(
+        (document) =>
+            parsingDocIds.has(document.id)
+            || document.parseStatus === "pending"
+            || document.parseStatus === "processing",
+    ).length;
+
     return (
         <div className="space-y-4 bg-gray-50 pb-8">
             <PageHeader
@@ -135,19 +300,63 @@ export default function RecordsPage() {
                         <p className="text-xs text-slate-500">Secure records</p>
                     </div>
                     <div className="rounded-2xl bg-sky-50 px-4 py-3 shadow-sm ring-1 ring-sky-100">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">AI Ready</p>
-                        <p className="mt-1 text-2xl font-bold text-slate-900">{documents.filter((document) => document.aiSummary).length}</p>
-                        <p className="text-xs text-slate-500">Summaries available</p>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">
+                            {processingCount > 0 ? "Parsing" : "AI Ready"}
+                        </p>
+                        <p className="mt-1 text-2xl font-bold text-slate-900">
+                            {processingCount > 0
+                                ? processingCount
+                                : documents.filter((document) => document.parsed && document.aiSummary).length}
+                        </p>
+                        <p className="text-xs text-slate-500">
+                            {processingCount > 0 ? "Documents in progress" : "Summaries available"}
+                        </p>
                     </div>
                 </div>
                 {uploading ? <ProgressBar value={uploadProgress} /> : null}
-                {documents.length === 0 ? (
+                {pageError && documents.length === 0 ? (
+                    <ErrorState
+                        description={pageError}
+                        onRetry={() => void loadDocuments()}
+                        title="Could not load records"
+                    />
+                ) : null}
+                {pageError && documents.length > 0 ? (
+                    <ErrorState
+                        description={pageError}
+                        onRetry={() => {
+                            setPageError(null);
+                            void loadDocuments();
+                        }}
+                        title="Action failed"
+                    />
+                ) : null}
+                {parseError ? (
+                    <ErrorState
+                        description={parseError}
+                        onRetry={() => {
+                            setParseError(null);
+                            fileInputRef.current?.click();
+                        }}
+                        title="Document processing failed"
+                    />
+                ) : null}
+                {loading ? (
+                    <p className="text-sm text-slate-500">Loading documents...</p>
+                ) : null}
+                {!loading && !pageError && documents.length === 0 ? (
                     <EmptyState description="Upload PDFs or images from your clinic visits." icon="📁" title="No records yet" />
                 ) : null}
-                {documents.map((document) => (
+                {documents.map((document) => {
+                    const displayDocument = parsingDocIds.has(document.id)
+                        ? { ...document, parseStatus: "processing" as const }
+                        : document;
+                    const status = getDocumentStatus(displayDocument);
+
+                    return (
                     <DocumentCard
                         date={new Date(document.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
-                        hasAiSummary={Boolean(document.aiSummary)}
+                        hasAiSummary={document.parsed && Boolean(document.aiSummary)}
                         icon={document.icon}
                         id={document.id}
                         key={document.id}
@@ -156,12 +365,31 @@ export default function RecordsPage() {
                             setSelectedDocument(document);
                             setExplanationLang("en");
                             setExplanationLoading(false);
+                            if (document.parseStatus === "failed") {
+                                setExplanationText(
+                                    document.parseError ?? "This document could not be processed.",
+                                );
+                                return;
+                            }
+                            if (
+                                document.parseStatus === "pending"
+                                || document.parseStatus === "processing"
+                                || parsingDocIds.has(document.id)
+                            ) {
+                                setExplanationText(
+                                    "Processing this document. AI summary will appear when parsing completes.",
+                                );
+                                return;
+                            }
                             setExplanationText(document.aiSummary ?? null);
                         }}
                         provider={document.provider}
+                        statusLabel={status?.label}
+                        statusVariant={status?.variant}
                         type={document.documentType.replaceAll("_", " ")}
                     />
-                ))}
+                    );
+                })}
             </div>
             <Modal onClose={() => setSelectedDocument(null)} open={Boolean(selectedDocument)} title={selectedDocument?.fileName ?? "Record details"}>
                 <div className="space-y-4">

--- a/apps/patient-portal/src/components/features/document-card.tsx
+++ b/apps/patient-portal/src/components/features/document-card.tsx
@@ -8,6 +8,8 @@ interface DocumentCardProps {
     provider: string;
     icon: string;
     hasAiSummary: boolean;
+    statusLabel?: string;
+    statusVariant?: "success" | "warning" | "danger" | "info" | "neutral";
     onClick: () => void;
 }
 
@@ -18,6 +20,8 @@ export function DocumentCard({
     name,
     onClick,
     provider,
+    statusLabel,
+    statusVariant = "neutral",
     type,
 }: DocumentCardProps) {
     return (
@@ -33,7 +37,8 @@ export function DocumentCard({
                             <p className="mt-1 text-xs text-slate-400">{provider}</p>
                         </div>
                         <div className="flex items-center gap-2">
-                            {hasAiSummary ? <Badge variant="info">AI Summary</Badge> : null}
+                            {statusLabel ? <Badge variant={statusVariant}>{statusLabel}</Badge> : null}
+                            {!statusLabel && hasAiSummary ? <Badge variant="info">AI Summary</Badge> : null}
                             <span className="text-sm text-slate-300">→</span>
                         </div>
                     </div>

--- a/apps/patient-portal/src/services/storage.ts
+++ b/apps/patient-portal/src/services/storage.ts
@@ -1,0 +1,55 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+interface UploadDocumentParams {
+    file: File;
+    patientId: string;
+    token: string;
+}
+
+function sanitizeFileName(fileName: string) {
+    return fileName
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9._-]/g, "");
+}
+
+function createStorageClient(token: string): SupabaseClient {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+        throw new Error("Supabase Storage is not configured for the patient portal.");
+    }
+
+    return createClient(supabaseUrl, supabaseAnonKey, {
+        accessToken: async () => token,
+        auth: {
+            autoRefreshToken: false,
+            detectSessionInUrl: false,
+            persistSession: false,
+        },
+    });
+}
+
+export async function uploadDocumentToStorage({
+    file,
+    patientId,
+    token,
+}: UploadDocumentParams): Promise<string> {
+    const supabase = createStorageClient(token);
+    const safeName = sanitizeFileName(file.name) || `document-${Date.now()}`;
+    const filePath = `${patientId}/${Date.now()}-${safeName}`;
+
+    const { data, error } = await supabase.storage.from("documents").upload(filePath, file, {
+        cacheControl: "3600",
+        contentType: file.type || "application/octet-stream",
+        upsert: false,
+    });
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return data.path;
+}

--- a/backend/src/app/agents/ingestion/graph.py
+++ b/backend/src/app/agents/ingestion/graph.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import json
 import logging
 from typing import Annotated, Any, TypedDict
+from uuid import UUID
 
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
 
+from app.agents.ingestion.prompts import (
+    EXTRACT_CONTENT_SYSTEM,
+    EXTRACT_CONTENT_USER,
+    GENERATE_SUMMARY_SYSTEM,
+    GENERATE_SUMMARY_USER,
+)
 from app.clients.model_router import TaskType, get_router
 
 logger = logging.getLogger(__name__)
@@ -65,6 +72,15 @@ class IngestionState(TypedDict):
     messages: Annotated[list[Any], add_messages]
 
 
+def _skip_if_error(state: IngestionState, node_name: str) -> bool:
+    """Skip downstream work when a previous node already failed."""
+    if not state.get("error"):
+        return False
+
+    logger.info("Skipping %s due to previous error: %s", node_name, state["error"])
+    return True
+
+
 async def receive_document(state: IngestionState) -> IngestionState:
     """Node 1: Validate input and download document from Supabase Storage.
 
@@ -77,9 +93,39 @@ async def receive_document(state: IngestionState) -> IngestionState:
     )
 
     try:
-        # TODO: Download from Supabase Storage using file_url
-        # For now, placeholder
-        state["raw_content"] = f"[Document content from {state['file_url']}]"
+        import io
+
+        import fitz
+        import pytesseract
+        from PIL import Image
+
+        from app.clients.supabase import get_admin_client
+
+        admin = get_admin_client()
+        file_bytes = admin.storage.from_("documents").download(state["file_url"])
+        file_path = state["file_url"].lower()
+
+        if file_path.endswith(".pdf") or state["document_type"] in (
+            "lab_report",
+            "discharge_summary",
+            "prescription",
+            "diagnostic_report",
+        ):
+            document = fitz.open(stream=file_bytes, filetype="pdf")
+            try:
+                raw_content = "\n".join(page.get_text() for page in document)
+            finally:
+                document.close()
+        elif any(
+            file_path.endswith(extension)
+            for extension in (".jpg", ".jpeg", ".png", ".webp", ".tiff", ".heic")
+        ):
+            image = Image.open(io.BytesIO(file_bytes))
+            raw_content = pytesseract.image_to_string(image)
+        else:
+            raw_content = file_bytes.decode("utf-8", errors="replace")
+
+        state["raw_content"] = raw_content
         state["error"] = None
 
         logger.info(f"Successfully received document: {state['document_id']}")
@@ -101,30 +147,17 @@ async def extract_content(state: IngestionState) -> IngestionState:
     """
     logger.info(f"extract_content: document_id={state['document_id']}")
 
+    if _skip_if_error(state, "extract_content"):
+        return state
+
     try:
         router = get_router()
-        client = router.get_client(TaskType.DOCUMENT_PARSING)
-
-        system_instruction = """You are a medical document parser. Extract structured data from the document.
-
-Extract the following information:
-- medications: list of medications with name, dosage, frequency, instructions
-- conditions: list of medical conditions/diagnoses
-- procedures: list of procedures performed
-- follow_up_instructions: list of follow-up instructions with timing
-- appointments: list of scheduled appointments
-
-Output as JSON with these exact keys."""
-
-        prompt = f"""Extract structured medical data from this document:
-
-{state["raw_content"]}
-
-Output as JSON."""
+        client = router.get_client_with_fallback(TaskType.DOCUMENT_PARSING)
+        prompt = EXTRACT_CONTENT_USER.format(raw_content=state["raw_content"] or "")
 
         response = await client.generate(
             prompt=prompt,
-            system_instruction=system_instruction,
+            system_instruction=EXTRACT_CONTENT_SYSTEM,
             temperature=0.3,
             max_tokens=2048,
         )
@@ -144,6 +177,7 @@ Output as JSON."""
                 raise ValueError(f"Could not parse JSON from response: {response[:200]}") from None
 
         state["extracted_data"] = extracted_data
+        state["raw_content"] = None
         state["error"] = None
 
         logger.info(
@@ -167,21 +201,26 @@ async def validate_fhir(state: IngestionState) -> IngestionState:
     """
     logger.info(f"validate_fhir: document_id={state['document_id']}")
 
+    if _skip_if_error(state, "validate_fhir"):
+        return state
+
     try:
-        # TODO: Implement FHIR validation using fhir.resources
-        # For now, pass through with basic validation
+        from app.tools.fhir_builder import validate_extracted_data
+
         extracted_data = state.get("extracted_data") or {}
-        validation_errors = []
+        patient_id = UUID(state["patient_id"]) if state.get("patient_id") else UUID(int=0)
+        source_document_id = UUID(state["document_id"]) if state.get("document_id") else None
+        validated, errors = validate_extracted_data(
+            extracted_data,
+            patient_id=patient_id,
+            source_document_id=source_document_id,
+        )
 
-        # Basic validation
-        if not extracted_data.get("medications"):
-            validation_errors.append("No medications found")
-
-        state["validated_data"] = extracted_data
-        state["validation_errors"] = validation_errors if validation_errors else None
+        state["validated_data"] = validated
+        state["validation_errors"] = errors if errors else None
         state["error"] = None
 
-        logger.info(f"Validation complete: {len(validation_errors)} errors")
+        logger.info(f"Validation complete: {len(errors)} errors")
         return state
 
     except Exception as e:
@@ -201,28 +240,19 @@ async def normalize_medications(state: IngestionState) -> IngestionState:
     """
     logger.info(f"normalize_medications: document_id={state['document_id']}")
 
+    if _skip_if_error(state, "normalize_medications"):
+        return state
+
     try:
+        from app.tools.medication_normalizer import normalize_all
+
         validated_data = state.get("validated_data") or {}
         medications = validated_data.get("medications", [])
 
-        normalized_medications = []
-        for med in medications:
-            # TODO: Call RxNorm service for normalization
-            # For now, pass through with basic structure
-            normalized_med = {
-                "name": med.get("name", ""),
-                "generic_name": med.get("name", ""),  # TODO: lookup via RxNorm
-                "rxcui": None,  # TODO: lookup via RxNorm
-                "dosage": med.get("dosage", ""),
-                "frequency": med.get("frequency", ""),
-                "instructions": med.get("instructions", ""),
-            }
-            normalized_medications.append(normalized_med)
-
-        state["normalized_medications"] = normalized_medications
+        state["normalized_medications"] = await normalize_all(medications)
         state["error"] = None
 
-        logger.info(f"Normalized {len(normalized_medications)} medications")
+        logger.info(f"Normalized {len(state['normalized_medications'])} medications")
         return state
 
     except Exception as e:
@@ -244,19 +274,20 @@ async def save_to_database(state: IngestionState) -> IngestionState:
     """
     logger.info(f"save_to_database: document_id={state['document_id']}")
 
+    if _skip_if_error(state, "save_to_database"):
+        return state
+
     try:
-        # TODO: Implement Supabase upserts
-        # For now, placeholder
-        saved_ids: dict[str, list[str]] = {
+        state["saved_ids"] = {
             "medications": [],
             "conditions": [],
+            "allergies": [],
+            "obligations": [],
             "appointments": [],
         }
-
-        state["saved_ids"] = saved_ids
         state["error"] = None
 
-        logger.info(f"Saved to database: {saved_ids}")
+        logger.info("Prepared database payloads for document %s", state["document_id"])
         return state
 
     except Exception as e:
@@ -276,26 +307,25 @@ async def generate_summary(state: IngestionState) -> IngestionState:
     """
     logger.info(f"generate_summary: document_id={state['document_id']}")
 
+    if _skip_if_error(state, "generate_summary"):
+        return state
+
     try:
         router = get_router()
-        client = router.get_client(TaskType.PATIENT_EXPLANATION)
-
-        system_instruction = """You are a nurse explaining medical information to a patient and their family.
-Use simple language that anyone can understand. Keep under 350 words.
-Be warm, supportive, and clear."""
-
-        extracted_data = state.get("extracted_data") or {}
-        prompt = f"""Explain this medical information to the patient in simple terms:
-
-Medications: {json.dumps(extracted_data.get("medications", []), indent=2)}
-Conditions: {json.dumps(extracted_data.get("conditions", []), indent=2)}
-Follow-up Instructions: {json.dumps(extracted_data.get("follow_up_instructions", []), indent=2)}
-
-Create a friendly, easy-to-understand summary."""
+        client = router.get_client_with_fallback(TaskType.PATIENT_EXPLANATION)
+        summary_data = state.get("validated_data") or state.get("extracted_data") or {}
+        prompt = GENERATE_SUMMARY_USER.format(
+            medications=json.dumps(summary_data.get("medications", []), default=str),
+            conditions=json.dumps(summary_data.get("conditions", []), default=str),
+            follow_up_instructions=json.dumps(
+                summary_data.get("follow_up_instructions", []),
+                default=str,
+            ),
+        )
 
         response = await client.generate(
             prompt=prompt,
-            system_instruction=system_instruction,
+            system_instruction=GENERATE_SUMMARY_SYSTEM,
             temperature=0.7,
             max_tokens=512,
         )
@@ -323,12 +353,18 @@ async def create_feed_tasks(state: IngestionState) -> IngestionState:
     """
     logger.info(f"create_feed_tasks: document_id={state['document_id']}")
 
+    if _skip_if_error(state, "create_feed_tasks"):
+        return state
+
     try:
-        # TODO: Create obligations in database
-        # For now, count what would be created
         normalized_medications = state.get("normalized_medications") or []
+        validated_data = state.get("validated_data") or {}
         extracted_data = state.get("extracted_data") or {}
-        follow_ups = extracted_data.get("follow_up_instructions") or []
+        follow_ups = (
+            validated_data.get("follow_up_instructions")
+            or extracted_data.get("follow_up_instructions")
+            or []
+        )
 
         created_tasks = len(normalized_medications) + len(follow_ups)
 

--- a/backend/src/app/agents/ingestion/graph.py
+++ b/backend/src/app/agents/ingestion/graph.py
@@ -251,8 +251,9 @@ async def normalize_medications(state: IngestionState) -> IngestionState:
 
         state["normalized_medications"] = await normalize_all(medications)
         state["error"] = None
+        normalized_medications = state["normalized_medications"] or []
 
-        logger.info(f"Normalized {len(state['normalized_medications'])} medications")
+        logger.info(f"Normalized {len(normalized_medications)} medications")
         return state
 
     except Exception as e:

--- a/backend/src/app/agents/ingestion/prompts.py
+++ b/backend/src/app/agents/ingestion/prompts.py
@@ -1,0 +1,45 @@
+"""Ingestion agent prompts — centralized for maintainability and testing.
+
+All prompts use ``str.format()`` placeholders so they can be reused and tested
+without requiring live model calls.
+"""
+
+EXTRACT_CONTENT_SYSTEM = """You are a medical document parser. Extract structured data from clinical documents.
+
+Extract the following information as a JSON object:
+- medications: list of objects with keys: name, dosage, frequency, instructions, route
+- conditions: list of objects with keys: name, clinical_status (default "active"), onset_date (if mentioned)
+- allergies: list of objects with keys: substance, reaction, severity
+- procedures: list of objects with keys: name, date (if mentioned)
+- follow_up_instructions: list of objects with keys: description, timing, provider (if mentioned)
+- appointments: list of objects with keys: description, date, provider
+
+Be precise. Only extract information that is explicitly stated in the document.
+If a field is not mentioned, omit it from the object.
+Output ONLY valid JSON — no markdown, no commentary."""
+
+EXTRACT_CONTENT_USER = """Extract structured medical data from this clinical document:
+
+{raw_content}"""
+
+GENERATE_SUMMARY_SYSTEM = """You are a nurse explaining medical information to a patient and their family.
+Use simple language that anyone can understand. Keep under 350 words.
+Be warm, supportive, and clear. Avoid medical jargon — use everyday words.
+If the patient has medications, explain what each one does and when to take it.
+If there are follow-up instructions, explain them clearly with specific timelines."""
+
+GENERATE_SUMMARY_USER = """Explain this medical information to the patient in simple terms:
+
+Medications: {medications}
+Conditions: {conditions}
+Follow-up Instructions: {follow_up_instructions}
+
+Create a friendly, easy-to-understand summary."""
+
+TRANSLATE_SUMMARY_SYSTEM = """You are a medical translator. Translate the following patient-friendly
+medical summary to {target_language}. Maintain the same warm, simple tone.
+Do not add or remove any medical information — translate accurately."""
+
+TRANSLATE_SUMMARY_USER = """Translate this medical summary to {target_language}:
+
+{summary}"""

--- a/backend/src/app/db/migrations/005_document_parse_tracking.sql
+++ b/backend/src/app/db/migrations/005_document_parse_tracking.sql
@@ -1,0 +1,12 @@
+-- Add ingestion lifecycle tracking to documents.
+
+ALTER TABLE documents
+ADD COLUMN IF NOT EXISTS file_path text,
+ADD COLUMN IF NOT EXISTS parse_status text NOT NULL DEFAULT 'none'
+    CHECK (parse_status IN ('none', 'pending', 'processing', 'completed', 'failed')),
+ADD COLUMN IF NOT EXISTS parse_error text,
+ADD COLUMN IF NOT EXISTS parse_attempts integer NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_documents_parse_status
+ON documents (patient_id, parse_status)
+WHERE parse_status IN ('pending', 'processing');

--- a/backend/src/app/models/document.py
+++ b/backend/src/app/models/document.py
@@ -27,6 +27,9 @@ class DocumentRead(BaseModel):
     file_size_bytes: int
     parsed: bool = False
     ai_summary: str | None = None
+    parse_status: str = "none"
+    parse_error: str | None = None
+    parse_attempts: int = 0
     source_clinic: str | None = None
     visibility: DocumentVisibility = DocumentVisibility.ALL_PROVIDERS
     created_at: str

--- a/backend/src/app/routers/documents.py
+++ b/backend/src/app/routers/documents.py
@@ -9,21 +9,26 @@ Upload flow:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, BackgroundTasks, Depends, status
 from pydantic import BaseModel, Field
 from supabase import Client
 
+from app.clients.supabase import get_admin_client
 from app.core.security import get_current_user
 from app.db.connection import get_db
 from app.models.auth import CurrentUser
 from app.models.document import DocumentRead
 from app.models.enums import DocumentType
 from app.services.document_service import DocumentService
+from app.services.explanation_service import ExplanationService
+from app.services.ingestion_service import IngestionService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _get_service(db: Client = Depends(get_db)) -> DocumentService:
@@ -48,6 +53,32 @@ class DocumentCreateRequest(BaseModel):
     notes: str | None = None
 
 
+class ExplainRequest(BaseModel):
+    """Language selection for AI explanation responses."""
+
+    language: str = "en"
+
+
+async def _run_ingestion_safe(
+    document_id: str,
+    patient_id: UUID,
+    file_path: str,
+    document_type: str,
+) -> None:
+    """Background task wrapper — catches all exceptions to prevent crash."""
+    try:
+        db = get_admin_client()
+        service = IngestionService(db)
+        await service.ingest_document(
+            document_id=UUID(document_id),
+            patient_id=patient_id,
+            file_path=file_path,
+            document_type=document_type,
+        )
+    except Exception:
+        logger.exception("Ingestion background task failed for document %s", document_id)
+
+
 # ── Endpoints ───────────────────────────────────────────
 
 
@@ -60,10 +91,11 @@ class DocumentCreateRequest(BaseModel):
 )
 async def create_document(
     body: DocumentCreateRequest,
+    background_tasks: BackgroundTasks,
     user: CurrentUser = Depends(get_current_user),
     service: DocumentService = Depends(_get_service),
 ) -> Any:
-    return await service.create_document(
+    document = await service.create_document(
         patient_id=user.id,
         uploaded_by=user.id,
         uploaded_by_role=user.role,
@@ -75,6 +107,14 @@ async def create_document(
         source_clinic=body.source_clinic,
         notes=body.notes,
     )
+    background_tasks.add_task(
+        _run_ingestion_safe,
+        document_id=str(document["id"]),
+        patient_id=user.id,
+        file_path=body.file_path,
+        document_type=body.document_type.value,
+    )
+    return document
 
 
 @router.get(
@@ -104,16 +144,25 @@ async def get_document(
 
 @router.post(
     "/{document_id}/explain",
-    summary="Trigger AI explanation (Phase 4)",
-    description="Returns plain-language summary. Will be wired to the Ingestion Agent.",
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+    summary="Get AI explanation of a document",
+    status_code=status.HTTP_200_OK,
 )
 async def explain_document(
     document_id: UUID,
+    body: ExplainRequest | None = None,
     user: CurrentUser = Depends(get_current_user),
+    service: DocumentService = Depends(_get_service),
 ) -> Any:
-    # Placeholder — will be implemented when AI agents are built (Phase 4)
-    return {
-        "document_id": str(document_id),
-        "message": "AI explanation not yet available — coming in Phase 4",
-    }
+    language = body.language if body else "en"
+    document = await service.get_document(document_id, user.id)
+
+    if language == "en" and document.get("ai_summary"):
+        return {"summary": document["ai_summary"], "language": "en", "cached": True}
+
+    explanation_service = ExplanationService()
+    summary = await explanation_service.explain(document_data=document, language=language)
+
+    if language == "en":
+        await service.update_summary(document_id, user.id, summary)
+
+    return {"summary": summary, "language": language, "cached": False}

--- a/backend/src/app/services/document_service.py
+++ b/backend/src/app/services/document_service.py
@@ -25,6 +25,9 @@ ALLOWED_MIME_TYPES = frozenset(
         "image/png",
         "image/webp",
         "image/heic",
+        "image/tiff",
+        "text/plain",
+        "text/csv",
     }
 )
 MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024  # 20 MB
@@ -73,6 +76,9 @@ class DocumentService:
             "document_type": document_type,
             "source_clinic": source_clinic,
             "notes": notes,
+            "parse_status": "pending",
+            "parse_error": None,
+            "parse_attempts": 0,
         }
 
         result = self.db.table("documents").insert(row).execute()
@@ -118,6 +124,16 @@ class DocumentService:
         if data.get("file_path"):
             data["file_url"] = self._generate_signed_url(data["file_path"])
         return data
+
+    async def update_summary(self, document_id: UUID, patient_id: UUID, summary: str) -> None:
+        """Cache an AI summary on the document row."""
+        (
+            self.db.table("documents")
+            .update({"ai_summary": summary, "parsed": True})
+            .eq("id", str(document_id))
+            .eq("patient_id", str(patient_id))
+            .execute()
+        )
 
     # ── Helpers ─────────────────────────────────────────
 

--- a/backend/src/app/services/explanation_service.py
+++ b/backend/src/app/services/explanation_service.py
@@ -1,0 +1,97 @@
+"""Explanation service — generates patient-friendly document summaries."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from app.agents.ingestion.prompts import (
+    GENERATE_SUMMARY_SYSTEM,
+    GENERATE_SUMMARY_USER,
+    TRANSLATE_SUMMARY_SYSTEM,
+    TRANSLATE_SUMMARY_USER,
+)
+from app.clients.model_router import TaskType, get_router
+
+logger = logging.getLogger(__name__)
+
+FALLBACK_MESSAGE = (
+    "A summary is not available at this time. Please ask your care team for an explanation."
+)
+LANGUAGE_NAMES = {"en": "English", "es": "Spanish"}
+
+
+class ExplanationService:
+    """Generates AI explanations for documents."""
+
+    async def explain(
+        self,
+        document_data: dict[str, Any],
+        language: str = "en",
+    ) -> str:
+        """Generate a patient-friendly explanation."""
+        target_language = language if language in LANGUAGE_NAMES else "en"
+        cached_summary = str(document_data.get("ai_summary") or "").strip()
+
+        try:
+            if target_language == "en" and cached_summary:
+                return cached_summary
+
+            english_summary = cached_summary or await self._generate_summary(document_data)
+            if target_language == "en":
+                return english_summary
+
+            return await self._translate_summary(english_summary, target_language)
+        except Exception as exc:
+            logger.warning(
+                "Failed to generate explanation for document %s: %s", document_data.get("id"), exc
+            )
+            return FALLBACK_MESSAGE
+
+    async def _generate_summary(self, document_data: dict[str, Any]) -> str:
+        """Generate an English summary from document data using Flash Lite."""
+        router = get_router()
+        client = router.get_client_with_fallback(TaskType.PATIENT_EXPLANATION)
+
+        follow_up_instructions = document_data.get("follow_up_instructions") or []
+        if not follow_up_instructions:
+            follow_up_instructions = [
+                {
+                    "description": document_data.get("notes")
+                    or f"Document type: {document_data.get('document_type', 'medical document')}",
+                    "provider": document_data.get("source_clinic"),
+                }
+            ]
+
+        prompt = GENERATE_SUMMARY_USER.format(
+            medications=json.dumps(document_data.get("medications", []), default=str),
+            conditions=json.dumps(document_data.get("conditions", []), default=str),
+            follow_up_instructions=json.dumps(follow_up_instructions, default=str),
+        )
+        response = await client.generate(
+            prompt=prompt,
+            system_instruction=GENERATE_SUMMARY_SYSTEM,
+            temperature=0.4,
+            max_tokens=512,
+        )
+        return response.strip() or FALLBACK_MESSAGE
+
+    async def _translate_summary(self, summary: str, target_language: str) -> str:
+        """Translate an English summary to the target language using Flash Lite."""
+        if target_language == "en":
+            return summary
+
+        router = get_router()
+        client = router.get_client_with_fallback(TaskType.PATIENT_EXPLANATION)
+        language_name = LANGUAGE_NAMES.get(target_language, target_language)
+        response = await client.generate(
+            prompt=TRANSLATE_SUMMARY_USER.format(
+                summary=summary,
+                target_language=language_name,
+            ),
+            system_instruction=TRANSLATE_SUMMARY_SYSTEM.format(target_language=language_name),
+            temperature=0.2,
+            max_tokens=512,
+        )
+        return response.strip() or FALLBACK_MESSAGE

--- a/backend/src/app/services/ingestion_service.py
+++ b/backend/src/app/services/ingestion_service.py
@@ -1,0 +1,305 @@
+"""Ingestion service — orchestrates document ingestion via LangGraph."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+from app.agents.ingestion.graph import IngestionState, create_ingestion_graph
+from app.core.exceptions import DocumentParseError
+from app.services.medication_service import MedicationService
+from app.services.obligation_service import ObligationService
+
+logger = logging.getLogger(__name__)
+
+MAX_PARSE_ATTEMPTS = 3
+
+
+class IngestionService:
+    """Runs the ingestion pipeline for a document."""
+
+    def __init__(self, db: Client) -> None:
+        self.db = db
+        self._graph = create_ingestion_graph()
+        self._med_service = MedicationService(db)
+        self._obligation_service = ObligationService(db)
+
+    async def ingest_document(
+        self,
+        document_id: UUID,
+        patient_id: UUID,
+        file_path: str,
+        document_type: str,
+    ) -> dict[str, Any]:
+        """Run the full ingestion pipeline for a document."""
+        attempts = self._get_parse_attempts(document_id)
+        if attempts >= MAX_PARSE_ATTEMPTS:
+            message = f"Maximum parse attempts ({MAX_PARSE_ATTEMPTS}) exceeded"
+            self._update_document_status(
+                document_id,
+                parse_status="failed",
+                parse_error=message,
+                parsed=False,
+            )
+            raise DocumentParseError(str(document_id), message)
+
+        self._update_document_status(
+            document_id,
+            parse_status="processing",
+            parse_error=None,
+            parsed=False,
+            parse_attempts=attempts + 1,
+        )
+
+        initial_state: IngestionState = {
+            "document_id": str(document_id),
+            "file_url": file_path,
+            "document_type": document_type,
+            "patient_id": str(patient_id),
+            "raw_content": None,
+            "extracted_data": None,
+            "validated_data": None,
+            "validation_errors": None,
+            "normalized_medications": None,
+            "saved_ids": None,
+            "patient_summary": None,
+            "created_tasks": None,
+            "error": None,
+            "retry_count": attempts,
+            "messages": [],
+        }
+
+        final_state = cast(IngestionState, await self._graph.ainvoke(initial_state))
+        if final_state.get("error"):
+            error = str(final_state["error"])
+            self._update_document_status(
+                document_id,
+                parse_status="failed",
+                parse_error=error,
+                parsed=False,
+            )
+            latest_attempts = attempts + 1
+            if latest_attempts >= MAX_PARSE_ATTEMPTS:
+                raise DocumentParseError(str(document_id), error)
+            return {
+                "status": "failed",
+                "medications_created": 0,
+                "obligations_created": 0,
+                "summary_length": 0,
+                "error": error,
+            }
+
+        validated_data = final_state.get("validated_data") or {}
+        extracted_data = final_state.get("extracted_data") or {}
+        normalized_medications = final_state.get("normalized_medications") or []
+
+        medication_ids = await self._save_medications(
+            patient_id,
+            document_id,
+            normalized_medications,
+        )
+        condition_ids = await self._save_conditions(
+            patient_id,
+            validated_data.get("conditions", []),
+        )
+        allergy_ids = await self._save_allergies(
+            patient_id,
+            validated_data.get("allergies", []),
+        )
+        obligation_ids = await self._save_obligations(
+            patient_id,
+            extracted_data.get("follow_up_instructions", []),
+        )
+
+        final_state["saved_ids"] = {
+            "medications": medication_ids,
+            "conditions": condition_ids,
+            "allergies": allergy_ids,
+            "obligations": obligation_ids,
+        }
+
+        summary = str(final_state.get("patient_summary") or "")
+        self._update_document_status(
+            document_id,
+            parse_status="completed",
+            parse_error=None,
+            parsed=True,
+            ai_summary=summary or None,
+        )
+
+        return {
+            "status": "completed",
+            "medications_created": len(medication_ids),
+            "conditions_created": len(condition_ids),
+            "allergies_created": len(allergy_ids),
+            "obligations_created": len(obligation_ids),
+            "summary_length": len(summary),
+        }
+
+    def _get_parse_attempts(self, document_id: UUID) -> int:
+        """Read the current parse attempt count for a document."""
+        result = (
+            self.db.table("documents")
+            .select("parse_attempts")
+            .eq("id", str(document_id))
+            .single()
+            .execute()
+        )
+        data = cast(dict[str, Any], result.data or {})
+        return int(data.get("parse_attempts") or 0)
+
+    def _update_document_status(
+        self,
+        document_id: UUID,
+        *,
+        parse_status: str,
+        parse_error: str | None = None,
+        parsed: bool | None = None,
+        ai_summary: str | None = None,
+        parse_attempts: int | None = None,
+    ) -> None:
+        """Update document parsing status in DB."""
+        payload: dict[str, Any] = {
+            "parse_status": parse_status,
+            "parse_error": parse_error,
+        }
+        if parsed is not None:
+            payload["parsed"] = parsed
+        if ai_summary is not None:
+            payload["ai_summary"] = ai_summary
+        if parse_attempts is not None:
+            payload["parse_attempts"] = parse_attempts
+
+        self.db.table("documents").update(payload).eq("id", str(document_id)).execute()
+
+    async def _save_medications(
+        self,
+        patient_id: UUID,
+        document_id: UUID,
+        normalized_medications: list[dict[str, Any]],
+    ) -> list[str]:
+        """Save normalized medications to DB via MedicationService."""
+        created_ids: list[str] = []
+        for medication in normalized_medications:
+            payload = {
+                "name": medication.get("name")
+                or medication.get("generic_name")
+                or "Unknown medication",
+                "generic_name": medication.get("generic_name"),
+                "rxcui": medication.get("rxcui"),
+                "dosage": medication.get("dosage")
+                or medication.get("parsed_dosage", {}).get("raw")
+                or "unspecified",
+                "frequency": medication.get("frequency")
+                or medication.get("normalized_frequency")
+                or "as directed",
+                "route": medication.get("route") or "oral",
+                "instructions": medication.get("instructions"),
+                "source_document_id": str(document_id),
+            }
+            created = await self._med_service.create_medication(patient_id, payload)
+            created_ids.append(str(created["id"]))
+        return created_ids
+
+    async def _save_obligations(
+        self,
+        patient_id: UUID,
+        follow_up_instructions: list[dict[str, Any]],
+    ) -> list[str]:
+        """Save follow-up instructions as obligations via ObligationService."""
+        created_ids: list[str] = []
+        for instruction in follow_up_instructions:
+            description = str(instruction.get("description") or "").strip()
+            if not description:
+                continue
+            payload = {
+                "obligation_type": self._detect_obligation_type(description),
+                "description": description,
+                "frequency": instruction.get("timing")
+                or instruction.get("frequency")
+                or "as directed",
+            }
+            created = await self._obligation_service.create_obligation(patient_id, payload)
+            created_ids.append(str(created["id"]))
+        return created_ids
+
+    async def _save_conditions(
+        self,
+        patient_id: UUID,
+        conditions: list[dict[str, Any]],
+    ) -> list[str]:
+        """Persist validated conditions directly to the conditions table."""
+        return await asyncio.to_thread(self._insert_conditions, patient_id, conditions)
+
+    def _insert_conditions(
+        self,
+        patient_id: UUID,
+        conditions: list[dict[str, Any]],
+    ) -> list[str]:
+        """Persist validated conditions directly to the conditions table."""
+        created_ids: list[str] = []
+        for condition in conditions:
+            result = (
+                self.db.table("conditions")
+                .insert(
+                    {
+                        "patient_id": str(patient_id),
+                        "name": condition.get("name"),
+                        "status": condition.get("status") or "active",
+                        "notes": condition.get("notes"),
+                    }
+                )
+                .execute()
+            )
+            data = cast(list[dict[str, Any]], result.data or [])
+            if data:
+                created_ids.append(str(data[0]["id"]))
+        return created_ids
+
+    async def _save_allergies(
+        self,
+        patient_id: UUID,
+        allergies: list[dict[str, Any]],
+    ) -> list[str]:
+        """Persist validated allergies directly to the allergies table."""
+        return await asyncio.to_thread(self._insert_allergies, patient_id, allergies)
+
+    def _insert_allergies(
+        self,
+        patient_id: UUID,
+        allergies: list[dict[str, Any]],
+    ) -> list[str]:
+        """Persist validated allergies directly to the allergies table."""
+        created_ids: list[str] = []
+        for allergy in allergies:
+            result = (
+                self.db.table("allergies")
+                .insert(
+                    {
+                        "patient_id": str(patient_id),
+                        "allergen": allergy.get("allergen"),
+                        "reaction": allergy.get("reaction"),
+                        "severity": allergy.get("severity") or "moderate",
+                    }
+                )
+                .execute()
+            )
+            data = cast(list[dict[str, Any]], result.data or [])
+            if data:
+                created_ids.append(str(data[0]["id"]))
+        return created_ids
+
+    def _detect_obligation_type(self, description: str) -> str:
+        """Infer obligation type from the free-text follow-up instruction."""
+        normalized = description.lower()
+        if any(token in normalized for token in ("diet", "sodium", "nutrition", "eat", "meal")):
+            return "diet"
+        if any(
+            token in normalized for token in ("walk", "exercise", "activity", "stretch", "physical")
+        ):
+            return "exercise"
+        return "custom"

--- a/backend/src/app/tools/fhir_builder.py
+++ b/backend/src/app/tools/fhir_builder.py
@@ -1,0 +1,223 @@
+"""FHIR Resource Builder — converts extracted clinical data to validated FHIR R4 resources.
+
+The FHIR objects are used for validation only. We still persist data in the
+project's relational schema, so each builder returns a cleaned dict shaped for
+our own tables on success.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from fhir.resources.allergyintolerance import AllergyIntolerance
+from fhir.resources.condition import Condition
+from fhir.resources.medicationrequest import MedicationRequest
+from pydantic import ValidationError as PydanticValidationError
+from pydantic.v1 import ValidationError as PydanticV1ValidationError
+
+logger = logging.getLogger(__name__)
+
+_VALID_ROUTES = {"oral", "topical", "iv", "im", "subcutaneous", "inhaled", "other"}
+_VALID_SEVERITIES = {"mild", "moderate", "severe"}
+_FHIR_VALIDATION_ERRORS = (PydanticValidationError, PydanticV1ValidationError)
+
+
+def _string(value: Any) -> str:
+    """Normalize a possibly-missing value to a stripped string."""
+    return str(value or "").strip()
+
+
+def _normalize_route(route: str) -> str:
+    """Map a free-text route into the allowed medication route enum values."""
+    normalized = route.strip().lower().replace("intravenous", "iv")
+    return normalized if normalized in _VALID_ROUTES else "oral"
+
+
+def _condition_status_payload(clinical_status: str) -> dict[str, Any]:
+    """Build the FHIR clinical status coding structure."""
+    code = _string(clinical_status).lower() or "active"
+    return {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": code,
+            }
+        ]
+    }
+
+
+def build_medication_request(
+    med: dict[str, Any],
+    patient_id: UUID,
+    source_document_id: UUID | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Build and validate a FHIR MedicationRequest from extracted medication data."""
+    name = _string(med.get("name"))
+    if not name:
+        return None, "Medication is missing a name"
+
+    dosage = _string(med.get("dosage")) or "unspecified"
+    frequency = _string(med.get("frequency")) or "as directed"
+    instructions = _string(med.get("instructions")) or None
+    route = _normalize_route(_string(med.get("route")) or "oral")
+
+    payload = {
+        "status": "active",
+        "intent": "order",
+        "subject": {"reference": f"Patient/{patient_id}"},
+        "medication": {"concept": {"text": name}},
+        "dosageInstruction": [
+            {"text": instructions or f"{dosage}, {frequency}", "route": {"text": route}}
+        ],
+    }
+
+    try:
+        MedicationRequest(**payload)
+    except _FHIR_VALIDATION_ERRORS as exc:
+        return None, f"Medication '{name}': {exc.errors()[0]['msg']}"
+
+    return {
+        "name": name,
+        "dosage": dosage,
+        "frequency": frequency,
+        "instructions": instructions,
+        "route": route,
+        "source_document_id": str(source_document_id) if source_document_id else None,
+    }, None
+
+
+def build_condition(
+    condition: dict[str, Any],
+    patient_id: UUID,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Build and validate a FHIR Condition from extracted condition data."""
+    name = _string(condition.get("name") or condition.get("code_text"))
+    if not name:
+        return None, "Condition is missing a name"
+
+    clinical_status = _string(condition.get("clinical_status")) or "active"
+    onset_date = _string(condition.get("onset_date")) or None
+    payload = {
+        "subject": {"reference": f"Patient/{patient_id}"},
+        "code": {"text": name},
+        "clinicalStatus": _condition_status_payload(clinical_status),
+    }
+    if onset_date:
+        payload["onsetString"] = onset_date
+
+    try:
+        Condition(**payload)
+    except _FHIR_VALIDATION_ERRORS as exc:
+        return None, f"Condition '{name}': {exc.errors()[0]['msg']}"
+
+    notes = f"Onset date: {onset_date}" if onset_date else None
+    return {
+        "name": name,
+        "status": clinical_status,
+        "notes": notes,
+    }, None
+
+
+def build_allergy_intolerance(
+    allergy: dict[str, Any],
+    patient_id: UUID,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Build and validate a FHIR AllergyIntolerance from extracted allergy data."""
+    substance = _string(allergy.get("substance") or allergy.get("allergen"))
+    if not substance:
+        return None, "Allergy is missing a substance"
+
+    reaction = _string(allergy.get("reaction")) or None
+    severity = (_string(allergy.get("severity")) or "moderate").lower()
+    if severity not in _VALID_SEVERITIES:
+        severity = "moderate"
+
+    payload: dict[str, Any] = {
+        "patient": {"reference": f"Patient/{patient_id}"},
+        "code": {"text": substance},
+    }
+    if reaction:
+        payload["reaction"] = [{"manifestation": [{"concept": {"text": reaction}}]}]
+
+    try:
+        AllergyIntolerance(**payload)
+    except _FHIR_VALIDATION_ERRORS as exc:
+        return None, f"Allergy '{substance}': {exc.errors()[0]['msg']}"
+
+    return {
+        "allergen": substance,
+        "reaction": reaction,
+        "severity": severity,
+    }, None
+
+
+def build_appointment(
+    instruction: dict[str, Any],
+    patient_id: UUID,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Build an appointment-shaped dict from follow-up instruction data."""
+    description = _string(instruction.get("description") or instruction.get("name"))
+    if not description:
+        return None, "Follow-up instruction is missing a description"
+
+    timing = _string(instruction.get("timing") or instruction.get("date")) or None
+    provider = _string(instruction.get("provider")) or None
+    return {
+        "description": description,
+        "timing": timing,
+        "provider": provider,
+        "patient_reference": f"Patient/{patient_id}",
+    }, None
+
+
+def validate_extracted_data(
+    extracted_data: dict[str, Any],
+    patient_id: UUID,
+    source_document_id: UUID | None = None,
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
+    """Validate all extracted data against FHIR schemas."""
+    validated_resources: dict[str, list[dict[str, Any]]] = {
+        "medications": [],
+        "conditions": [],
+        "allergies": [],
+        "appointments": [],
+        "follow_up_instructions": [],
+    }
+    validation_errors: list[str] = []
+
+    for med in extracted_data.get("medications", []) or []:
+        validated, error = build_medication_request(med, patient_id, source_document_id)
+        if validated:
+            validated_resources["medications"].append(validated)
+        if error:
+            validation_errors.append(error)
+
+    for condition in extracted_data.get("conditions", []) or []:
+        validated, error = build_condition(condition, patient_id)
+        if validated:
+            validated_resources["conditions"].append(validated)
+        if error:
+            validation_errors.append(error)
+
+    for allergy in extracted_data.get("allergies", []) or []:
+        validated, error = build_allergy_intolerance(allergy, patient_id)
+        if validated:
+            validated_resources["allergies"].append(validated)
+        if error:
+            validation_errors.append(error)
+
+    appointment_candidates = [
+        *(extracted_data.get("appointments", []) or []),
+        *(extracted_data.get("follow_up_instructions", []) or []),
+    ]
+    for appointment in appointment_candidates:
+        validated, error = build_appointment(appointment, patient_id)
+        if validated:
+            validated_resources["appointments"].append(validated)
+            validated_resources["follow_up_instructions"].append(validated)
+        if error:
+            validation_errors.append(error)
+
+    return validated_resources, validation_errors

--- a/backend/src/app/tools/fhir_builder.py
+++ b/backend/src/app/tools/fhir_builder.py
@@ -8,7 +8,7 @@ our own tables on success.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from fhir.resources.allergyintolerance import AllergyIntolerance
@@ -48,6 +48,11 @@ def _condition_status_payload(clinical_status: str) -> dict[str, Any]:
     }
 
 
+def _validate_resource(resource_cls: Any, payload: dict[str, Any]) -> None:
+    """Run FHIR model validation through a dynamic boundary for mypy."""
+    cast(Any, resource_cls)(**payload)
+
+
 def build_medication_request(
     med: dict[str, Any],
     patient_id: UUID,
@@ -63,7 +68,7 @@ def build_medication_request(
     instructions = _string(med.get("instructions")) or None
     route = _normalize_route(_string(med.get("route")) or "oral")
 
-    payload = {
+    payload: dict[str, Any] = {
         "status": "active",
         "intent": "order",
         "subject": {"reference": f"Patient/{patient_id}"},
@@ -74,7 +79,7 @@ def build_medication_request(
     }
 
     try:
-        MedicationRequest(**payload)
+        _validate_resource(MedicationRequest, payload)
     except _FHIR_VALIDATION_ERRORS as exc:
         return None, f"Medication '{name}': {exc.errors()[0]['msg']}"
 
@@ -99,7 +104,7 @@ def build_condition(
 
     clinical_status = _string(condition.get("clinical_status")) or "active"
     onset_date = _string(condition.get("onset_date")) or None
-    payload = {
+    payload: dict[str, Any] = {
         "subject": {"reference": f"Patient/{patient_id}"},
         "code": {"text": name},
         "clinicalStatus": _condition_status_payload(clinical_status),
@@ -108,7 +113,7 @@ def build_condition(
         payload["onsetString"] = onset_date
 
     try:
-        Condition(**payload)
+        _validate_resource(Condition, payload)
     except _FHIR_VALIDATION_ERRORS as exc:
         return None, f"Condition '{name}': {exc.errors()[0]['msg']}"
 
@@ -142,7 +147,7 @@ def build_allergy_intolerance(
         payload["reaction"] = [{"manifestation": [{"concept": {"text": reaction}}]}]
 
     try:
-        AllergyIntolerance(**payload)
+        _validate_resource(AllergyIntolerance, payload)
     except _FHIR_VALIDATION_ERRORS as exc:
         return None, f"Allergy '{substance}': {exc.errors()[0]['msg']}"
 

--- a/backend/src/app/tools/medication_normalizer.py
+++ b/backend/src/app/tools/medication_normalizer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import Any
+from typing import Any, cast
 
 from app.services.rxnorm_service import normalize_drug_name
 
@@ -131,6 +131,6 @@ async def normalize_all(medications: list[dict[str, Any]]) -> list[dict[str, Any
             }
             normalized.append(fallback)
             continue
-        normalized.append(result)
+        normalized.append(cast(dict[str, Any], result))
 
     return normalized

--- a/backend/src/app/tools/medication_normalizer.py
+++ b/backend/src/app/tools/medication_normalizer.py
@@ -1,0 +1,136 @@
+"""Medication normalizer — parse dosage strings + RxNorm lookup."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+from app.services.rxnorm_service import normalize_drug_name
+
+logger = logging.getLogger(__name__)
+
+DOSAGE_PATTERN = re.compile(
+    r"(\d+(?:\.\d+)?)\s*(mg|mcg|g|ml|units?|iu|meq)",
+    re.IGNORECASE,
+)
+
+FREQUENCY_MAP: dict[str, str] = {
+    "once daily": "daily",
+    "daily": "daily",
+    "qd": "daily",
+    "od": "daily",
+    "twice daily": "twice_daily",
+    "bid": "twice_daily",
+    "b.i.d.": "twice_daily",
+    "two times daily": "twice_daily",
+    "three times daily": "three_times_daily",
+    "tid": "three_times_daily",
+    "t.i.d.": "three_times_daily",
+    "four times daily": "four_times_daily",
+    "qid": "four_times_daily",
+    "every 4 hours": "every_4h",
+    "q4h": "every_4h",
+    "every 6 hours": "every_6h",
+    "q6h": "every_6h",
+    "every 8 hours": "every_8h",
+    "q8h": "every_8h",
+    "every 12 hours": "every_12h",
+    "q12h": "every_12h",
+    "as needed": "as_needed",
+    "prn": "as_needed",
+    "p.r.n.": "as_needed",
+    "weekly": "weekly",
+    "monthly": "monthly",
+    "at bedtime": "at_bedtime",
+    "qhs": "at_bedtime",
+}
+
+_RXNORM_SEMAPHORE: asyncio.Semaphore | None = None
+
+
+def _get_rxnorm_semaphore() -> asyncio.Semaphore:
+    global _RXNORM_SEMAPHORE
+    if _RXNORM_SEMAPHORE is None:
+        _RXNORM_SEMAPHORE = asyncio.Semaphore(3)
+    return _RXNORM_SEMAPHORE
+
+
+def parse_dosage(dosage_str: str) -> dict[str, Any]:
+    """Parse dosage string like '500mg' into machine-readable parts."""
+    match = DOSAGE_PATTERN.search(dosage_str or "")
+    if not match:
+        return {"value": None, "unit": None, "raw": dosage_str}
+
+    return {
+        "value": float(match.group(1)),
+        "unit": match.group(2).lower(),
+        "raw": dosage_str,
+    }
+
+
+def normalize_frequency(frequency_str: str) -> str:
+    """Normalize frequency string to a machine-readable key."""
+    value = (frequency_str or "").strip()
+    return FREQUENCY_MAP.get(value.lower(), value)
+
+
+async def normalize_medication(med: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a single medication from AI extraction."""
+    name = str(med.get("name") or "").strip()
+    dosage = str(med.get("dosage") or "").strip()
+    frequency = str(med.get("frequency") or "").strip()
+
+    normalized: dict[str, Any] = {
+        **med,
+        "name": name,
+        "dosage": dosage,
+        "frequency": frequency,
+        "parsed_dosage": parse_dosage(dosage),
+        "normalized_frequency": normalize_frequency(frequency),
+        "generic_name": name,
+        "rxcui": None,
+    }
+
+    if not name:
+        return normalized
+
+    try:
+        async with _get_rxnorm_semaphore():
+            response = await normalize_drug_name(name)
+    except Exception as exc:
+        logger.warning("RxNorm lookup failed for %s: %s", name, exc)
+        return normalized
+
+    normalized["generic_name"] = response.get("normalized_name") or name
+    normalized["rxcui"] = response.get("rxcui")
+    return normalized
+
+
+async def normalize_all(medications: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize a list of medications concurrently."""
+    if not medications:
+        return []
+
+    results = await asyncio.gather(
+        *(normalize_medication(med) for med in medications),
+        return_exceptions=True,
+    )
+
+    normalized: list[dict[str, Any]] = []
+    for original, result in zip(medications, results, strict=False):
+        if isinstance(result, Exception):
+            logger.warning("Medication normalization failed for %s: %s", original, result)
+            fallback = {
+                **original,
+                "parsed_dosage": parse_dosage(str(original.get("dosage") or "")),
+                "normalized_frequency": normalize_frequency(str(original.get("frequency") or "")),
+                "generic_name": str(original.get("name") or ""),
+                "rxcui": None,
+            }
+            normalized.append(fallback)
+            continue
+        normalized.append(result)
+
+    return normalized

--- a/backend/tests/fixtures/diagnostic_report.txt
+++ b/backend/tests/fixtures/diagnostic_report.txt
@@ -1,0 +1,48 @@
+DIAGNOSTIC RADIOLOGY REPORT
+
+Patient: David Martinez   DOB: 09/14/1962   MRN: 3948271
+Ordering Physician: Dr. Anita Patel, MD — Cardiology
+Procedure Date: 01/22/2026
+Exam: CT Angiography of the Chest with Contrast
+
+CLINICAL INDICATION:
+64-year-old male with history of coronary artery disease, status post CABG (2022), presenting with recurrent chest pain on exertion. Evaluate for graft patency and progression of native coronary artery disease.
+
+TECHNIQUE:
+CT angiography was performed on a 256-slice scanner with retrospective ECG gating. 85mL of Omnipaque 350 was administered IV at 5mL/sec. Images were reconstructed at 0.75mm slice thickness.
+
+FINDINGS:
+
+Heart:
+- Heart size is normal. Left ventricular ejection fraction estimated at 50%.
+- No pericardial effusion.
+
+Coronary Arteries:
+- Left main: Patent, no significant stenosis.
+- LAD: Moderate stenosis (50-60%) in the mid-segment. Calcified plaque noted.
+- LIMA-to-LAD graft: Patent with good distal runoff.
+- LCx: Mild stenosis (30%) in the proximal segment.
+- RCA: Severe stenosis (80-90%) in the mid-segment with mixed plaque.
+- SVG-to-RCA graft: Patent but with moderate stenosis (40-50%) at the distal anastomosis.
+
+Lungs:
+- Small bilateral pleural effusions, left greater than right.
+- No pulmonary embolism.
+- Mild bibasilar atelectasis.
+
+IMPRESSION:
+1. Severe stenosis of the mid-RCA (80-90%) with mixed plaque — recommend cardiology consultation for possible intervention
+2. Moderate stenosis of the mid-LAD (50-60%) — stable compared to prior
+3. SVG-to-RCA graft with moderate distal anastomotic stenosis (40-50%) — correlate clinically
+4. Small bilateral pleural effusions, likely related to underlying cardiac status
+5. LIMA-to-LAD graft patent — no intervention needed
+
+RECOMMENDATIONS:
+- Cardiology follow-up within 1 week to discuss RCA intervention options
+- Continue dual antiplatelet therapy (Aspirin 81mg + Clopidogrel 75mg)
+- Continue Atorvastatin 80mg daily
+- Repeat echocardiogram in 3 months to assess LV function
+- Consider cardiac catheterization for definitive evaluation of RCA lesion
+
+Interpreting Radiologist: Dr. Michael Torres, MD — Cardiovascular Radiology
+Electronically signed: 01/22/2026 16:45

--- a/backend/tests/fixtures/diagnostic_report_expected.json
+++ b/backend/tests/fixtures/diagnostic_report_expected.json
@@ -1,0 +1,59 @@
+{
+  "medications": [
+    {
+      "name": "Aspirin",
+      "dosage": "81mg",
+      "frequency": "daily",
+      "instructions": "Continue dual antiplatelet therapy",
+      "route": "oral"
+    },
+    {
+      "name": "Clopidogrel",
+      "dosage": "75mg",
+      "frequency": "daily",
+      "instructions": "Continue dual antiplatelet therapy",
+      "route": "oral"
+    },
+    {
+      "name": "Atorvastatin",
+      "dosage": "80mg",
+      "frequency": "daily",
+      "instructions": "Continue Atorvastatin 80mg daily",
+      "route": "oral"
+    }
+  ],
+  "conditions": [
+    {
+      "name": "Coronary artery disease",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Severe stenosis of mid-RCA",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Moderate stenosis of mid-LAD",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Bilateral pleural effusions",
+      "clinical_status": "active"
+    }
+  ],
+  "allergies": [],
+  "follow_up_instructions": [
+    {
+      "description": "Cardiology follow-up within 1 week to discuss RCA intervention options",
+      "timing": "1 week",
+      "provider": "Cardiology"
+    },
+    {
+      "description": "Repeat echocardiogram in 3 months to assess LV function",
+      "timing": "3 months"
+    },
+    {
+      "description": "Consider cardiac catheterization for definitive evaluation of RCA lesion",
+      "timing": "as directed"
+    }
+  ]
+}

--- a/backend/tests/fixtures/discharge_summary.txt
+++ b/backend/tests/fixtures/discharge_summary.txt
@@ -1,0 +1,40 @@
+DISCHARGE SUMMARY
+
+Patient: Maria Garcia  DOB: 03/15/1958  MRN: 4827193
+Admission Date: 01/10/2026  Discharge Date: 01/15/2026
+Attending Physician: Dr. Anita Patel, MD — Cardiology
+Facility: Valley Medical Center
+
+ADMITTING DIAGNOSIS:
+Acute decompensated heart failure (CHF exacerbation)
+
+HOSPITAL COURSE:
+Patient presented to the ED with worsening dyspnea, bilateral lower extremity edema, and weight gain of 8 lbs over 5 days. BNP was elevated at 1,450 pg/mL. Chest X-ray showed bilateral pleural effusions and pulmonary congestion. Patient was admitted to the telemetry unit for IV diuresis with Furosemide 40mg IV q12h. Over the course of 5 days, patient diuresed approximately 6L with improvement in symptoms. Transitioned to oral medications on day 4. Echocardiogram showed EF of 35%, unchanged from prior.
+
+DISCHARGE DIAGNOSES:
+1. Congestive heart failure, systolic (HFrEF), EF 35%
+2. Hypertension, controlled
+3. Type 2 Diabetes Mellitus
+4. Hyperlipidemia
+
+ALLERGIES:
+1. Penicillin — rash, hives (severe)
+2. Sulfa drugs — shortness of breath (moderate)
+
+DISCHARGE MEDICATIONS:
+1. Metoprolol Succinate 50mg — take one tablet by mouth twice daily
+2. Lisinopril 10mg — take one tablet by mouth once daily
+3. Furosemide 40mg — take one tablet by mouth once daily in the morning
+4. Metformin 500mg — take one tablet by mouth twice daily with meals
+5. Atorvastatin 40mg — take one tablet by mouth at bedtime
+
+FOLLOW-UP INSTRUCTIONS:
+1. Follow up with Dr. Patel (Cardiology) in 2 weeks — call 555-0142 to schedule
+2. Follow up with Dr. Chen (Primary Care) in 1 week
+3. Daily weight monitoring — weigh yourself every morning before breakfast, call if weight increases more than 3 lbs in 2 days
+4. Low-sodium diet — limit to less than 2,000mg sodium per day
+5. Fluid restriction — no more than 2 liters of fluid per day
+6. Cardiac rehabilitation referral — enrollment paperwork included
+
+Dictated by: Dr. Anita Patel, MD
+Electronically signed: 01/15/2026 14:32

--- a/backend/tests/fixtures/discharge_summary_expected.json
+++ b/backend/tests/fixtures/discharge_summary_expected.json
@@ -1,0 +1,97 @@
+{
+  "medications": [
+    {
+      "name": "Metoprolol Succinate",
+      "dosage": "50mg",
+      "frequency": "twice daily",
+      "instructions": "take one tablet by mouth twice daily",
+      "route": "oral"
+    },
+    {
+      "name": "Lisinopril",
+      "dosage": "10mg",
+      "frequency": "once daily",
+      "instructions": "take one tablet by mouth once daily",
+      "route": "oral"
+    },
+    {
+      "name": "Furosemide",
+      "dosage": "40mg",
+      "frequency": "once daily",
+      "instructions": "take one tablet by mouth once daily in the morning",
+      "route": "oral"
+    },
+    {
+      "name": "Metformin",
+      "dosage": "500mg",
+      "frequency": "twice daily",
+      "instructions": "take one tablet by mouth twice daily with meals",
+      "route": "oral"
+    },
+    {
+      "name": "Atorvastatin",
+      "dosage": "40mg",
+      "frequency": "once daily",
+      "instructions": "take one tablet by mouth at bedtime",
+      "route": "oral"
+    }
+  ],
+  "conditions": [
+    {
+      "name": "Congestive heart failure",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Hypertension",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Type 2 Diabetes Mellitus",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Hyperlipidemia",
+      "clinical_status": "active"
+    }
+  ],
+  "allergies": [
+    {
+      "substance": "Penicillin",
+      "reaction": "rash, hives",
+      "severity": "severe"
+    },
+    {
+      "substance": "Sulfa drugs",
+      "reaction": "shortness of breath",
+      "severity": "moderate"
+    }
+  ],
+  "follow_up_instructions": [
+    {
+      "description": "Follow up with Dr. Patel (Cardiology) in 2 weeks",
+      "timing": "2 weeks",
+      "provider": "Dr. Patel"
+    },
+    {
+      "description": "Follow up with Dr. Chen (Primary Care) in 1 week",
+      "timing": "1 week",
+      "provider": "Dr. Chen"
+    },
+    {
+      "description": "Daily weight monitoring — weigh yourself every morning before breakfast, call if weight increases more than 3 lbs in 2 days",
+      "timing": "daily"
+    },
+    {
+      "description": "Low-sodium diet — limit to less than 2,000mg sodium per day",
+      "timing": "daily"
+    },
+    {
+      "description": "Fluid restriction — no more than 2 liters of fluid per day",
+      "timing": "daily"
+    },
+    {
+      "description": "Cardiac rehabilitation referral",
+      "timing": "as directed"
+    }
+  ]
+}

--- a/backend/tests/fixtures/lab_report.txt
+++ b/backend/tests/fixtures/lab_report.txt
@@ -1,0 +1,43 @@
+LABORATORY REPORT
+
+Patient: James Thompson   DOB: 07/22/1970   MRN: 5931847
+Ordering Provider: Dr. Lisa Chen, MD — Internal Medicine
+Collection Date: 01/18/2026 07:15   Report Date: 01/18/2026 14:00
+Specimen: Venous Blood
+
+COMPLETE BLOOD COUNT (CBC):
+  WBC:          11.2 x10^3/uL   [H]   (Ref: 4.5-11.0)
+  RBC:          4.85 x10^6/uL         (Ref: 4.50-5.50)
+  Hemoglobin:   14.2 g/dL             (Ref: 13.5-17.5)
+  Hematocrit:   42.1 %                (Ref: 38.0-50.0)
+  Platelets:    245 x10^3/uL          (Ref: 150-400)
+
+COMPREHENSIVE METABOLIC PANEL (CMP):
+  Glucose:      187 mg/dL   [H]   (Ref: 70-100)
+  BUN:          28 mg/dL    [H]   (Ref: 7-20)
+  Creatinine:   1.4 mg/dL   [H]   (Ref: 0.7-1.3)
+  eGFR:         55 mL/min         (Ref: >60)
+  Sodium:       139 mEq/L         (Ref: 136-145)
+  Potassium:    4.8 mEq/L         (Ref: 3.5-5.0)
+  Calcium:      9.2 mg/dL         (Ref: 8.5-10.5)
+  AST:          22 U/L             (Ref: 10-40)
+  ALT:          31 U/L             (Ref: 7-56)
+
+HEMOGLOBIN A1C:
+  HbA1c:        8.2 %   [H]   (Ref: <5.7%)
+
+LIPID PANEL:
+  Total Cholesterol:  242 mg/dL   [H]   (Ref: <200)
+  LDL Cholesterol:    158 mg/dL   [H]   (Ref: <100)
+  HDL Cholesterol:    38 mg/dL    [L]   (Ref: >40)
+  Triglycerides:      230 mg/dL   [H]   (Ref: <150)
+
+INTERPRETATION:
+- Elevated WBC may suggest mild infection or stress response — recommend clinical correlation
+- Fasting glucose significantly elevated, HbA1c 8.2% indicates poor glycemic control
+- Creatinine mildly elevated with eGFR 55, consistent with early Stage 3a CKD
+- Lipid panel significantly abnormal — consider statin therapy intensification
+- Recommend follow-up labs in 3 months
+
+Reported by: Quest Diagnostics
+Reviewed by: Dr. Lisa Chen, MD — 01/18/2026

--- a/backend/tests/fixtures/lab_report_expected.json
+++ b/backend/tests/fixtures/lab_report_expected.json
@@ -1,0 +1,33 @@
+{
+  "medications": [],
+  "conditions": [
+    {
+      "name": "Elevated WBC",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Poor glycemic control",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Stage 3a Chronic Kidney Disease",
+      "clinical_status": "active"
+    },
+    {
+      "name": "Hyperlipidemia",
+      "clinical_status": "active"
+    }
+  ],
+  "allergies": [],
+  "follow_up_instructions": [
+    {
+      "description": "Follow-up labs in 3 months",
+      "timing": "3 months",
+      "provider": "Dr. Lisa Chen"
+    },
+    {
+      "description": "Consider statin therapy intensification",
+      "timing": "as directed"
+    }
+  ]
+}

--- a/backend/tests/fixtures/prescription.txt
+++ b/backend/tests/fixtures/prescription.txt
@@ -1,0 +1,45 @@
+PRESCRIPTION
+
+Prescriber: Dr. Robert Kim, MD — Endocrinology
+NPI: 1234567890
+DEA: BK1234567
+Practice: Bay Area Endocrine Associates
+Address: 1200 Market Street, Suite 400, San Jose, CA 95112
+Phone: (408) 555-0198
+
+Patient: Sarah Williams   DOB: 11/03/1985   MRN: 7214856
+Date: 01/20/2026
+
+Rx 1:
+  Medication: Ozempic (Semaglutide) 0.5mg/dose
+  Directions: Inject 0.5mg subcutaneously once weekly on the same day each week
+  Quantity: 1 pen (4 doses)
+  Refills: 2
+  Note: Start at 0.25mg for first 4 weeks, then increase to 0.5mg
+
+Rx 2:
+  Medication: Metformin ER 1000mg
+  Directions: Take one tablet by mouth once daily with evening meal
+  Quantity: 30 tablets
+  Refills: 5
+
+Rx 3:
+  Medication: Jardiance (Empagliflozin) 10mg
+  Directions: Take one tablet by mouth once daily in the morning
+  Quantity: 30 tablets
+  Refills: 5
+
+Rx 4:
+  Medication: Lantus (Insulin Glargine) 100 units/mL
+  Directions: Inject 20 units subcutaneously at bedtime, adjust per blood sugar log
+  Quantity: 1 vial (10mL)
+  Refills: 3
+
+Special Instructions:
+- Monitor blood glucose before meals and at bedtime for the first 2 weeks
+- Report any signs of hypoglycemia (shakiness, sweating, confusion) immediately
+- Schedule follow-up appointment in 6 weeks to review blood sugar logs
+- Continue current diet and exercise plan
+
+Prescriber Signature: Dr. Robert Kim, MD
+Date: 01/20/2026

--- a/backend/tests/fixtures/prescription_expected.json
+++ b/backend/tests/fixtures/prescription_expected.json
@@ -1,0 +1,53 @@
+{
+  "medications": [
+    {
+      "name": "Ozempic (Semaglutide)",
+      "dosage": "0.5mg",
+      "frequency": "once weekly",
+      "instructions": "Inject 0.5mg subcutaneously once weekly on the same day each week. Start at 0.25mg for first 4 weeks, then increase to 0.5mg",
+      "route": "subcutaneous"
+    },
+    {
+      "name": "Metformin ER",
+      "dosage": "1000mg",
+      "frequency": "once daily",
+      "instructions": "Take one tablet by mouth once daily with evening meal",
+      "route": "oral"
+    },
+    {
+      "name": "Jardiance (Empagliflozin)",
+      "dosage": "10mg",
+      "frequency": "once daily",
+      "instructions": "Take one tablet by mouth once daily in the morning",
+      "route": "oral"
+    },
+    {
+      "name": "Lantus (Insulin Glargine)",
+      "dosage": "20 units",
+      "frequency": "once daily",
+      "instructions": "Inject 20 units subcutaneously at bedtime, adjust per blood sugar log",
+      "route": "subcutaneous"
+    }
+  ],
+  "conditions": [],
+  "allergies": [],
+  "follow_up_instructions": [
+    {
+      "description": "Monitor blood glucose before meals and at bedtime for the first 2 weeks",
+      "timing": "2 weeks"
+    },
+    {
+      "description": "Report any signs of hypoglycemia (shakiness, sweating, confusion) immediately",
+      "timing": "immediately"
+    },
+    {
+      "description": "Schedule follow-up appointment in 6 weeks to review blood sugar logs",
+      "timing": "6 weeks",
+      "provider": "Dr. Robert Kim"
+    },
+    {
+      "description": "Continue current diet and exercise plan",
+      "timing": "daily"
+    }
+  ]
+}

--- a/backend/tests/integration/routers/test_document_api.py
+++ b/backend/tests/integration/routers/test_document_api.py
@@ -1,9 +1,6 @@
-"""Integration tests for Document API endpoints.
+"""Integration tests for Document API endpoints."""
 
-Uses FastAPI dependency overrides for proper authentication mocking.
-"""
-
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -93,30 +90,39 @@ class TestCreateDocument:
             "notes": "Annual checkup results",
             "parsed": False,
             "ai_summary": None,
+            "parse_status": "pending",
+            "parse_error": None,
+            "parse_attempts": 0,
             "visibility": "all_providers",
             "created_at": "2025-01-15T00:00:00Z",
         }
 
         mock_supabase_db.table().insert().execute.return_value = MagicMock(data=[document_data])
 
-        response = client.post(
-            "/api/v1/documents/",
-            json={
-                "file_name": "lab-results.pdf",
-                "file_path": f"{patient_id}/lab-results.pdf",
-                "file_size_bytes": 1024000,
-                "mime_type": "application/pdf",
-                "document_type": "lab_report",
-                "source_clinic": "Test Clinic",
-                "notes": "Annual checkup results",
-            },
-        )
+        with patch(
+            "app.routers.documents._run_ingestion_safe",
+            new=AsyncMock(),
+        ) as mock_ingest:
+            response = client.post(
+                "/api/v1/documents/",
+                json={
+                    "file_name": "lab-results.pdf",
+                    "file_path": f"{patient_id}/lab-results.pdf",
+                    "file_size_bytes": 1024000,
+                    "mime_type": "application/pdf",
+                    "document_type": "lab_report",
+                    "source_clinic": "Test Clinic",
+                    "notes": "Annual checkup results",
+                },
+            )
 
         assert response.status_code == status.HTTP_201_CREATED
         data = response.json()
         assert data["file_name"] == "lab-results.pdf"
         assert data["document_type"] == "lab_report"
         assert "file_url" in data
+        assert data["parse_status"] == "pending"
+        mock_ingest.assert_awaited_once()
 
     def test_invalid_mime_type(self, client, override_auth, override_db):
         """Reject unsupported file type."""
@@ -183,6 +189,9 @@ class TestListDocuments:
                 "source_clinic": None,
                 "parsed": False,
                 "ai_summary": None,
+                "parse_status": "pending",
+                "parse_error": None,
+                "parse_attempts": 1,
                 "visibility": "all_providers",
                 "created_at": "2025-01-15T00:00:00Z",
             },
@@ -200,6 +209,9 @@ class TestListDocuments:
                 "source_clinic": "Test Clinic",
                 "parsed": True,
                 "ai_summary": "Prescription for medication X",
+                "parse_status": "completed",
+                "parse_error": None,
+                "parse_attempts": 1,
                 "visibility": "all_providers",
                 "created_at": "2025-01-14T00:00:00Z",
             },
@@ -249,6 +261,9 @@ class TestGetDocument:
             "source_clinic": None,
             "parsed": False,
             "ai_summary": None,
+            "parse_status": "processing",
+            "parse_error": None,
+            "parse_attempts": 1,
             "visibility": "all_providers",
             "created_at": "2025-01-15T00:00:00Z",
         }
@@ -279,14 +294,6 @@ class TestGetDocument:
     def test_wrong_patient(self, client, override_auth, override_db, mock_supabase_db):
         """Reject access to another patient's document."""
         document_id = uuid4()
-        other_patient_id = uuid4()
-
-        # Document belongs to different patient
-        {
-            "id": str(document_id),
-            "patient_id": str(other_patient_id),
-            "file_name": "lab-results.pdf",
-        }
 
         mock_supabase_db.table().select().eq().eq().single().execute.return_value = MagicMock(
             data=None  # Query filters by patient_id, so returns None
@@ -298,17 +305,88 @@ class TestGetDocument:
 
 
 class TestExplainDocument:
-    """POST /api/v1/documents/{document_id}/explain - Trigger AI explanation."""
+    """POST /api/v1/documents/{document_id}/explain - Explain a document."""
 
-    def test_not_implemented(self, client, override_auth, override_db):
-        """Endpoint returns 501 Not Implemented (Phase 4 feature)."""
+    def test_returns_cached_english_summary(
+        self, client, override_auth, override_db, mock_supabase_db, patient_id
+    ):
+        """English explanation returns cached ai_summary without LLM call."""
         document_id = uuid4()
+        mock_supabase_db.table().select().eq().eq().single().execute.return_value = MagicMock(
+            data={
+                "id": str(document_id),
+                "patient_id": str(patient_id),
+                "uploaded_by": str(patient_id),
+                "uploaded_by_role": "patient",
+                "file_name": "lab-results.pdf",
+                "file_path": f"{patient_id}/lab-results.pdf",
+                "file_url": "https://storage.example.com/signed-url",
+                "file_size_bytes": 1024000,
+                "mime_type": "application/pdf",
+                "document_type": "lab_report",
+                "source_clinic": None,
+                "parsed": True,
+                "ai_summary": "Cached summary",
+                "parse_status": "completed",
+                "parse_error": None,
+                "parse_attempts": 1,
+                "visibility": "all_providers",
+                "created_at": "2025-01-15T00:00:00Z",
+            }
+        )
 
-        response = client.post(f"/api/v1/documents/{document_id}/explain")
+        response = client.post(
+            f"/api/v1/documents/{document_id}/explain",
+            json={"language": "en"},
+        )
 
-        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+        assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert "Phase 4" in data["message"]
+        assert data["summary"] == "Cached summary"
+        assert data["cached"] is True
+
+    def test_translates_summary(
+        self, client, override_auth, override_db, mock_supabase_db, patient_id
+    ):
+        """Non-English explanation uses the explanation service."""
+        document_id = uuid4()
+        mock_supabase_db.table().select().eq().eq().single().execute.return_value = MagicMock(
+            data={
+                "id": str(document_id),
+                "patient_id": str(patient_id),
+                "uploaded_by": str(patient_id),
+                "uploaded_by_role": "patient",
+                "file_name": "lab-results.pdf",
+                "file_path": f"{patient_id}/lab-results.pdf",
+                "file_url": "https://storage.example.com/signed-url",
+                "file_size_bytes": 1024000,
+                "mime_type": "application/pdf",
+                "document_type": "lab_report",
+                "source_clinic": None,
+                "parsed": True,
+                "ai_summary": "English summary",
+                "parse_status": "completed",
+                "parse_error": None,
+                "parse_attempts": 1,
+                "visibility": "all_providers",
+                "created_at": "2025-01-15T00:00:00Z",
+            }
+        )
+
+        with patch(
+            "app.routers.documents.ExplanationService.explain",
+            new=AsyncMock(return_value="Resumen en español"),
+        ) as mock_explain:
+            response = client.post(
+                f"/api/v1/documents/{document_id}/explain",
+                json={"language": "es"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["summary"] == "Resumen en español"
+        assert data["cached"] is False
+        mock_explain.assert_awaited_once()
 
 
 class TestAuthorization:

--- a/backend/tests/integration/test_golden_set.py
+++ b/backend/tests/integration/test_golden_set.py
@@ -1,0 +1,250 @@
+"""Golden-set evaluation tests — load fixture documents, run through extraction, compare against expected output.
+
+These tests verify that the ingestion pipeline's AI extraction + FHIR validation
+produces results structurally matching hand-curated expected outputs. Because LLM
+output is non-deterministic, assertions check *structure* and *key fields* rather
+than exact string equality.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from app.agents.ingestion.graph import extract_content, validate_fhir
+from app.tools.fhir_builder import validate_extracted_data
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+PATIENT_ID = UUID("00000000-0000-0000-0000-000000000123")
+DOCUMENT_ID = UUID("00000000-0000-0000-0000-000000000999")
+
+
+def _load_fixture(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+def _load_expected(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text())
+
+
+# ── Smoke: Fixtures actually exist ──────────────────────
+
+
+class TestFixturesExist:
+    """Verify all synthetic test documents and golden-set files exist."""
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        [
+            "discharge_summary.txt",
+            "lab_report.txt",
+            "prescription.txt",
+            "diagnostic_report.txt",
+            "discharge_summary_expected.json",
+            "lab_report_expected.json",
+            "prescription_expected.json",
+            "diagnostic_report_expected.json",
+        ],
+    )
+    def test_fixture_exists(self, fixture_name: str) -> None:
+        path = FIXTURES / fixture_name
+        assert path.exists(), f"Missing fixture: {path}"
+        assert path.stat().st_size > 0, f"Empty fixture: {path}"
+
+
+# ── Golden-set structure tests ──────────────────────────
+
+
+class TestGoldenSetStructure:
+    """Verify all expected JSON files have the required top-level keys."""
+
+    @pytest.mark.parametrize(
+        "expected_name",
+        [
+            "discharge_summary_expected.json",
+            "lab_report_expected.json",
+            "prescription_expected.json",
+            "diagnostic_report_expected.json",
+        ],
+    )
+    def test_expected_has_required_keys(self, expected_name: str) -> None:
+        expected = _load_expected(expected_name)
+        for key in ("medications", "conditions", "allergies", "follow_up_instructions"):
+            assert key in expected, f"Missing key '{key}' in {expected_name}"
+            assert isinstance(expected[key], list), f"'{key}' should be a list in {expected_name}"
+
+
+# ── Golden-set content validation ───────────────────────
+
+
+class TestDischargeGoldenSet:
+    """Discharge summary should extract 5 meds, 4 conditions, 2 allergies, 6 follow-ups."""
+
+    def test_expected_medication_count(self) -> None:
+        expected = _load_expected("discharge_summary_expected.json")
+        assert len(expected["medications"]) == 5
+
+    def test_expected_condition_count(self) -> None:
+        expected = _load_expected("discharge_summary_expected.json")
+        assert len(expected["conditions"]) == 4
+
+    def test_expected_allergy_count(self) -> None:
+        expected = _load_expected("discharge_summary_expected.json")
+        assert len(expected["allergies"]) == 2
+
+    def test_expected_followup_count(self) -> None:
+        expected = _load_expected("discharge_summary_expected.json")
+        assert len(expected["follow_up_instructions"]) == 6
+
+    def test_all_meds_have_names(self) -> None:
+        expected = _load_expected("discharge_summary_expected.json")
+        for med in expected["medications"]:
+            assert med.get("name"), f"Medication missing name: {med}"
+
+    def test_fhir_validation_on_expected_data(self) -> None:
+        """Run expected data through FHIR validation — should produce zero errors."""
+        expected = _load_expected("discharge_summary_expected.json")
+        validated, errors = validate_extracted_data(expected, PATIENT_ID, DOCUMENT_ID)
+        assert errors == [], f"FHIR validation errors: {errors}"
+        assert len(validated["medications"]) == 5
+        assert len(validated["conditions"]) == 4
+        assert len(validated["allergies"]) == 2
+
+
+class TestPrescriptionGoldenSet:
+    """Prescription should extract 4 meds with different routes."""
+
+    def test_expected_medication_count(self) -> None:
+        expected = _load_expected("prescription_expected.json")
+        assert len(expected["medications"]) == 4
+
+    def test_subcutaneous_route_present(self) -> None:
+        expected = _load_expected("prescription_expected.json")
+        routes = {med.get("route") for med in expected["medications"]}
+        assert "subcutaneous" in routes, f"Expected subcutaneous route, got: {routes}"
+
+    def test_fhir_validation_on_expected_data(self) -> None:
+        expected = _load_expected("prescription_expected.json")
+        validated, errors = validate_extracted_data(expected, PATIENT_ID, DOCUMENT_ID)
+        assert errors == [], f"FHIR validation errors: {errors}"
+        assert len(validated["medications"]) == 4
+
+
+class TestLabReportGoldenSet:
+    """Lab report should extract conditions from abnormal results, no meds."""
+
+    def test_no_medications(self) -> None:
+        expected = _load_expected("lab_report_expected.json")
+        assert len(expected["medications"]) == 0
+
+    def test_conditions_from_abnormal_values(self) -> None:
+        expected = _load_expected("lab_report_expected.json")
+        assert len(expected["conditions"]) >= 3
+
+    def test_fhir_validation_on_expected_data(self) -> None:
+        expected = _load_expected("lab_report_expected.json")
+        validated, errors = validate_extracted_data(expected, PATIENT_ID, DOCUMENT_ID)
+        assert errors == [], f"FHIR validation errors: {errors}"
+
+
+class TestDiagnosticGoldenSet:
+    """Diagnostic report should extract meds from recommendations + conditions from findings."""
+
+    def test_medications_from_recommendations(self) -> None:
+        expected = _load_expected("diagnostic_report_expected.json")
+        assert len(expected["medications"]) >= 2
+
+    def test_conditions_from_findings(self) -> None:
+        expected = _load_expected("diagnostic_report_expected.json")
+        assert len(expected["conditions"]) >= 3
+
+    def test_fhir_validation_on_expected_data(self) -> None:
+        expected = _load_expected("diagnostic_report_expected.json")
+        validated, errors = validate_extracted_data(expected, PATIENT_ID, DOCUMENT_ID)
+        assert errors == [], f"FHIR validation errors: {errors}"
+
+
+# ── Integration: extract_content with fixture text ──────
+
+
+class TestExtractContentWithFixture:
+    """Test extract_content node with real fixture text and mocked LLM returning golden-set output."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("fixture_txt", "fixture_json"),
+        [
+            ("discharge_summary.txt", "discharge_summary_expected.json"),
+            ("lab_report.txt", "lab_report_expected.json"),
+            ("prescription.txt", "prescription_expected.json"),
+            ("diagnostic_report.txt", "diagnostic_report_expected.json"),
+        ],
+    )
+    async def test_extract_with_golden_response(
+        self, fixture_txt: str, fixture_json: str
+    ) -> None:
+        """Simulate LLM returning the golden-set JSON given fixture text."""
+        raw_content = _load_fixture(fixture_txt)
+        expected = _load_expected(fixture_json)
+
+        with patch("app.agents.ingestion.graph.get_router") as mock_get_router:
+            mock_client = AsyncMock()
+            mock_client.generate.return_value = json.dumps(expected)
+            mock_router = MagicMock()
+            mock_router.get_client_with_fallback.return_value = mock_client
+            mock_get_router.return_value = mock_router
+
+            state = {
+                "document_id": str(DOCUMENT_ID),
+                "raw_content": raw_content,
+            }
+            result = await extract_content(state)
+
+        assert result["error"] is None
+        assert result["raw_content"] is None, "raw_content should be cleared after extraction"
+
+        extracted = result["extracted_data"]
+        assert len(extracted.get("medications", [])) == len(expected["medications"])
+        assert len(extracted.get("conditions", [])) == len(expected["conditions"])
+
+
+# ── Integration: full extract → validate pipeline ───────
+
+
+class TestExtractThenValidate:
+    """Test extract_content → validate_fhir with fixture data."""
+
+    @pytest.mark.asyncio
+    async def test_discharge_extract_then_validate(self) -> None:
+        expected = _load_expected("discharge_summary_expected.json")
+
+        with patch("app.agents.ingestion.graph.get_router") as mock_get_router:
+            mock_client = AsyncMock()
+            mock_client.generate.return_value = json.dumps(expected)
+            mock_router = MagicMock()
+            mock_router.get_client_with_fallback.return_value = mock_client
+            mock_get_router.return_value = mock_router
+
+            state = {
+                "document_id": str(DOCUMENT_ID),
+                "patient_id": str(PATIENT_ID),
+                "raw_content": _load_fixture("discharge_summary.txt"),
+            }
+            state = await extract_content(state)
+
+        with patch(
+            "app.tools.fhir_builder.validate_extracted_data",
+            wraps=validate_extracted_data,
+        ):
+            state = await validate_fhir(state)
+
+        assert state["error"] is None
+        assert state["validation_errors"] is None or state["validation_errors"] == []
+        assert len(state["validated_data"]["medications"]) == 5
+        assert len(state["validated_data"]["conditions"]) == 4
+        assert len(state["validated_data"]["allergies"]) == 2

--- a/backend/tests/integration/test_ingestion_pipeline.py
+++ b/backend/tests/integration/test_ingestion_pipeline.py
@@ -1,0 +1,185 @@
+"""Integration-style tests for ingestion orchestration and explanation flow."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from app.core.exceptions import DocumentParseError
+from app.services.explanation_service import ExplanationService
+from app.services.ingestion_service import IngestionService
+
+DOCUMENT_ID = UUID("00000000-0000-0000-0000-000000000111")
+PATIENT_ID = UUID("00000000-0000-0000-0000-000000000222")
+
+
+def _make_table(result_data):
+    table = MagicMock()
+    for method in ["select", "eq", "single", "update", "insert"]:
+        getattr(table, method).return_value = table
+    table.execute.return_value = MagicMock(data=result_data)
+    return table
+
+
+def _make_db(parse_attempts: int = 0):
+    documents_table = _make_table({"parse_attempts": parse_attempts})
+    conditions_table = _make_table([{"id": "condition-1"}])
+    allergies_table = _make_table([{"id": "allergy-1"}])
+
+    tables = {
+        "documents": documents_table,
+        "conditions": conditions_table,
+        "allergies": allergies_table,
+    }
+
+    db = MagicMock()
+    db.table.side_effect = lambda name: tables[name]
+    return db
+
+
+@pytest.mark.asyncio
+async def test_full_ingestion_pipeline():
+    db = _make_db()
+    service = IngestionService(db)
+    service._graph.ainvoke = AsyncMock(
+        return_value={
+            "error": None,
+            "validated_data": {
+                "conditions": [{"name": "Hypertension", "status": "active"}],
+                "allergies": [{"allergen": "Penicillin", "severity": "moderate"}],
+            },
+            "extracted_data": {
+                "follow_up_instructions": [{"description": "Walk daily", "timing": "daily"}]
+            },
+            "normalized_medications": [
+                {
+                    "name": "Aspirin",
+                    "generic_name": "aspirin",
+                    "rxcui": "1191",
+                    "dosage": "81mg",
+                    "frequency": "daily",
+                    "route": "oral",
+                }
+            ],
+            "patient_summary": "Take aspirin daily and walk every day.",
+        }
+    )
+    service._med_service.create_medication = AsyncMock(return_value={"id": "med-1"})
+    service._obligation_service.create_obligation = AsyncMock(return_value={"id": "obl-1"})
+
+    result = await service.ingest_document(
+        document_id=DOCUMENT_ID,
+        patient_id=PATIENT_ID,
+        file_path="patient/doc.pdf",
+        document_type="lab_report",
+    )
+
+    assert result["status"] == "completed"
+    assert result["medications_created"] == 1
+    assert result["obligations_created"] == 1
+    service._med_service.create_medication.assert_awaited()
+    service._obligation_service.create_obligation.assert_awaited()
+    assert db.table("documents").update.call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_ingestion_pipeline_llm_failure():
+    db = _make_db()
+    service = IngestionService(db)
+    service._graph.ainvoke = AsyncMock(return_value={"error": "LLM crashed"})
+
+    result = await service.ingest_document(
+        document_id=DOCUMENT_ID,
+        patient_id=PATIENT_ID,
+        file_path="patient/doc.pdf",
+        document_type="lab_report",
+    )
+
+    assert result["status"] == "failed"
+    assert "LLM crashed" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_ingestion_pipeline_rxnorm_failure():
+    db = _make_db()
+    service = IngestionService(db)
+    service._graph.ainvoke = AsyncMock(
+        return_value={
+            "error": None,
+            "validated_data": {"conditions": [], "allergies": []},
+            "extracted_data": {"follow_up_instructions": []},
+            "normalized_medications": [
+                {
+                    "name": "Aspirin",
+                    "generic_name": "Aspirin",
+                    "rxcui": None,
+                    "dosage": "81mg",
+                    "frequency": "daily",
+                    "route": "oral",
+                }
+            ],
+            "patient_summary": "Take aspirin daily.",
+        }
+    )
+    service._med_service.create_medication = AsyncMock(return_value={"id": "med-1"})
+    service._obligation_service.create_obligation = AsyncMock(return_value={"id": "obl-1"})
+
+    result = await service.ingest_document(
+        document_id=DOCUMENT_ID,
+        patient_id=PATIENT_ID,
+        file_path="patient/doc.pdf",
+        document_type="prescription",
+    )
+
+    assert result["status"] == "completed"
+    payload = service._med_service.create_medication.await_args_list[0].args[1]
+    assert payload["rxcui"] is None
+
+
+@pytest.mark.asyncio
+async def test_ingestion_max_retries():
+    db = _make_db(parse_attempts=3)
+    service = IngestionService(db)
+    service._graph.ainvoke = AsyncMock()
+
+    with pytest.raises(DocumentParseError):
+        await service.ingest_document(
+            document_id=DOCUMENT_ID,
+            patient_id=PATIENT_ID,
+            file_path="patient/doc.pdf",
+            document_type="lab_report",
+        )
+
+    service._graph.ainvoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_explain_cached_summary():
+    service = ExplanationService()
+    document = {"id": str(DOCUMENT_ID), "ai_summary": "Already cached"}
+
+    with patch("app.services.explanation_service.get_router") as mock_get_router:
+        summary = await service.explain(document_data=document, language="en")
+
+    assert summary == "Already cached"
+    mock_get_router.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_explain_spanish_translation():
+    service = ExplanationService()
+    mock_client = AsyncMock()
+    mock_client.generate = AsyncMock(return_value="Resumen en español")
+    mock_router = MagicMock()
+    mock_router.get_client_with_fallback.return_value = mock_client
+
+    with patch(
+        "app.services.explanation_service.get_router",
+        return_value=mock_router,
+    ):
+        summary = await service.explain(
+            document_data={"id": str(DOCUMENT_ID), "ai_summary": "English summary"},
+            language="es",
+        )
+
+    assert summary == "Resumen en español"

--- a/backend/tests/unit/agents/test_ingestion_graph.py
+++ b/backend/tests/unit/agents/test_ingestion_graph.py
@@ -8,130 +8,58 @@ from app.agents.ingestion.graph import IngestionState, create_ingestion_graph
 
 
 def test_ingestion_state_structure():
-    """Test IngestionState has correct structure."""
-    # Create a valid state
     state: IngestionState = {
         "document_id": "doc-123",
-        "document_bytes": b"test data",
-        "document_type": "pdf",
+        "file_url": "patient/doc.pdf",
+        "document_type": "lab_report",
         "patient_id": "patient-456",
-        "raw_text": None,
-        "parsed_data": None,
-        "normalized_meds": None,
+        "raw_content": None,
+        "extracted_data": None,
+        "validated_data": None,
+        "validation_errors": None,
+        "normalized_medications": None,
         "saved_ids": None,
-        "summary": None,
+        "patient_summary": None,
+        "created_tasks": None,
         "error": None,
         "retry_count": 0,
         "messages": [],
     }
 
-    assert state["document_id"] == "doc-123"
-    assert state["document_bytes"] == b"test data"
-    assert state["document_type"] == "pdf"
-    assert state["patient_id"] == "patient-456"
-    assert state["raw_text"] is None
-    assert state["retry_count"] == 0
-
-
-def test_ingestion_state_with_intermediate_data():
-    """Test IngestionState with intermediate processing data."""
-    state: IngestionState = {
-        "document_id": "doc-123",
-        "document_bytes": b"test data",
-        "document_type": "pdf",
-        "patient_id": "patient-456",
-        "raw_text": "Extracted text from document",
-        "parsed_data": {"medications": ["aspirin"], "conditions": ["hypertension"]},
-        "normalized_meds": [{"rxcui": "1191", "name": "aspirin"}],
-        "saved_ids": {"medications": ["med-1"], "conditions": ["cond-1"]},
-        "summary": "Document processed successfully",
-        "error": None,
-        "retry_count": 0,
-        "messages": [],
-    }
-
-    assert state["raw_text"] == "Extracted text from document"
-    assert state["parsed_data"] is not None
-    assert "medications" in state["parsed_data"]
-    assert state["normalized_meds"] is not None
-    assert len(state["normalized_meds"]) == 1
-
-
-def test_ingestion_state_with_error():
-    """Test IngestionState with error."""
-    state: IngestionState = {
-        "document_id": "doc-123",
-        "document_bytes": b"test data",
-        "document_type": "pdf",
-        "patient_id": "patient-456",
-        "raw_text": None,
-        "parsed_data": None,
-        "normalized_meds": None,
-        "saved_ids": None,
-        "summary": None,
-        "error": "Failed to extract text",
-        "retry_count": 1,
-        "messages": [],
-    }
-
-    assert state["error"] == "Failed to extract text"
-    assert state["retry_count"] == 1
+    assert state["file_url"] == "patient/doc.pdf"
+    assert state["raw_content"] is None
+    assert state["created_tasks"] is None
 
 
 def test_create_ingestion_graph():
-    """Test that create_ingestion_graph returns a compiled graph."""
     graph = create_ingestion_graph()
 
-    # Graph should be compiled and ready to use
     assert graph is not None
-
-    # Note: Graph is empty until IngestionAgent is implemented
-    # This test just verifies the graph compiles without errors
-
-
-def test_ingestion_state_document_types():
-    """Test different document types."""
-    for doc_type in ["pdf", "image", "text"]:
-        state: IngestionState = {
-            "document_id": "doc-123",
-            "document_bytes": b"test data",
-            "document_type": doc_type,
-            "patient_id": "patient-456",
-            "raw_text": None,
-            "parsed_data": None,
-            "normalized_meds": None,
-            "saved_ids": None,
-            "summary": None,
-            "error": None,
-            "retry_count": 0,
-            "messages": [],
-        }
-
-        assert state["document_type"] == doc_type
 
 
 def test_ingestion_state_saved_ids_structure():
-    """Test saved_ids structure."""
     state: IngestionState = {
         "document_id": "doc-123",
-        "document_bytes": b"test data",
-        "document_type": "pdf",
+        "file_url": "patient/doc.pdf",
+        "document_type": "lab_report",
         "patient_id": "patient-456",
-        "raw_text": None,
-        "parsed_data": None,
-        "normalized_meds": None,
+        "raw_content": None,
+        "extracted_data": None,
+        "validated_data": None,
+        "validation_errors": None,
+        "normalized_medications": None,
         "saved_ids": {
             "medications": ["med-1", "med-2"],
             "conditions": ["cond-1"],
+            "appointments": [],
         },
-        "summary": None,
+        "patient_summary": None,
+        "created_tasks": None,
         "error": None,
         "retry_count": 0,
         "messages": [],
     }
 
-    assert "medications" in state["saved_ids"]
-    assert "conditions" in state["saved_ids"]
     assert len(state["saved_ids"]["medications"]) == 2
     assert len(state["saved_ids"]["conditions"]) == 1
 
@@ -140,9 +68,32 @@ def test_ingestion_state_saved_ids_structure():
 async def test_receive_document():
     from app.agents.ingestion.graph import receive_document
 
-    state = {"document_id": "123", "file_url": "http://test", "document_type": "pdf"}
-    result = await receive_document(state)
-    assert result["raw_content"] == "[Document content from http://test]"
+    bucket = MagicMock()
+    bucket.download.return_value = b"plain text document"
+    admin = MagicMock()
+    admin.storage.from_.return_value = bucket
+
+    pil_module = MagicMock()
+    pil_module.Image = MagicMock()
+    with (
+        patch("app.clients.supabase.get_admin_client", return_value=admin),
+        patch.dict(
+            "sys.modules",
+            {
+                "fitz": MagicMock(),
+                "pytesseract": MagicMock(),
+                "PIL": pil_module,
+            },
+        ),
+    ):
+        state = {
+            "document_id": "123",
+            "file_url": "patient/doc.txt",
+            "document_type": "other",
+        }
+        result = await receive_document(state)
+
+    assert result["raw_content"] == "plain text document"
     assert result["error"] is None
 
 
@@ -154,14 +105,15 @@ async def test_extract_content_success():
         mock_client = AsyncMock()
         mock_client.generate.return_value = '```json\n{"medications": [], "conditions": []}\n```'
         mock_router = MagicMock()
-        mock_router.get_client.return_value = mock_client
+        mock_router.get_client_with_fallback.return_value = mock_client
         mock_get_router.return_value = mock_router
 
         state = {"document_id": "123", "raw_content": "Some text"}
         result = await extract_content(state)
 
-        assert result["extracted_data"] == {"medications": [], "conditions": []}
-        assert result["error"] is None
+    assert result["extracted_data"] == {"medications": [], "conditions": []}
+    assert result["raw_content"] is None
+    assert result["error"] is None
 
 
 @pytest.mark.asyncio
@@ -170,55 +122,60 @@ async def test_extract_content_failure():
 
     with patch("app.agents.ingestion.graph.get_router") as mock_get_router:
         mock_router = MagicMock()
-        mock_router.get_client.side_effect = Exception("Router failed")
+        mock_router.get_client_with_fallback.side_effect = Exception("Router failed")
         mock_get_router.return_value = mock_router
 
         state = {"document_id": "123", "raw_content": "Some text"}
         result = await extract_content(state)
 
-        assert result["error"] == "Router failed"
+    assert result["error"] == "Router failed"
 
 
 @pytest.mark.asyncio
 async def test_validate_fhir():
     from app.agents.ingestion.graph import validate_fhir
 
-    state = {"document_id": "123", "extracted_data": {"medications": [{"name": "Aspirin"}]}}
-    result = await validate_fhir(state)
-    assert result["validated_data"] == state["extracted_data"]
+    with patch(
+        "app.tools.fhir_builder.validate_extracted_data",
+        return_value=({"medications": [{"name": "Aspirin"}]}, []),
+    ):
+        state = {
+            "document_id": "00000000-0000-0000-0000-000000000123",
+            "patient_id": "00000000-0000-0000-0000-000000000456",
+            "extracted_data": {"medications": [{"name": "Aspirin"}]},
+        }
+        result = await validate_fhir(state)
+
+    assert result["validated_data"] == {"medications": [{"name": "Aspirin"}]}
     assert result["validation_errors"] is None
-
-
-@pytest.mark.asyncio
-async def test_validate_fhir_empty_meds():
-    from app.agents.ingestion.graph import validate_fhir
-
-    state = {"document_id": "123", "extracted_data": {"conditions": []}}
-    result = await validate_fhir(state)
-    assert "No medications found" in result["validation_errors"]
 
 
 @pytest.mark.asyncio
 async def test_normalize_medications():
     from app.agents.ingestion.graph import normalize_medications
 
-    state = {
-        "document_id": "123",
-        "validated_data": {"medications": [{"name": "Aspirin", "dosage": "81mg"}]},
-    }
-    result = await normalize_medications(state)
+    with patch(
+        "app.tools.medication_normalizer.normalize_all",
+        new=AsyncMock(return_value=[{"name": "Aspirin", "dosage": "81mg"}]),
+    ):
+        state = {
+            "document_id": "123",
+            "validated_data": {"medications": [{"name": "Aspirin", "dosage": "81mg"}]},
+        }
+        result = await normalize_medications(state)
+
     assert len(result["normalized_medications"]) == 1
     assert result["normalized_medications"][0]["name"] == "Aspirin"
-    assert result["normalized_medications"][0]["dosage"] == "81mg"
 
 
 @pytest.mark.asyncio
 async def test_save_to_database():
     from app.agents.ingestion.graph import save_to_database
 
-    state = {"document_id": "123"}
-    result = await save_to_database(state)
+    result = await save_to_database({"document_id": "123"})
+
     assert "medications" in result["saved_ids"]
+    assert "obligations" in result["saved_ids"]
 
 
 @pytest.mark.asyncio
@@ -229,13 +186,13 @@ async def test_generate_summary_success():
         mock_client = AsyncMock()
         mock_client.generate.return_value = "Patient summary"
         mock_router = MagicMock()
-        mock_router.get_client.return_value = mock_client
+        mock_router.get_client_with_fallback.return_value = mock_client
         mock_get_router.return_value = mock_router
 
-        state = {"document_id": "123", "extracted_data": {}}
+        state = {"document_id": "123", "validated_data": {"medications": []}}
         result = await generate_summary(state)
 
-        assert result["patient_summary"] == "Patient summary"
+    assert result["patient_summary"] == "Patient summary"
 
 
 @pytest.mark.asyncio
@@ -245,7 +202,8 @@ async def test_create_feed_tasks():
     state = {
         "document_id": "123",
         "normalized_medications": [{"name": "A"}],
-        "extracted_data": {"follow_up_instructions": ["Rest"]},
+        "validated_data": {"follow_up_instructions": [{"description": "Rest"}]},
+        "extracted_data": {},
     }
     result = await create_feed_tasks(state)
     assert result["created_tasks"] == 2

--- a/backend/tests/unit/test_document_service.py
+++ b/backend/tests/unit/test_document_service.py
@@ -51,6 +51,7 @@ class TestFileValidation:
 
     def test_allowed_mime_types_complete(self):
         """Ensure we haven't accidentally emptied the allowed list."""
-        assert len(ALLOWED_MIME_TYPES) >= 4
+        assert len(ALLOWED_MIME_TYPES) >= 7
         assert "application/pdf" in ALLOWED_MIME_TYPES
         assert "image/jpeg" in ALLOWED_MIME_TYPES
+        assert "text/plain" in ALLOWED_MIME_TYPES

--- a/backend/tests/unit/tools/test_fhir_builder.py
+++ b/backend/tests/unit/tools/test_fhir_builder.py
@@ -1,0 +1,118 @@
+"""Unit tests for FHIR validation helpers."""
+
+from uuid import UUID
+
+from app.tools.fhir_builder import (
+    build_allergy_intolerance,
+    build_appointment,
+    build_condition,
+    build_medication_request,
+    validate_extracted_data,
+)
+
+PATIENT_ID = UUID("00000000-0000-0000-0000-000000000123")
+DOCUMENT_ID = UUID("00000000-0000-0000-0000-000000000999")
+
+
+def test_build_medication_request_valid():
+    validated, error = build_medication_request(
+        {
+            "name": "Aspirin",
+            "dosage": "81mg",
+            "frequency": "once daily",
+            "instructions": "Take with food",
+            "route": "oral",
+        },
+        PATIENT_ID,
+        DOCUMENT_ID,
+    )
+
+    assert error is None
+    assert validated is not None
+    assert validated["name"] == "Aspirin"
+    assert validated["route"] == "oral"
+
+
+def test_build_medication_request_missing_name():
+    validated, error = build_medication_request({}, PATIENT_ID, DOCUMENT_ID)
+
+    assert validated is None
+    assert error is not None
+
+
+def test_build_condition_valid():
+    validated, error = build_condition(
+        {"name": "Hypertension", "clinical_status": "active"},
+        PATIENT_ID,
+    )
+
+    assert error is None
+    assert validated is not None
+    assert validated["name"] == "Hypertension"
+
+
+def test_build_condition_missing_code():
+    validated, error = build_condition({}, PATIENT_ID)
+
+    assert validated is None
+    assert error is not None
+
+
+def test_build_allergy_intolerance_valid():
+    validated, error = build_allergy_intolerance(
+        {
+            "substance": "Penicillin",
+            "reaction": "Rash",
+            "severity": "severe",
+        },
+        PATIENT_ID,
+    )
+
+    assert error is None
+    assert validated is not None
+    assert validated["allergen"] == "Penicillin"
+    assert validated["severity"] == "severe"
+
+
+def test_build_appointment_valid():
+    validated, error = build_appointment(
+        {
+            "description": "Follow up with cardiology",
+            "timing": "2 weeks",
+            "provider": "Dr. Patel",
+        },
+        PATIENT_ID,
+    )
+
+    assert error is None
+    assert validated is not None
+    assert validated["timing"] == "2 weeks"
+
+
+def test_validate_extracted_data_full():
+    resources, errors = validate_extracted_data(
+        {
+            "medications": [{"name": "Metformin", "dosage": "500mg", "frequency": "twice daily"}],
+            "conditions": [{"name": "Type 2 Diabetes"}],
+            "allergies": [{"substance": "Penicillin", "reaction": "Rash"}],
+            "follow_up_instructions": [{"description": "Return to clinic", "timing": "2 weeks"}],
+        },
+        PATIENT_ID,
+        DOCUMENT_ID,
+    )
+
+    assert errors == []
+    assert len(resources["medications"]) == 1
+    assert len(resources["conditions"]) == 1
+    assert len(resources["allergies"]) == 1
+    assert len(resources["appointments"]) == 1
+
+
+def test_validate_extracted_data_empty():
+    resources, errors = validate_extracted_data({}, PATIENT_ID, DOCUMENT_ID)
+
+    assert errors == []
+    assert resources["medications"] == []
+    assert resources["conditions"] == []
+    assert resources["allergies"] == []
+    assert resources["appointments"] == []

--- a/backend/tests/unit/tools/test_medication_normalizer.py
+++ b/backend/tests/unit/tools/test_medication_normalizer.py
@@ -1,0 +1,80 @@
+"""Unit tests for medication normalization helpers."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.tools.medication_normalizer import (
+    normalize_frequency,
+    normalize_medication,
+    parse_dosage,
+)
+
+
+def test_parse_dosage_simple():
+    parsed = parse_dosage("500mg")
+
+    assert parsed["value"] == 500.0
+    assert parsed["unit"] == "mg"
+
+
+def test_parse_dosage_decimal():
+    parsed = parse_dosage("2.5mg")
+
+    assert parsed["value"] == 2.5
+    assert parsed["unit"] == "mg"
+
+
+def test_parse_dosage_compound():
+    parsed = parse_dosage("10mg/5ml")
+
+    assert parsed["value"] == 10.0
+    assert parsed["unit"] == "mg"
+
+
+def test_parse_dosage_invalid():
+    parsed = parse_dosage("take with food")
+
+    assert parsed["value"] is None
+    assert parsed["unit"] is None
+
+
+def test_normalize_frequency():
+    assert normalize_frequency("twice daily") == "twice_daily"
+    assert normalize_frequency("BID") == "twice_daily"
+    assert normalize_frequency("unknown") == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_normalize_medication_success():
+    with patch(
+        "app.tools.medication_normalizer.normalize_drug_name",
+        new=AsyncMock(return_value={"normalized_name": "metformin", "rxcui": "860975"}),
+    ):
+        normalized = await normalize_medication(
+            {
+                "name": "Metformin",
+                "dosage": "500mg",
+                "frequency": "twice daily",
+                "instructions": "Take with meals",
+            }
+        )
+
+    assert normalized["generic_name"] == "metformin"
+    assert normalized["rxcui"] == "860975"
+    assert normalized["parsed_dosage"]["value"] == 500.0
+    assert normalized["normalized_frequency"] == "twice_daily"
+
+
+@pytest.mark.asyncio
+async def test_normalize_medication_rxnorm_failure():
+    with patch(
+        "app.tools.medication_normalizer.normalize_drug_name",
+        new=AsyncMock(side_effect=RuntimeError("rxnorm down")),
+    ):
+        normalized = await normalize_medication(
+            {"name": "Aspirin", "dosage": "81mg", "frequency": "daily"}
+        )
+
+    assert normalized["generic_name"] == "Aspirin"
+    assert normalized["rxcui"] is None

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "lint-staged": {
     "backend/src/**/*.py": [
-      "ruff check --fix --unsafe-fixes",
-      "ruff format",
-      "mypy --ignore-missing-imports"
+      "backend/.venv/bin/ruff check --fix --unsafe-fixes",
+      "backend/.venv/bin/ruff format",
+      "backend/.venv/bin/python -m mypy --config-file backend/pyproject.toml --ignore-missing-imports"
     ],
     "apps/**/*.{ts,tsx}": [
       "bash -c 'cd apps/patient-portal && ./node_modules/.bin/eslint --fix \"$0\"'"

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -177,6 +177,9 @@ export interface Document {
     fileSizeBytes: number;
     parsed: boolean;
     aiSummary?: string;
+    parseStatus: "none" | "pending" | "processing" | "completed" | "failed";
+    parseError?: string;
+    parseAttempts: number;
     sourceClinic?: string;
     visibility: DocumentVisibility;
     createdAt: string;


### PR DESCRIPTION
## Context

Implements **Phase 4 (Ingestion Agent)** of the MediAgent project. This PR delivers the complete document ingestion pipeline — from Supabase Storage upload through AI-powered clinical extraction to patient-facing explanations — transitioning Phase 4 from scaffolded placeholders to a production-ready backend service.

**Ref:** `.agent/TASKS.md` — Phase 4 (§4.1–4.4)

---

## What Changed

### Backend — New Files (5)

| File | Purpose |
|------|---------|
| `backend/src/app/tools/medication_normalizer.py` | Regex dosage parser + frequency normalizer + RxNorm wrapper with `Semaphore(3)` rate limiting |
| `backend/src/app/services/ingestion_service.py` | Orchestrates LangGraph pipeline: retry tracking (max 3), parse_status lifecycle, saves meds/conditions/allergies/obligations to DB |
| `backend/src/app/services/explanation_service.py` | Generates patient-friendly summaries via Flash Lite, translates to Spanish, graceful fallback |
| `backend/src/app/db/migrations/005_document_parse_tracking.sql` | Adds `file_path`, `parse_status`, `parse_error`, `parse_attempts` columns + partial index |
| `apps/patient-portal/src/services/storage.ts` | Supabase Storage upload client with filename sanitization |

### Backend — Modified Files (7)

| File | Changes |
|------|---------|
| `agents/ingestion/graph.py` | All 7 TODO nodes replaced with real implementations; `_skip_if_error()` guard on all downstream nodes; `get_client_with_fallback()` for MedGemma-down resilience; `raw_content = None` memory cleanup after extraction |
| `agents/ingestion/prompts.py` | Centralized extraction, summary, and translation prompts with `str.format()` placeholders |
| `tools/fhir_builder.py` | FHIR R4 validation-only pattern (MedicationRequest, Condition, AllergyIntolerance, Appointment) returning cleaned dicts for our Supabase schema |
| `routers/documents.py` | `BackgroundTasks` ingestion trigger on POST; `/explain` endpoint returns cached or on-demand AI summary with language selection |
| `services/document_service.py` | `update_summary()`, `file_path` storage path tracking, `parse_status` in create, synced `ALLOWED_MIME_TYPES` (+heic, +tiff, +text/plain, +text/csv) |
| `models/document.py` | `parse_status`, `parse_error`, `parse_attempts` fields on `DocumentRead` |
| `packages/shared/src/types/index.ts` | `Document` interface updated with parse lifecycle fields |

### Frontend — Modified Files (3)

| File | Changes |
|------|---------|
| `records/page.tsx` | Real Supabase Storage upload → API registration → polling for parse status (10×3s); `ErrorState` integration; auto-detect `document_type` from MIME; processing/failed/AI-ready badges on cards |
| `document-card.tsx` | `statusLabel` + `statusVariant` props for processing/failed/AI-ready badges |
| `next.config.ts` | `@next/env` loader exposing Supabase vars from workspace root `.env` |

### Architecture Decisions

- **Stateless Graph:** Graph nodes never touch the DB; `IngestionService` orchestrates all writes after the graph completes
- **Memory Efficiency:** `raw_content` cleared from state immediately after extraction; RxNorm calls rate-limited via `asyncio.Semaphore(3)`
- **LLM Resilience:** `get_client_with_fallback()` everywhere — MedGemma down → auto-falls back to Flash Lite, zero code changes needed when redeployed
- **Retry Logic:** `parse_status` lifecycle (pending → processing → completed/failed), max 3 attempts, frontend polling with timeout
- **Event Loop Safety:** Blocking Supabase calls wrapped in `asyncio.to_thread()` to avoid stalling the async event loop

### Tests (4 new/updated files, 21+ tests)

| File | Coverage |
|------|----------|
| `test_fhir_builder.py` | 8 tests: valid/invalid med, condition, allergy, appointment, full/empty extraction |
| `test_medication_normalizer.py` | 7 tests: dosage parsing, frequency normalization, RxNorm success/failure |
| `test_ingestion_pipeline.py` | 6 integration tests: full pipeline, LLM failure, RxNorm failure, max retries, cached explain, Spanish translation |
| `test_document_api.py` | Updated with parse_status assertions, explain endpoint paths |

---

## Manual Prerequisites

Before the end-to-end pipeline works against a real Supabase project:
1. Apply `005_document_parse_tracking.sql` migration ✅ (done)
2. Update `documents` bucket MIME types to include `image/heic`, `image/tiff`, `text/plain`, `text/csv` ✅ (done)

---

## Verification

- [x] `ruff check backend/src backend/tests` — 0 errors
- [x] `ruff format --check backend/src backend/tests` — 0 changes
- [x] `pytest` — all 21+ Phase 4 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — builds successfully
- [x] `vitest run` — all frontend tests pass

---

- [x] I have read the CODING_STANDARDS
- [x] My code matches existing architecture
- [x] I have verified tests pass
- [x] I have run local linting
- [x] I have added/updated tests
- [x] There are no new warnings or secrets