### PR TITLE
feat(auth): complete supabase auth flows for both portals

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -180,7 +180,7 @@
 - [x] Make all components responsive (mobile-first for patient, desktop-first for clinician)
 
 ### 3.2 Patient Portal — Auth
-- [x] Sign-up page (magic link flow)
+- [x] Sign-up page (email/password flow via Supabase Auth)
 - [x] Onboarding flow (name, DOB, language, allergies)
 - [x] Join clinic (enter code or use invite link)
 - [x] Auth state management in Redux

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -42,11 +42,15 @@ jobs:
             --repository-format=docker \
             --location=${REGION} \
             --description="Docker repository for Cloud Run deployments" || true
-          
-          # Set cleanup policy to keep only 1 most recent image
+
+      - name: Apply Artifact Registry cleanup policy
+        run: |
           gcloud artifacts repositories set-cleanup-policies cloud-run-source-deploy \
             --location=${REGION} \
-            --policy=backend/cleanup-policy.json || true
+            --policy=backend/cleanup-policy.json
+
+          gcloud artifacts repositories list-cleanup-policies cloud-run-source-deploy \
+            --location=${REGION}
 
       - name: Build Docker Image
         run: |
@@ -56,16 +60,21 @@ jobs:
 
       - name: Clean up old images
         run: |
-          # List all images and delete old ones (keep only latest)
-          # This runs AFTER the new image is pushed, so old images no longer have the "latest" tag
+          IMAGE_REPO="${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME}"
+
           gcloud artifacts docker images list \
-            ${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME} \
+            "${IMAGE_REPO}" \
+            --include-tags \
             --format="get(version)" \
-            --filter="NOT tags:latest" | while read digest; do
+            --filter="NOT tags:latest" | sort -u | while read -r digest; do
+              if [ -z "${digest}" ]; then
+                continue
+              fi
+
               echo "Deleting old image: $digest"
               gcloud artifacts docker images delete \
-                "${REGION}-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy/${SERVICE_NAME}@${digest}" \
-                --quiet || true
+                "${IMAGE_REPO}@${digest}" \
+                --quiet
           done
 
       - name: Deploy to Cloud Run

--- a/apps/clinician-portal/package-lock.json
+++ b/apps/clinician-portal/package-lock.json
@@ -12,6 +12,7 @@
         "next": "16.1.7",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-icons": "^5.6.0",
         "react-redux": "^9.2.0",
         "recharts": "^3.8.0"
       },
@@ -7344,6 +7345,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/apps/clinician-portal/package.json
+++ b/apps/clinician-portal/package.json
@@ -15,6 +15,7 @@
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-icons": "^5.6.0",
     "react-redux": "^9.2.0",
     "recharts": "^3.8.0"
   },

--- a/apps/clinician-portal/src/__tests__/auth-session.test.ts
+++ b/apps/clinician-portal/src/__tests__/auth-session.test.ts
@@ -1,0 +1,42 @@
+import { CLINICIAN_AUTH_STORAGE_KEY, restoreStoredSession, writeStoredSession } from "@/services/auth-session";
+import type { ClinicianAuthSession } from "@/store/slices/auth-slice";
+import { describe, expect, it, vi } from "vitest";
+
+const session: ClinicianAuthSession = {
+    accessToken: "access-token",
+    expiresAt: Math.floor(Date.now() / 1000) + 300,
+    refreshToken: "refresh-token",
+    user: {
+        email: "doctor@example.com",
+        id: "clinician-1",
+        role: "clinician",
+    },
+};
+
+describe("Clinician auth session", () => {
+    it("refreshes expiring clinician sessions", async () => {
+        writeStoredSession({ ...session, expiresAt: Math.floor(Date.now() / 1000) + 20 });
+
+        const restored = await restoreStoredSession({
+            refreshSession: vi.fn().mockResolvedValue({
+                ...session,
+                accessToken: "new-access-token",
+                expiresAt: Math.floor(Date.now() / 1000) + 900,
+            }),
+        });
+
+        expect(restored?.accessToken).toBe("new-access-token");
+        expect(window.localStorage.getItem(CLINICIAN_AUTH_STORAGE_KEY)).toContain("new-access-token");
+    });
+
+    it("clears storage when refresh fails", async () => {
+        writeStoredSession({ ...session, expiresAt: Math.floor(Date.now() / 1000) + 20 });
+
+        const restored = await restoreStoredSession({
+            refreshSession: vi.fn().mockRejectedValue(new Error("refresh failed")),
+        });
+
+        expect(restored).toBeNull();
+        expect(window.localStorage.getItem(CLINICIAN_AUTH_STORAGE_KEY)).toBeNull();
+    });
+});

--- a/apps/clinician-portal/src/__tests__/login-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/login-page.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ClinicianLoginPage from "@/app/(auth)/login/page";
+
+const { dispatch, post, replace, writeStoredSession } = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    post: vi.fn(),
+    replace: vi.fn(),
+    writeStoredSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace }),
+}));
+
+vi.mock("react-redux", () => ({
+    useDispatch: () => dispatch,
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { post },
+}));
+
+vi.mock("@/services/auth-session", () => ({
+    writeStoredSession,
+}));
+
+describe("Clinician login page", () => {
+    beforeEach(() => {
+        replace.mockReset();
+        dispatch.mockReset();
+        post.mockReset();
+        writeStoredSession.mockReset();
+    });
+
+    it("rejects patient credentials on the clinician portal", async () => {
+        post.mockResolvedValue({
+            tokens: {
+                access_token: "access-token",
+                expires_at: 1234567890,
+                refresh_token: "refresh-token",
+            },
+            user: {
+                email: "patient@example.com",
+                id: "patient-1",
+                role: "patient",
+            },
+        });
+
+        render(<ClinicianLoginPage />);
+        fireEvent.change(screen.getByLabelText(/email/i), {
+            target: { value: "patient@example.com" },
+        });
+        fireEvent.change(screen.getByLabelText(/^password$/i), {
+            target: { value: "SecurePass123!" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+        expect(await screen.findByText(/patient account/i)).toBeInTheDocument();
+        expect(replace).not.toHaveBeenCalled();
+    });
+});

--- a/apps/clinician-portal/src/__tests__/sidebar.test.tsx
+++ b/apps/clinician-portal/src/__tests__/sidebar.test.tsx
@@ -13,7 +13,9 @@ describe("Sidebar", () => {
     beforeEach(() => {
         store.dispatch(
             hydrateSession({
-                token: "test-token",
+                accessToken: "test-token",
+                expiresAt: 1234567890,
+                refreshToken: "refresh-token",
                 user: {
                     email: "dr.smith@cityhealth.org",
                     id: "clinician-1",

--- a/apps/clinician-portal/src/__tests__/signup-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/signup-page.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ClinicianSignupPage from "@/app/(auth)/signup/page";
+
+const { dispatch, post, replace, writeStoredSession } = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    post: vi.fn(),
+    replace: vi.fn(),
+    writeStoredSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace }),
+}));
+
+vi.mock("react-redux", () => ({
+    useDispatch: () => dispatch,
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { post },
+}));
+
+vi.mock("@/services/auth-session", () => ({
+    writeStoredSession,
+}));
+
+describe("Clinician signup page", () => {
+    beforeEach(() => {
+        replace.mockReset();
+        dispatch.mockReset();
+        post.mockReset();
+        writeStoredSession.mockReset();
+    });
+
+    it("stores the full session and routes to the dashboard", async () => {
+        post.mockResolvedValue({
+            tokens: {
+                access_token: "access-token",
+                expires_at: 1234567890,
+                refresh_token: "refresh-token",
+            },
+            user: {
+                email: "doctor@example.com",
+                id: "clinician-1",
+                role: "clinician",
+            },
+        });
+
+        render(<ClinicianSignupPage />);
+        fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: "Amina" } });
+        fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: "Khan" } });
+        fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: "doctor@example.com" } });
+        fireEvent.change(screen.getByLabelText(/^specialty$/i), { target: { value: "Primary Care" } });
+        fireEvent.change(screen.getByLabelText(/clinic name/i), { target: { value: "City Health" } });
+        fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: "SecurePass123!" } });
+        fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: "SecurePass123!" } });
+        fireEvent.click(screen.getByRole("button", { name: /create clinician account/i }));
+
+        await waitFor(() => {
+            expect(writeStoredSession).toHaveBeenCalledWith({
+                accessToken: "access-token",
+                expiresAt: 1234567890,
+                refreshToken: "refresh-token",
+                user: {
+                    email: "doctor@example.com",
+                    id: "clinician-1",
+                    role: "clinician",
+                },
+            });
+        });
+        expect(replace).toHaveBeenCalledWith("/dashboard");
+    });
+});

--- a/apps/clinician-portal/src/app/(auth)/login/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/login/page.tsx
@@ -6,15 +6,15 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
 import { api } from "@/services/api";
-import { hydrateSession, type ClinicianAuthUser } from "@/store/slices/auth-slice";
+import { writeStoredSession } from "@/services/auth-session";
+import { hydrateSession, type ClinicianAuthSession } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
-
-const storageKey = "mediagent-clinician-auth";
-const isDevelopment = process.env.NODE_ENV === "development";
 
 interface LoginResponse {
     tokens: {
         access_token: string;
+        expires_at: number;
+        refresh_token: string;
     };
     user: {
         email: string;
@@ -26,8 +26,8 @@ interface LoginResponse {
 export default function ClinicianLoginPage() {
     const router = useRouter();
     const dispatch = useDispatch<AppDispatch>();
-    const [email, setEmail] = useState(isDevelopment ? "dr.smith@cityhealth.org" : "");
-    const [password, setPassword] = useState(isDevelopment ? "password123" : "");
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
     const [error, setError] = useState("");
     const [submitting, setSubmitting] = useState(false);
 
@@ -38,17 +38,22 @@ export default function ClinicianLoginPage() {
 
         try {
             const response = await api.post<LoginResponse>("/api/v1/auth/login", { email, password });
-            const user: ClinicianAuthUser = {
-                email: response.user.email,
-                id: response.user.id,
-                role: "clinician",
-            };
-            const session = {
-                token: response.tokens.access_token,
-                user,
+            if (response.user.role !== "clinician") {
+                throw new Error("This login belongs to a patient account.");
+            }
+
+            const session: ClinicianAuthSession = {
+                accessToken: response.tokens.access_token,
+                expiresAt: response.tokens.expires_at,
+                refreshToken: response.tokens.refresh_token,
+                user: {
+                    email: response.user.email,
+                    id: response.user.id,
+                    role: "clinician",
+                },
             };
 
-            window.localStorage.setItem(storageKey, JSON.stringify(session));
+            writeStoredSession(session);
             dispatch(hydrateSession(session));
             router.replace("/dashboard");
         } catch (submissionError) {
@@ -87,8 +92,8 @@ export default function ClinicianLoginPage() {
                         </Button>
                     </form>
                     <div className="flex items-center justify-between text-sm">
-                        <Link className="text-blue-600" href="/setup">
-                            First-time clinic setup
+                        <Link className="text-blue-600" href="/signup">
+                            Create clinician account
                         </Link>
                         <span className="text-gray-400">Forgot password?</span>
                     </div>

--- a/apps/clinician-portal/src/app/(auth)/setup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/setup/page.tsx
@@ -9,18 +9,21 @@ import type { RootState } from "@/store/store";
 
 export default function ClinicSetupPage() {
     const router = useRouter();
-    const token = useSelector((state: RootState) => state.auth.token);
+    const accessToken = useSelector((state: RootState) => state.auth.accessToken);
     const [clinicName, setClinicName] = useState("City Health Primary Care");
     const [npiNumber, setNpiNumber] = useState("1234567890");
     const [specialty, setSpecialty] = useState("Primary Care");
     const [error, setError] = useState("");
+    const [submitting, setSubmitting] = useState(false);
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
         setError("");
+        setSubmitting(true);
 
-        if (!token) {
+        if (!accessToken) {
             setError("Please sign in first so we can save your clinician profile.");
+            setSubmitting(false);
             return;
         }
 
@@ -32,11 +35,12 @@ export default function ClinicSetupPage() {
                     npi_number: npiNumber,
                     specialty,
                 },
-                { token },
+                { token: accessToken },
             );
             router.replace("/dashboard");
         } catch (submissionError) {
             setError((submissionError as Error).message);
+            setSubmitting(false);
         }
     }
 
@@ -52,7 +56,9 @@ export default function ClinicSetupPage() {
                     <Input label="NPI number" onChange={(event) => setNpiNumber(event.target.value)} value={npiNumber} />
                     <Input label="Specialty" onChange={(event) => setSpecialty(event.target.value)} value={specialty} />
                     {error ? <p className="text-sm text-red-600">{error}</p> : null}
-                    <Button fullWidth type="submit">Save and continue</Button>
+                    <Button disabled={submitting} fullWidth type="submit">
+                        {submitting ? "Saving..." : "Save and continue"}
+                    </Button>
                 </form>
             </Card>
         </div>

--- a/apps/clinician-portal/src/app/(auth)/setup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/setup/page.tsx
@@ -10,9 +10,9 @@ import type { RootState } from "@/store/store";
 export default function ClinicSetupPage() {
     const router = useRouter();
     const accessToken = useSelector((state: RootState) => state.auth.accessToken);
-    const [clinicName, setClinicName] = useState("City Health Primary Care");
-    const [npiNumber, setNpiNumber] = useState("1234567890");
-    const [specialty, setSpecialty] = useState("Primary Care");
+    const [clinicName, setClinicName] = useState("");
+    const [npiNumber, setNpiNumber] = useState("");
+    const [specialty, setSpecialty] = useState("");
     const [error, setError] = useState("");
     const [submitting, setSubmitting] = useState(false);
 

--- a/apps/clinician-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useDispatch } from "react-redux";
+import { Button, Card, Input } from "@/components/ui";
+import { api } from "@/services/api";
+import { writeStoredSession } from "@/services/auth-session";
+import { hydrateSession, type ClinicianAuthSession } from "@/store/slices/auth-slice";
+import type { AppDispatch } from "@/store/store";
+
+interface SignupResponse {
+    tokens: {
+        access_token: string;
+        expires_at: number;
+        refresh_token: string;
+    };
+    user: {
+        email: string;
+        id: string;
+        role: "patient" | "clinician";
+    };
+}
+
+export default function ClinicianSignupPage() {
+    const router = useRouter();
+    const dispatch = useDispatch<AppDispatch>();
+    const [error, setError] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [formData, setFormData] = useState({
+        clinicName: "",
+        confirmPassword: "",
+        email: "",
+        firstName: "",
+        lastName: "",
+        npiNumber: "",
+        password: "",
+        specialty: "",
+    });
+
+    function updateField(field: keyof typeof formData, value: string) {
+        setFormData((current) => ({ ...current, [field]: value }));
+    }
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError("");
+
+        if (formData.password !== formData.confirmPassword) {
+            setError("Passwords do not match.");
+            return;
+        }
+
+        setSubmitting(true);
+
+        try {
+            const response = await api.post<SignupResponse>("/api/v1/auth/signup/clinician", {
+                clinic_name: formData.clinicName,
+                email: formData.email,
+                first_name: formData.firstName,
+                last_name: formData.lastName,
+                npi_number: formData.npiNumber || undefined,
+                password: formData.password,
+                specialty: formData.specialty,
+            });
+
+            if (response.user.role !== "clinician") {
+                throw new Error("This signup produced a non-clinician account.");
+            }
+
+            const session: ClinicianAuthSession = {
+                accessToken: response.tokens.access_token,
+                expiresAt: response.tokens.expires_at,
+                refreshToken: response.tokens.refresh_token,
+                user: {
+                    email: response.user.email,
+                    id: response.user.id,
+                    role: "clinician",
+                },
+            };
+            writeStoredSession(session);
+            dispatch(hydrateSession(session));
+            router.replace("/dashboard");
+        } catch (submissionError) {
+            setError((submissionError as Error).message);
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <div className="flex min-h-screen bg-gray-50">
+            <div className="hidden w-1/2 bg-gray-900 px-12 py-16 text-white lg:flex lg:flex-col lg:justify-between">
+                <div className="space-y-4">
+                    <p className="text-sm font-medium uppercase tracking-[0.3em] text-blue-300">MediAgent Pro</p>
+                    <h1 className="max-w-md text-5xl font-bold leading-tight">Stand up your clinic workspace with one secure account.</h1>
+                    <p className="max-w-lg text-lg text-gray-300">
+                        Create your clinician account, connect your clinic identity, and begin managing patient follow-up from a shared dashboard.
+                    </p>
+                </div>
+                <p className="text-sm text-gray-400">Supabase-backed auth with role-aware access through the backend API.</p>
+            </div>
+
+            <div className="flex flex-1 items-center justify-center px-6 py-12">
+                <Card className="w-full max-w-xl space-y-6" padding="lg">
+                    <div className="space-y-2">
+                        <p className="text-sm font-medium text-blue-600">Clinician signup</p>
+                        <h2 className="text-3xl font-bold text-gray-900">Create your account</h2>
+                        <p className="text-sm text-gray-500">Set up a clinician login for dashboard access and invite-code workflows.</p>
+                    </div>
+                    <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
+                        <Input label="First name" onChange={(event) => updateField("firstName", event.target.value)} value={formData.firstName} />
+                        <Input label="Last name" onChange={(event) => updateField("lastName", event.target.value)} value={formData.lastName} />
+                        <Input label="Email" onChange={(event) => updateField("email", event.target.value)} type="email" value={formData.email} />
+                        <Input label="Specialty" onChange={(event) => updateField("specialty", event.target.value)} value={formData.specialty} />
+                        <Input label="Clinic name" onChange={(event) => updateField("clinicName", event.target.value)} value={formData.clinicName} />
+                        <Input label="NPI number (optional)" onChange={(event) => updateField("npiNumber", event.target.value)} value={formData.npiNumber} />
+                        <Input label="Password" onChange={(event) => updateField("password", event.target.value)} type="password" value={formData.password} />
+                        <Input
+                            label="Confirm password"
+                            onChange={(event) => updateField("confirmPassword", event.target.value)}
+                            type="password"
+                            value={formData.confirmPassword}
+                        />
+                        {error ? <p className="text-sm text-red-600 md:col-span-2">{error}</p> : null}
+                        <div className="md:col-span-2">
+                            <Button disabled={submitting} fullWidth type="submit">
+                                {submitting ? "Creating account..." : "Create clinician account"}
+                            </Button>
+                        </div>
+                    </form>
+                    <div className="text-sm text-gray-500">
+                        Already have a clinician account?{" "}
+                        <Link className="font-medium text-blue-600" href="/login">
+                            Sign in
+                        </Link>
+                    </div>
+                </Card>
+            </div>
+        </div>
+    );
+}

--- a/apps/clinician-portal/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { HiOutlineClipboardDocumentList, HiOutlineExclamationTriangle, HiOutlineMagnifyingGlass, HiOutlineUsers } from "react-icons/hi2";
 import { useDispatch, useSelector } from "react-redux";
 import { Card } from "@/components/ui";
 import { setPatients, setStats, type DashboardStat } from "@/store/slices/dashboard-slice";
@@ -95,7 +96,13 @@ export default function DashboardPage() {
                     return (
                         <Card className="flex items-center gap-4 px-6 py-5" key={stat.label} padding="sm">
                             <div className={`flex h-14 w-14 items-center justify-center rounded-full text-2xl ${emphasis}`}>
-                                {stat.label === "Monitored Patients" ? "👥" : stat.label === "Critical Risk (< 70% or ADR)" ? "⚠️" : "📝"}
+                                {stat.label === "Monitored Patients" ? (
+                                    <HiOutlineUsers className="h-7 w-7" />
+                                ) : stat.label === "Critical Risk (< 70% or ADR)" ? (
+                                    <HiOutlineExclamationTriangle className="h-7 w-7" />
+                                ) : (
+                                    <HiOutlineClipboardDocumentList className="h-7 w-7" />
+                                )}
                             </div>
                             <div>
                                 <p className="text-sm font-medium text-slate-500">{stat.label}</p>
@@ -110,7 +117,7 @@ export default function DashboardPage() {
                 <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-6 py-5">
                     <h2 className="text-xl font-bold text-slate-900">Active Patient Alerts</h2>
                     <label className="relative block">
-                        <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-slate-400">🔎</span>
+                        <HiOutlineMagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
                         <input
                             className="w-64 rounded-lg border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm text-slate-700 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
                             onChange={(event) => setQuery(event.target.value)}

--- a/apps/clinician-portal/src/app/(dashboard)/medwatch/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/medwatch/page.tsx
@@ -1,5 +1,12 @@
 import { EmptyState } from "@/components/ui";
+import { HiOutlineExclamationTriangle } from "react-icons/hi2";
 
 export default function MedWatchPage() {
-    return <EmptyState description="Pending FDA drafts will appear here for review." icon="⚠️" title="No MedWatch drafts" />;
+    return (
+        <EmptyState
+            description="Pending FDA drafts will appear here for review."
+            icon={<HiOutlineExclamationTriangle />}
+            title="No MedWatch drafts"
+        />
+    );
 }

--- a/apps/clinician-portal/src/app/(dashboard)/messages/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/messages/page.tsx
@@ -1,5 +1,12 @@
 import { EmptyState } from "@/components/ui";
+import { HiOutlineChatBubbleLeftRight } from "react-icons/hi2";
 
 export default function MessagesPage() {
-    return <EmptyState description="Clinician and patient communication threads will appear here." icon="💬" title="No messages yet" />;
+    return (
+        <EmptyState
+            description="Clinician and patient communication threads will appear here."
+            icon={<HiOutlineChatBubbleLeftRight />}
+            title="No messages yet"
+        />
+    );
 }

--- a/apps/clinician-portal/src/app/(dashboard)/settings/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/settings/page.tsx
@@ -1,3 +1,4 @@
+import { HiOutlineClipboardDocument, HiOutlineMagnifyingGlass, HiOutlinePrinter } from "react-icons/hi2";
 import { Badge, Button, Card, Input } from "@/components/ui";
 
 const settingsTabs = ["General Profile", "Team & Roles", "Patient Invites", "Integrations (MCP)"] as const;
@@ -48,7 +49,7 @@ export default function SettingsPage() {
                         <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-6 py-5">
                             <h3 className="text-xl font-bold text-slate-900">Active Staff (4)</h3>
                             <label className="relative block">
-                                <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-slate-400">🔎</span>
+                                <HiOutlineMagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
                                 <input
                                     className="w-64 rounded-lg border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm text-slate-700 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
                                     placeholder="Search team..."
@@ -89,14 +90,14 @@ export default function SettingsPage() {
                         <div className="mt-6 flex items-center justify-between rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-5">
                             <span className="text-3xl font-bold tracking-[0.14em]">CITY-8832</span>
                             <button className="rounded-md bg-slate-800 px-3 py-2 text-slate-300" type="button">
-                                📋
+                                <HiOutlineClipboardDocument className="h-5 w-5" />
                             </button>
                         </div>
                         <button
                             className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-white/20 bg-white/10 px-4 py-3 text-sm font-medium text-white transition hover:bg-white/15"
                             type="button"
                         >
-                            🖨️
+                            <HiOutlinePrinter className="h-5 w-5" />
                             <span>Print Handouts for Front Desk</span>
                         </button>
                     </div>

--- a/apps/clinician-portal/src/components/features/risk-badge.tsx
+++ b/apps/clinician-portal/src/components/features/risk-badge.tsx
@@ -1,3 +1,4 @@
+import { FaCircle } from "react-icons/fa6";
 import { Badge } from "@/components/ui";
 
 interface RiskBadgeProps {
@@ -5,16 +6,16 @@ interface RiskBadgeProps {
 }
 
 const riskConfig = {
-    high: { icon: "🔴", label: "High", variant: "danger" as const },
-    low: { icon: "🟢", label: "Low", variant: "success" as const },
-    medium: { icon: "🟡", label: "Medium", variant: "warning" as const },
+    high: { iconClassName: "text-red-500", label: "High", variant: "danger" as const },
+    low: { iconClassName: "text-green-500", label: "Low", variant: "success" as const },
+    medium: { iconClassName: "text-yellow-500", label: "Medium", variant: "warning" as const },
 };
 
 export function RiskBadge({ level }: RiskBadgeProps) {
     const config = riskConfig[level];
     return (
         <Badge variant={config.variant}>
-            <span className="mr-1">{config.icon}</span>
+            <FaCircle className={`mr-1 text-[10px] ${config.iconClassName}`} />
             {config.label}
         </Badge>
     );

--- a/apps/clinician-portal/src/components/layouts/sidebar.tsx
+++ b/apps/clinician-portal/src/components/layouts/sidebar.tsx
@@ -2,12 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { HiOutlineChartBarSquare, HiOutlineChatBubbleLeftRight, HiOutlineCog6Tooth, HiOutlineExclamationTriangle, HiOutlineUsers } from "react-icons/hi2";
 
 const primaryNavigation = [
-    { href: "/dashboard", icon: "📊", label: "Risk Radar" },
-    { href: "/patients", icon: "👥", label: "Patient Roster" },
-    { href: "/medwatch", icon: "⚠️", label: "MedWatch Queue" },
-    { href: "/messages", icon: "💬", label: "Messages" },
+    { href: "/dashboard", icon: HiOutlineChartBarSquare, label: "Risk Radar" },
+    { href: "/patients", icon: HiOutlineUsers, label: "Patient Roster" },
+    { href: "/medwatch", icon: HiOutlineExclamationTriangle, label: "MedWatch Queue" },
+    { href: "/messages", icon: HiOutlineChatBubbleLeftRight, label: "Messages" },
 ];
 
 export function Sidebar() {
@@ -24,6 +25,7 @@ export function Sidebar() {
             <nav className="flex-1 space-y-2 px-4 py-6">
                 {primaryNavigation.map((item) => {
                     const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                    const Icon = item.icon;
 
                     return (
                         <Link
@@ -31,7 +33,7 @@ export function Sidebar() {
                             href={item.href}
                             key={item.href}
                         >
-                            <span>{item.icon}</span>
+                            <Icon className="h-5 w-5" />
                             <span>{item.label}</span>
                         </Link>
                     );
@@ -43,7 +45,7 @@ export function Sidebar() {
                         className={`mt-3 flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition ${pathname === "/settings" ? "bg-blue-600 text-white shadow-sm" : "text-slate-300 hover:bg-slate-800 hover:text-white"}`}
                         href="/settings"
                     >
-                        <span>⚙️</span>
+                        <HiOutlineCog6Tooth className="h-5 w-5" />
                         <span>Clinic Settings</span>
                     </Link>
                 </div>

--- a/apps/clinician-portal/src/components/layouts/top-header.tsx
+++ b/apps/clinician-portal/src/components/layouts/top-header.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
+import { HiOutlineBell, HiOutlineUserPlus } from "react-icons/hi2";
 import { Button } from "@/components/ui";
 
 export function TopHeader() {
@@ -15,11 +16,14 @@ export function TopHeader() {
                 rightContent: (
                     <div className="flex items-center gap-4">
                         <div className="relative text-slate-400">
-                            <span className="text-lg">🔔</span>
+                            <HiOutlineBell className="h-5 w-5" />
                             <span className="absolute -right-0.5 top-0 h-2.5 w-2.5 rounded-full border-2 border-white bg-red-600" />
                         </div>
                         <Button className="px-4 py-2 text-xs font-semibold leading-tight">
-                            + Invite
+                            <span className="inline-flex items-center gap-1">
+                                <HiOutlineUserPlus className="h-4 w-4" />
+                                Invite
+                            </span>
                             <br />
                             Patient
                         </Button>

--- a/apps/clinician-portal/src/components/ui/empty-state.tsx
+++ b/apps/clinician-portal/src/components/ui/empty-state.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from "react";
+import { HiOutlineInbox } from "react-icons/hi2";
 
 interface EmptyStateProps {
-    icon: string;
+    icon?: ReactNode;
     title: string;
     description?: string;
     action?: ReactNode;
@@ -10,7 +11,7 @@ interface EmptyStateProps {
 export function EmptyState({ action, description, icon, title }: EmptyStateProps) {
     return (
         <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-gray-300 bg-white px-6 py-10 text-center shadow-sm">
-            <span className="text-4xl">{icon}</span>
+            <span className="text-4xl text-slate-400">{icon ?? <HiOutlineInbox />}</span>
             <div className="space-y-1">
                 <h3 className="text-base font-semibold text-gray-900">{title}</h3>
                 {description ? <p className="text-sm text-gray-500">{description}</p> : null}

--- a/apps/clinician-portal/src/components/ui/error-state.tsx
+++ b/apps/clinician-portal/src/components/ui/error-state.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from "react";
+import { HiOutlineExclamationTriangle } from "react-icons/hi2";
 
 interface ErrorStateProps {
     title?: string;
     description?: string;
-    icon?: string;
+    icon?: ReactNode;
     onRetry?: () => void;
     action?: ReactNode;
 }
@@ -11,13 +12,13 @@ interface ErrorStateProps {
 export function ErrorState({
     action,
     description = "Something went wrong. Please try again.",
-    icon = "⚠️",
+    icon = <HiOutlineExclamationTriangle />,
     onRetry,
     title = "Error",
 }: ErrorStateProps) {
     return (
         <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-red-200 bg-red-50 px-6 py-10 text-center shadow-sm">
-            <span className="text-4xl">{icon}</span>
+            <span className="text-4xl text-red-500">{icon}</span>
             <div className="space-y-1">
                 <h3 className="text-base font-semibold text-gray-900">{title}</h3>
                 <p className="text-sm text-gray-600">{description}</p>

--- a/apps/clinician-portal/src/services/auth-session.ts
+++ b/apps/clinician-portal/src/services/auth-session.ts
@@ -1,98 +1,20 @@
+import { createAuthSessionStorage } from "../../../../packages/shared/src/utils/auth-session";
 import type { ClinicianAuthSession, ClinicianAuthUser } from "@/store/slices/auth-slice";
 
-export const CLINICIAN_AUTH_STORAGE_KEY = "mediagent-clinician-auth";
-const REFRESH_WINDOW_SECONDS = 60;
+const clinicianAuthSessionStorage = createAuthSessionStorage<
+    "clinician",
+    ClinicianAuthUser,
+    ClinicianAuthSession
+>({
+    role: "clinician",
+    storageKey: "mediagent-clinician-auth",
+});
 
-interface LegacyStoredSession {
-    token?: string | null;
-    refreshToken?: string | null;
-    expiresAt?: number | null;
-    user?: ClinicianAuthUser | null;
-}
-
-interface RestoreSessionParams {
-    refreshSession: (refreshToken: string) => Promise<ClinicianAuthSession>;
-}
-
-function normalizeStoredSession(value: string | null): ClinicianAuthSession | null {
-    if (!value) {
-        return null;
-    }
-
-    try {
-        const parsed = JSON.parse(value) as ClinicianAuthSession | LegacyStoredSession;
-        const user = parsed.user;
-        if (!user || user.role !== "clinician") {
-            return null;
-        }
-
-        if ("accessToken" in parsed && "refreshToken" in parsed && "expiresAt" in parsed) {
-            if (!parsed.accessToken || !parsed.refreshToken || !parsed.expiresAt) {
-                return null;
-            }
-
-            return {
-                accessToken: parsed.accessToken,
-                refreshToken: parsed.refreshToken,
-                expiresAt: parsed.expiresAt,
-                user,
-            };
-        }
-
-        if (!parsed.token || !parsed.refreshToken || !parsed.expiresAt) {
-            return null;
-        }
-
-        return {
-            accessToken: parsed.token,
-            refreshToken: parsed.refreshToken,
-            expiresAt: parsed.expiresAt,
-            user,
-        };
-    } catch {
-        return null;
-    }
-}
-
-export function isSessionExpiring(expiresAt: number, nowSeconds = Math.floor(Date.now() / 1000)) {
-    return expiresAt - nowSeconds <= REFRESH_WINDOW_SECONDS;
-}
-
-export function readStoredSession() {
-    return normalizeStoredSession(window.localStorage.getItem(CLINICIAN_AUTH_STORAGE_KEY));
-}
-
-export function writeStoredSession(session: ClinicianAuthSession) {
-    window.localStorage.setItem(CLINICIAN_AUTH_STORAGE_KEY, JSON.stringify(session));
-}
-
-export function clearStoredSession() {
-    window.localStorage.removeItem(CLINICIAN_AUTH_STORAGE_KEY);
-}
-
-export async function restoreStoredSession({
-    refreshSession,
-}: RestoreSessionParams): Promise<ClinicianAuthSession | null> {
-    const storedSession = readStoredSession();
-    if (!storedSession) {
-        clearStoredSession();
-        return null;
-    }
-
-    if (!isSessionExpiring(storedSession.expiresAt)) {
-        return storedSession;
-    }
-
-    try {
-        const refreshedSession = await refreshSession(storedSession.refreshToken);
-        if (refreshedSession.user.role !== "clinician") {
-            clearStoredSession();
-            return null;
-        }
-        writeStoredSession(refreshedSession);
-        return refreshedSession;
-    } catch {
-        clearStoredSession();
-        return null;
-    }
-}
+export const CLINICIAN_AUTH_STORAGE_KEY = clinicianAuthSessionStorage.storageKey;
+export const {
+    clearStoredSession,
+    isSessionExpiring,
+    readStoredSession,
+    restoreStoredSession,
+    writeStoredSession,
+} = clinicianAuthSessionStorage;

--- a/apps/clinician-portal/src/services/auth-session.ts
+++ b/apps/clinician-portal/src/services/auth-session.ts
@@ -1,0 +1,98 @@
+import type { ClinicianAuthSession, ClinicianAuthUser } from "@/store/slices/auth-slice";
+
+export const CLINICIAN_AUTH_STORAGE_KEY = "mediagent-clinician-auth";
+const REFRESH_WINDOW_SECONDS = 60;
+
+interface LegacyStoredSession {
+    token?: string | null;
+    refreshToken?: string | null;
+    expiresAt?: number | null;
+    user?: ClinicianAuthUser | null;
+}
+
+interface RestoreSessionParams {
+    refreshSession: (refreshToken: string) => Promise<ClinicianAuthSession>;
+}
+
+function normalizeStoredSession(value: string | null): ClinicianAuthSession | null {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(value) as ClinicianAuthSession | LegacyStoredSession;
+        const user = parsed.user;
+        if (!user || user.role !== "clinician") {
+            return null;
+        }
+
+        if ("accessToken" in parsed && "refreshToken" in parsed && "expiresAt" in parsed) {
+            if (!parsed.accessToken || !parsed.refreshToken || !parsed.expiresAt) {
+                return null;
+            }
+
+            return {
+                accessToken: parsed.accessToken,
+                refreshToken: parsed.refreshToken,
+                expiresAt: parsed.expiresAt,
+                user,
+            };
+        }
+
+        if (!parsed.token || !parsed.refreshToken || !parsed.expiresAt) {
+            return null;
+        }
+
+        return {
+            accessToken: parsed.token,
+            refreshToken: parsed.refreshToken,
+            expiresAt: parsed.expiresAt,
+            user,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function isSessionExpiring(expiresAt: number, nowSeconds = Math.floor(Date.now() / 1000)) {
+    return expiresAt - nowSeconds <= REFRESH_WINDOW_SECONDS;
+}
+
+export function readStoredSession() {
+    return normalizeStoredSession(window.localStorage.getItem(CLINICIAN_AUTH_STORAGE_KEY));
+}
+
+export function writeStoredSession(session: ClinicianAuthSession) {
+    window.localStorage.setItem(CLINICIAN_AUTH_STORAGE_KEY, JSON.stringify(session));
+}
+
+export function clearStoredSession() {
+    window.localStorage.removeItem(CLINICIAN_AUTH_STORAGE_KEY);
+}
+
+export async function restoreStoredSession({
+    refreshSession,
+}: RestoreSessionParams): Promise<ClinicianAuthSession | null> {
+    const storedSession = readStoredSession();
+    if (!storedSession) {
+        clearStoredSession();
+        return null;
+    }
+
+    if (!isSessionExpiring(storedSession.expiresAt)) {
+        return storedSession;
+    }
+
+    try {
+        const refreshedSession = await refreshSession(storedSession.refreshToken);
+        if (refreshedSession.user.role !== "clinician") {
+            clearStoredSession();
+            return null;
+        }
+        writeStoredSession(refreshedSession);
+        return refreshedSession;
+    } catch {
+        clearStoredSession();
+        return null;
+    }
+}

--- a/apps/clinician-portal/src/store/provider.tsx
+++ b/apps/clinician-portal/src/store/provider.tsx
@@ -1,35 +1,66 @@
 "use client";
 
 import { useEffect } from "react";
+import { api } from "@/services/api";
+import { clearStoredSession, restoreStoredSession } from "@/services/auth-session";
 import { Provider } from "react-redux";
-import { finishHydration, hydrateSession, type ClinicianAuthUser } from "./slices/auth-slice";
+import { finishHydration, hydrateSession, type ClinicianAuthSession } from "./slices/auth-slice";
 import { store } from "./store";
-
-const CLINICIAN_AUTH_STORAGE_KEY = "mediagent-clinician-auth";
 
 export function StoreProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
-        try {
-            const storedValue = window.localStorage.getItem(CLINICIAN_AUTH_STORAGE_KEY);
-            if (!storedValue) {
+        let isMounted = true;
+
+        async function bootstrapAuth() {
+            const session = await restoreStoredSession({
+                refreshSession: async (refreshToken) => {
+                    const response = await api.post<{
+                        tokens: {
+                            access_token: string;
+                            refresh_token: string;
+                            expires_at: number;
+                        };
+                        user: {
+                            email: string;
+                            id: string;
+                            role: "patient" | "clinician";
+                        };
+                    }>("/api/v1/auth/refresh", { refresh_token: refreshToken });
+
+                    if (response.user.role !== "clinician") {
+                        throw new Error("This session belongs to a patient account.");
+                    }
+
+                    return {
+                        accessToken: response.tokens.access_token,
+                        expiresAt: response.tokens.expires_at,
+                        refreshToken: response.tokens.refresh_token,
+                        user: {
+                            email: response.user.email,
+                            id: response.user.id,
+                            role: "clinician",
+                        },
+                    } satisfies ClinicianAuthSession;
+                },
+            });
+
+            if (!isMounted) {
+                return;
+            }
+
+            if (session) {
+                store.dispatch(hydrateSession(session));
+            } else {
+                clearStoredSession();
                 store.dispatch(finishHydration());
-                return;
             }
-
-            const parsed = JSON.parse(storedValue) as {
-                token: string | null;
-                user: ClinicianAuthUser;
-            };
-
-            if (parsed.user) {
-                store.dispatch(hydrateSession(parsed));
-                return;
-            }
-        } catch {
-            window.localStorage.removeItem(CLINICIAN_AUTH_STORAGE_KEY);
         }
 
-        store.dispatch(finishHydration());
+        void bootstrapAuth();
+
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
     return <Provider store={store}>{children}</Provider>;

--- a/apps/clinician-portal/src/store/provider.tsx
+++ b/apps/clinician-portal/src/store/provider.tsx
@@ -25,7 +25,10 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                             id: string;
                             role: "patient" | "clinician";
                         };
-                    }>("/api/v1/auth/refresh", { refresh_token: refreshToken });
+                    }>("/api/v1/auth/refresh", {
+                        expected_role: "clinician",
+                        refresh_token: refreshToken,
+                    });
 
                     if (response.user.role !== "clinician") {
                         throw new Error("This session belongs to a patient account.");

--- a/apps/clinician-portal/src/store/slices/auth-slice.ts
+++ b/apps/clinician-portal/src/store/slices/auth-slice.ts
@@ -4,19 +4,30 @@ import { createSlice } from "@reduxjs/toolkit";
 export interface ClinicianAuthUser {
     id: string;
     email: string;
-    role: "provider" | "admin" | "nurse" | "clinician";
+    role: "clinician";
+}
+
+export interface ClinicianAuthSession {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    user: ClinicianAuthUser;
 }
 
 interface AuthState {
     user: ClinicianAuthUser | null;
-    token: string | null;
+    accessToken: string | null;
+    refreshToken: string | null;
+    expiresAt: number | null;
     isAuthenticated: boolean;
     loading: boolean;
 }
 
 const initialState: AuthState = {
     user: null,
-    token: null,
+    accessToken: null,
+    refreshToken: null,
+    expiresAt: null,
     isAuthenticated: false,
     loading: true,
 };
@@ -27,10 +38,12 @@ export const authSlice = createSlice({
     reducers: {
         hydrateSession: (
             state,
-            action: PayloadAction<{ token: string | null; user: ClinicianAuthUser } | null>,
+            action: PayloadAction<ClinicianAuthSession | null>,
         ) => {
             state.user = action.payload?.user ?? null;
-            state.token = action.payload?.token ?? null;
+            state.accessToken = action.payload?.accessToken ?? null;
+            state.refreshToken = action.payload?.refreshToken ?? null;
+            state.expiresAt = action.payload?.expiresAt ?? null;
             state.isAuthenticated = !!action.payload?.user;
             state.loading = false;
         },
@@ -39,19 +52,28 @@ export const authSlice = createSlice({
             state.isAuthenticated = !!action.payload;
             state.loading = false;
         },
-        setToken: (state, action: PayloadAction<string | null>) => {
-            state.token = action.payload;
+        setAccessToken: (state, action: PayloadAction<string | null>) => {
+            state.accessToken = action.payload;
+        },
+        setRefreshToken: (state, action: PayloadAction<string | null>) => {
+            state.refreshToken = action.payload;
+        },
+        setExpiresAt: (state, action: PayloadAction<number | null>) => {
+            state.expiresAt = action.payload;
         },
         finishHydration: (state) => {
             state.loading = false;
         },
         logout: (state) => {
             state.user = null;
-            state.token = null;
+            state.accessToken = null;
+            state.refreshToken = null;
+            state.expiresAt = null;
             state.isAuthenticated = false;
             state.loading = false;
         },
     },
 });
 
-export const { hydrateSession, setUser, setToken, finishHydration, logout } = authSlice.actions;
+export const { hydrateSession, setUser, setAccessToken, setRefreshToken, setExpiresAt, finishHydration, logout } =
+    authSlice.actions;

--- a/apps/patient-portal/package-lock.json
+++ b/apps/patient-portal/package-lock.json
@@ -14,6 +14,7 @@
         "next": "16.1.7",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-icons": "^5.6.0",
         "react-redux": "^9.2.0"
       },
       "devDependencies": {
@@ -7236,6 +7237,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/apps/patient-portal/package.json
+++ b/apps/patient-portal/package.json
@@ -17,6 +17,7 @@
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-icons": "^5.6.0",
     "react-redux": "^9.2.0"
   },
   "devDependencies": {

--- a/apps/patient-portal/src/__tests__/auth-session.test.ts
+++ b/apps/patient-portal/src/__tests__/auth-session.test.ts
@@ -1,0 +1,59 @@
+import {
+    PATIENT_AUTH_STORAGE_KEY,
+    clearStoredSession,
+    isSessionExpiring,
+    restoreStoredSession,
+    writeStoredSession,
+} from "@/services/auth-session";
+import type { PatientAuthSession } from "@/store/slices/auth-slice";
+import { describe, expect, it, vi } from "vitest";
+
+const session: PatientAuthSession = {
+    accessToken: "access-token",
+    expiresAt: Math.floor(Date.now() / 1000) + 300,
+    refreshToken: "refresh-token",
+    user: {
+        email: "patient@example.com",
+        id: "patient-1",
+        role: "patient",
+    },
+};
+
+describe("patient auth session", () => {
+    it("detects expiring sessions", () => {
+        expect(isSessionExpiring(Math.floor(Date.now() / 1000) + 30)).toBe(true);
+        expect(isSessionExpiring(Math.floor(Date.now() / 1000) + 600)).toBe(false);
+    });
+
+    it("refreshes and persists an expiring session", async () => {
+        writeStoredSession({ ...session, expiresAt: Math.floor(Date.now() / 1000) + 10 });
+        const refreshSession = vi.fn().mockResolvedValue({
+            ...session,
+            accessToken: "new-access-token",
+            expiresAt: Math.floor(Date.now() / 1000) + 900,
+        });
+
+        const restored = await restoreStoredSession({ refreshSession });
+
+        expect(refreshSession).toHaveBeenCalledWith("refresh-token");
+        expect(restored?.accessToken).toBe("new-access-token");
+        expect(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY)).toContain("new-access-token");
+    });
+
+    it("clears storage when refresh fails", async () => {
+        writeStoredSession({ ...session, expiresAt: Math.floor(Date.now() / 1000) + 10 });
+
+        const restored = await restoreStoredSession({
+            refreshSession: vi.fn().mockRejectedValue(new Error("refresh failed")),
+        });
+
+        expect(restored).toBeNull();
+        expect(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY)).toBeNull();
+    });
+
+    it("clears invalid sessions", () => {
+        window.localStorage.setItem(PATIENT_AUTH_STORAGE_KEY, JSON.stringify({ token: "bad" }));
+        clearStoredSession();
+        expect(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY)).toBeNull();
+    });
+});

--- a/apps/patient-portal/src/__tests__/login-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/login-page.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import LoginPage from "@/app/login/page";
+
+const { dispatch, post, replace, writeStoredSession } = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    post: vi.fn(),
+    replace: vi.fn(),
+    writeStoredSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace }),
+}));
+
+vi.mock("react-redux", () => ({
+    useDispatch: () => dispatch,
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { post },
+}));
+
+vi.mock("@/services/auth-session", () => ({
+    writeStoredSession,
+}));
+
+describe("Patient login page", () => {
+    beforeEach(() => {
+        replace.mockReset();
+        dispatch.mockReset();
+        post.mockReset();
+        writeStoredSession.mockReset();
+    });
+
+    it("stores full session and redirects on successful patient login", async () => {
+        post.mockResolvedValue({
+            tokens: {
+                access_token: "access-token",
+                expires_at: 1234567890,
+                refresh_token: "refresh-token",
+            },
+            user: {
+                email: "patient@example.com",
+                id: "patient-1",
+                role: "patient",
+            },
+        });
+
+        render(<LoginPage />);
+        fireEvent.change(screen.getByLabelText(/email address/i), {
+            target: { value: "patient@example.com" },
+        });
+        fireEvent.change(screen.getByLabelText(/^password$/i), {
+            target: { value: "SecurePass123!" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+        await waitFor(() => {
+            expect(writeStoredSession).toHaveBeenCalledWith({
+                accessToken: "access-token",
+                expiresAt: 1234567890,
+                refreshToken: "refresh-token",
+                user: {
+                    email: "patient@example.com",
+                    id: "patient-1",
+                    role: "patient",
+                },
+            });
+        });
+        expect(replace).toHaveBeenCalledWith("/today");
+    });
+
+    it("shows an error for clinician credentials", async () => {
+        post.mockResolvedValue({
+            tokens: {
+                access_token: "access-token",
+                expires_at: 1234567890,
+                refresh_token: "refresh-token",
+            },
+            user: {
+                email: "doctor@example.com",
+                id: "clinician-1",
+                role: "clinician",
+            },
+        });
+
+        render(<LoginPage />);
+        fireEvent.change(screen.getByLabelText(/email address/i), {
+            target: { value: "doctor@example.com" },
+        });
+        fireEvent.change(screen.getByLabelText(/^password$/i), {
+            target: { value: "SecurePass123!" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+        expect(await screen.findByText(/clinician account/i)).toBeInTheDocument();
+        expect(replace).not.toHaveBeenCalled();
+    });
+});

--- a/apps/patient-portal/src/__tests__/onboarding-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/onboarding-page.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import OnboardingPage from "@/app/(auth)/onboarding/page";
+
+const { dispatch, post, put, replace } = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace }),
+}));
+
+vi.mock("react-redux", () => ({
+    useDispatch: () => dispatch,
+    useSelector: (selector: (state: unknown) => unknown) =>
+        selector({
+            auth: { accessToken: "access-token" },
+            onboarding: {
+                profileDraft: {
+                    dateOfBirth: "1990-01-01",
+                    firstName: "Sarah",
+                    lastName: "Jones",
+                },
+            },
+        }),
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { post, put },
+}));
+
+describe("Patient onboarding page", () => {
+    beforeEach(() => {
+        replace.mockReset();
+        dispatch.mockReset();
+        post.mockReset();
+        put.mockReset();
+    });
+
+    it("surfaces join-clinic errors and lets the user continue", async () => {
+        put.mockResolvedValue({});
+        post.mockRejectedValue(new Error("Invalid or expired invite code"));
+
+        render(<OnboardingPage />);
+        fireEvent.click(screen.getByRole("button", { name: /next/i }));
+        fireEvent.click(screen.getByRole("button", { name: /next/i }));
+        fireEvent.click(screen.getByRole("button", { name: /next/i }));
+        fireEvent.change(screen.getByLabelText(/clinic invite code/i), {
+            target: { value: "BAD-CODE" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /finish setup/i }));
+
+        expect(await screen.findByText(/invalid or expired invite code/i)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /skip clinic for now/i }));
+
+        await waitFor(() => {
+            expect(replace).toHaveBeenCalledWith("/today");
+        });
+    });
+});

--- a/apps/patient-portal/src/__tests__/profile-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/profile-page.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ProfilePage from "@/app/(app)/profile/page";
+
+const { clearStoredSession, dispatch, get, post, replace } = vi.hoisted(() => ({
+    clearStoredSession: vi.fn(),
+    dispatch: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace }),
+}));
+
+vi.mock("react-redux", () => ({
+    useDispatch: () => dispatch,
+    useSelector: (selector: (state: unknown) => unknown) =>
+        selector({
+            auth: { accessToken: "access-token" },
+        }),
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { get, post },
+}));
+
+vi.mock("@/services/auth-session", () => ({
+    clearStoredSession,
+}));
+
+describe("Patient profile page", () => {
+    beforeEach(() => {
+        clearStoredSession.mockReset();
+        dispatch.mockReset();
+        get.mockReset();
+        post.mockReset();
+        replace.mockReset();
+    });
+
+    it("loads profile details and the linked care team", async () => {
+        get.mockImplementation(async (endpoint: string) => {
+            if (endpoint === "/api/v1/patients/me") {
+                return {
+                    created_at: "2026-01-10T00:00:00Z",
+                    date_of_birth: "1985-03-15",
+                    email: "sarah@example.com",
+                    first_name: "Sarah",
+                    id: "patient-1",
+                    last_name: "Johnson",
+                    preferred_language: "en",
+                };
+            }
+
+            return [
+                {
+                    clinician_first_name: "Emily",
+                    clinician_id: "clinician-1",
+                    clinician_last_name: "Smith",
+                    clinic_name: "City Health",
+                    created_at: "2026-01-10T00:00:00Z",
+                    id: "care-team-1",
+                    patient_id: "patient-1",
+                    role: "Primary Care",
+                    status: "active",
+                },
+            ];
+        });
+
+        render(<ProfilePage />);
+
+        expect(await screen.findByText("Sarah Johnson")).toBeInTheDocument();
+        expect(screen.getByText("sarah@example.com")).toBeInTheDocument();
+        expect(screen.getByText("Dr. Emily Smith")).toBeInTheDocument();
+        expect(screen.getByText("City Health")).toBeInTheDocument();
+    });
+
+    it("lets the patient join another clinic after onboarding", async () => {
+        let careTeamResponse: Array<Record<string, string>> = [];
+        get.mockImplementation(async (endpoint: string) => {
+            if (endpoint === "/api/v1/patients/me") {
+                return {
+                    created_at: "2026-01-10T00:00:00Z",
+                    date_of_birth: "1985-03-15",
+                    email: "sarah@example.com",
+                    first_name: "Sarah",
+                    id: "patient-1",
+                    last_name: "Johnson",
+                    preferred_language: "en",
+                };
+            }
+
+            return careTeamResponse;
+        });
+        post.mockResolvedValueOnce({});
+
+        render(<ProfilePage />);
+
+        expect(await screen.findByText(/no care teams linked yet/i)).toBeInTheDocument();
+
+        fireEvent.change(await screen.findByLabelText(/clinic invite code/i), {
+            target: { value: "NORTH-8832" },
+        });
+        fireEvent.click(await screen.findByRole("button", { name: /join clinic/i }));
+
+        await waitFor(() => {
+            expect(post).toHaveBeenCalledWith(
+                "/api/v1/patients/me/care-team/join?invite_code=NORTH-8832",
+                undefined,
+                { token: "access-token" },
+            );
+        });
+
+        careTeamResponse = [
+            {
+                clinician_first_name: "Amir",
+                clinician_id: "clinician-2",
+                clinician_last_name: "Khan",
+                clinic_name: "Northside Clinic",
+                created_at: "2026-02-11T00:00:00Z",
+                id: "care-team-2",
+                patient_id: "patient-1",
+                role: "Cardiology",
+                status: "active",
+            },
+        ];
+
+        expect(await screen.findByText(/clinic linked successfully/i)).toBeInTheDocument();
+        expect(await screen.findByText("Dr. Amir Khan")).toBeInTheDocument();
+        expect(screen.getByText("Northside Clinic")).toBeInTheDocument();
+    });
+
+    it("surfaces invite-code errors without leaving the page", async () => {
+        get.mockImplementation(async (endpoint: string) => {
+            if (endpoint === "/api/v1/patients/me") {
+                return {
+                    created_at: "2026-01-10T00:00:00Z",
+                    date_of_birth: "1985-03-15",
+                    email: "sarah@example.com",
+                    first_name: "Sarah",
+                    id: "patient-1",
+                    last_name: "Johnson",
+                    preferred_language: "en",
+                };
+            }
+
+            return [];
+        });
+        post.mockRejectedValueOnce(new Error("Invalid or expired invite code"));
+
+        render(<ProfilePage />);
+
+        expect(await screen.findByText(/no care teams linked yet/i)).toBeInTheDocument();
+
+        fireEvent.change(await screen.findByLabelText(/clinic invite code/i), {
+            target: { value: "BAD-CODE" },
+        });
+        fireEvent.click(await screen.findByRole("button", { name: /join clinic/i }));
+
+        expect(await screen.findByText(/invalid or expired invite code/i)).toBeInTheDocument();
+        expect(replace).not.toHaveBeenCalledWith("/login");
+    });
+});

--- a/apps/patient-portal/src/app/(app)/chat/page.tsx
+++ b/apps/patient-portal/src/app/(app)/chat/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { HiArrowUp, HiMicrophone, HiSparkles } from "react-icons/hi2";
 import { ChatBubble } from "@/components/features";
 import { Button, Input } from "@/components/ui";
 import { ChatRole, type ChatMessage } from "@/types";
@@ -66,7 +67,7 @@ export default function ChatPage() {
                 <div className="flex items-start justify-between gap-4">
                     <div className="flex items-start gap-3">
                         <div className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-sm text-sky-200">
-                            ✦
+                            <HiSparkles className="h-5 w-5" />
                         </div>
                         <div>
                             <h1 className="text-2xl font-bold text-white">Care Companion</h1>
@@ -120,7 +121,7 @@ export default function ChatPage() {
                         className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300"
                         type="button"
                     >
-                        🎙
+                        <HiMicrophone className="h-5 w-5" />
                     </button>
                     <div className="flex-1">
                         <Input
@@ -135,7 +136,7 @@ export default function ChatPage() {
                         disabled={!input.trim()}
                         type="submit"
                     >
-                        ↑
+                        <HiArrowUp className="h-5 w-5" />
                     </button>
                 </div>
             </form>

--- a/apps/patient-portal/src/app/(app)/profile/page.tsx
+++ b/apps/patient-portal/src/app/(app)/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { HiOutlineBuildingOffice2 } from "react-icons/hi2";
 import { useDispatch, useSelector } from "react-redux";
 import { PageHeader } from "@/components/layouts";
 import { api } from "@/services/api";
@@ -253,7 +254,7 @@ export default function ProfilePage() {
                             ) : (
                                 <EmptyState
                                     description="Add a clinic invite code to connect your account with a care team."
-                                    icon="MD"
+                                    icon={<HiOutlineBuildingOffice2 />}
                                     title="No care teams linked yet"
                                 />
                             )}

--- a/apps/patient-portal/src/app/(app)/profile/page.tsx
+++ b/apps/patient-portal/src/app/(app)/profile/page.tsx
@@ -1,41 +1,135 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { PageHeader } from "@/components/layouts";
+import { api } from "@/services/api";
 import { clearStoredSession } from "@/services/auth-session";
-import { Badge, Button, Card } from "@/components/ui";
+import { Badge, Button, Card, EmptyState, ErrorState, Input, Skeleton } from "@/components/ui";
 import { logout } from "@/store/slices/auth-slice";
-import type { AppDispatch } from "@/store/store";
-import type { CareTeamMember, Patient } from "@/types";
+import type { AppDispatch, RootState } from "@/store/store";
+import type { CareTeamMember, Language, Patient } from "@/types";
 
-const patientProfile: Patient = {
-    createdAt: "2026-01-10T00:00:00Z",
-    dateOfBirth: "1985-03-15",
-    email: "sarah@example.com",
-    firstName: "Sarah",
-    id: "demo-patient",
-    lastName: "Johnson",
-    preferredLanguage: "en",
-};
+interface PatientProfileResponse {
+    id: string;
+    email: string;
+    first_name: string;
+    last_name: string;
+    date_of_birth: string;
+    gender?: Patient["gender"];
+    preferred_language: Language;
+    created_at: string;
+}
 
-const careTeam: CareTeamMember[] = [
-    {
-        clinicName: "City Health",
-        clinicianFirstName: "Emily",
-        clinicianId: "provider-1",
-        clinicianLastName: "Smith",
-        createdAt: "2026-01-10T00:00:00Z",
-        id: "care-team-1",
-        patientId: "demo-patient",
-        role: "Primary Care",
-        status: "active",
-    },
-];
+interface CareTeamResponse {
+    id: string;
+    patient_id: string;
+    clinician_id: string;
+    clinician_first_name: string;
+    clinician_last_name: string;
+    role: string;
+    specialty_context?: string;
+    clinic_name?: string;
+    status: CareTeamMember["status"];
+    created_at: string;
+}
+
+function mapPatient(profile: PatientProfileResponse): Patient {
+    return {
+        createdAt: profile.created_at,
+        dateOfBirth: profile.date_of_birth,
+        email: profile.email,
+        firstName: profile.first_name,
+        gender: profile.gender,
+        id: profile.id,
+        lastName: profile.last_name,
+        preferredLanguage: profile.preferred_language,
+    };
+}
+
+function mapCareTeamMember(member: CareTeamResponse): CareTeamMember {
+    return {
+        clinicName: member.clinic_name,
+        clinicianFirstName: member.clinician_first_name,
+        clinicianId: member.clinician_id,
+        clinicianLastName: member.clinician_last_name,
+        createdAt: member.created_at,
+        id: member.id,
+        patientId: member.patient_id,
+        role: member.role,
+        specialtyContext: member.specialty_context,
+        status: member.status,
+    };
+}
+
+function formatLanguage(language: Language) {
+    return language === "es" ? "Spanish" : "English";
+}
 
 export default function ProfilePage() {
     const dispatch = useDispatch<AppDispatch>();
     const router = useRouter();
+    const accessToken = useSelector((state: RootState) => state.auth.accessToken);
+    const [patientProfile, setPatientProfile] = useState<Patient | null>(null);
+    const [careTeam, setCareTeam] = useState<CareTeamMember[]>([]);
+    const [inviteCode, setInviteCode] = useState("");
+    const [joinError, setJoinError] = useState("");
+    const [joinSuccess, setJoinSuccess] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [pageError, setPageError] = useState("");
+    const [joining, setJoining] = useState(false);
+
+    async function fetchCareTeam(token: string) {
+        const response = await api.get<CareTeamResponse[]>("/api/v1/patients/me/care-team", {
+            token,
+        });
+        return response.map(mapCareTeamMember);
+    }
+
+    useEffect(() => {
+        if (!accessToken) {
+            router.replace("/login");
+            return;
+        }
+
+        const token: string = accessToken;
+
+        let isMounted = true;
+
+        async function loadAccount() {
+            setLoading(true);
+            setPageError("");
+
+            try {
+                const [profileResponse, careTeamResponse] = await Promise.all([
+                    api.get<PatientProfileResponse>("/api/v1/patients/me", { token }),
+                    fetchCareTeam(token),
+                ]);
+
+                if (!isMounted) {
+                    return;
+                }
+
+                setPatientProfile(mapPatient(profileResponse));
+                setCareTeam(careTeamResponse);
+            } catch (error) {
+                if (isMounted) {
+                    setPageError((error as Error).message);
+                }
+            } finally {
+                if (isMounted) {
+                    setLoading(false);
+                }
+            }
+        }
+
+        void loadAccount();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [accessToken, router]);
 
     function handleLogout() {
         clearStoredSession();
@@ -43,78 +137,173 @@ export default function ProfilePage() {
         router.replace("/login");
     }
 
+    async function handleJoinClinic(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        if (!accessToken) {
+            router.replace("/login");
+            return;
+        }
+
+        if (!inviteCode.trim()) {
+            setJoinError("Enter a clinic invite code to continue.");
+            return;
+        }
+
+        setJoinError("");
+        setJoinSuccess("");
+        setJoining(true);
+
+        try {
+            await api.post(
+                `/api/v1/patients/me/care-team/join?invite_code=${encodeURIComponent(inviteCode.trim())}`,
+                undefined,
+                { token: accessToken },
+            );
+            const refreshedCareTeam = await fetchCareTeam(accessToken);
+            setCareTeam(refreshedCareTeam);
+            setInviteCode("");
+            setJoinSuccess("Clinic linked successfully. Your new care team is now available.");
+        } catch (error) {
+            setJoinError((error as Error).message);
+        } finally {
+            setJoining(false);
+        }
+    }
+
     return (
         <div className="space-y-4 bg-gray-50 pb-8">
-            <PageHeader subtitle="Personal information and linked clinicians." title="Profile" />
+            <PageHeader subtitle="Manage your account and linked clinics." title="Profile" />
             <div className="-mt-4 space-y-4 px-5">
-                <Card className="overflow-hidden border-sky-100 bg-gradient-to-br from-sky-600 to-sky-700 text-white shadow-lg shadow-sky-100">
-                    <div className="flex items-center gap-4">
-                        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/20 text-2xl font-semibold">
-                            S
-                        </div>
-                        <div className="min-w-0">
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-100">Patient account</p>
-                            <h2 className="truncate text-xl font-semibold text-white">
-                                {patientProfile.firstName} {patientProfile.lastName}
-                            </h2>
-                            <p className="mt-1 text-sm text-sky-100">{patientProfile.email}</p>
-                        </div>
+                {loading ? (
+                    <div className="space-y-4">
+                        <Skeleton className="h-32 w-full rounded-3xl" />
+                        <Skeleton className="h-48 w-full rounded-3xl" />
+                        <Skeleton className="h-56 w-full rounded-3xl" />
                     </div>
-                </Card>
+                ) : null}
 
-                <Card className="space-y-4">
-                    <div className="flex items-center justify-between gap-3">
-                        <div>
-                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Profile details</p>
-                            <h3 className="mt-1 text-lg font-semibold text-slate-900">Personal information</h3>
-                        </div>
-                        <Badge variant="info">Active</Badge>
-                    </div>
-                    <div className="grid gap-3 text-sm text-slate-600">
-                        <div className="rounded-2xl bg-slate-50 px-4 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Date of birth</p>
-                            <p className="mt-1 font-medium text-slate-800">{patientProfile.dateOfBirth}</p>
-                        </div>
-                        <div className="rounded-2xl bg-slate-50 px-4 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Preferred language</p>
-                            <p className="mt-1 font-medium text-slate-800">English</p>
-                        </div>
-                    </div>
-                </Card>
+                {!loading && pageError ? (
+                    <ErrorState
+                        description={pageError}
+                        onRetry={() => window.location.reload()}
+                        title="Unable to load your profile"
+                    />
+                ) : null}
 
-                <Card className="space-y-3">
-                    <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Connected clinic</p>
-                        <h3 className="mt-1 text-lg font-semibold text-slate-900">Care team</h3>
-                    </div>
-                    {careTeam.map((member) => (
-                        <div className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-4" key={member.id}>
-                            <div className="flex items-start justify-between gap-3">
-                                <div>
-                                    <p className="font-medium text-slate-900">
-                                        Dr. {member.clinicianFirstName} {member.clinicianLastName}
-                                    </p>
-                                    <p className="mt-1 text-sm text-slate-500">{member.role}</p>
+                {!loading && !pageError && patientProfile ? (
+                    <>
+                        <Card className="overflow-hidden border-sky-100 bg-gradient-to-br from-sky-600 to-sky-700 text-white shadow-lg shadow-sky-100">
+                            <div className="flex items-center gap-4">
+                                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/20 text-2xl font-semibold">
+                                    {patientProfile.firstName.charAt(0)}
                                 </div>
-                                <Badge variant="success">Linked</Badge>
+                                <div className="min-w-0">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-100">Patient account</p>
+                                    <h2 className="truncate text-xl font-semibold text-white">
+                                        {patientProfile.firstName} {patientProfile.lastName}
+                                    </h2>
+                                    <p className="mt-1 text-sm text-sky-100">{patientProfile.email}</p>
+                                </div>
                             </div>
-                            <p className="mt-3 text-sm text-slate-500">{member.clinicName}</p>
-                        </div>
-                    ))}
-                </Card>
+                        </Card>
 
-                <Card className="space-y-3 border-red-100 bg-red-50/70">
-                    <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-red-400">Account</p>
-                        <h3 className="mt-1 text-lg font-semibold text-slate-900">Sign out safely</h3>
-                        <p className="mt-1 text-sm text-slate-600">
-                            Use this if you are on a shared phone or finished reviewing your care plan.
-                        </p>
-                    </div>
-                    <Button fullWidth onClick={handleLogout} variant="danger">
-                        Sign out
-                    </Button>
-                </Card>
+                        <Card className="space-y-4">
+                            <div className="flex items-center justify-between gap-3">
+                                <div>
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Profile details</p>
+                                    <h3 className="mt-1 text-lg font-semibold text-slate-900">Personal information</h3>
+                                </div>
+                                <Badge variant="info">Active</Badge>
+                            </div>
+                            <div className="grid gap-3 text-sm text-slate-600">
+                                <div className="rounded-2xl bg-slate-50 px-4 py-3">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Date of birth</p>
+                                    <p className="mt-1 font-medium text-slate-800">{patientProfile.dateOfBirth}</p>
+                                </div>
+                                <div className="rounded-2xl bg-slate-50 px-4 py-3">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Preferred language</p>
+                                    <p className="mt-1 font-medium text-slate-800">{formatLanguage(patientProfile.preferredLanguage)}</p>
+                                </div>
+                            </div>
+                        </Card>
+
+                        <Card className="space-y-4">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Connected clinics</p>
+                                <h3 className="mt-1 text-lg font-semibold text-slate-900">Care teams</h3>
+                            </div>
+                            {careTeam.length ? (
+                                <div className="space-y-3">
+                                    {careTeam.map((member) => (
+                                        <div className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-4" key={member.id}>
+                                            <div className="flex items-start justify-between gap-3">
+                                                <div>
+                                                    <p className="font-medium text-slate-900">
+                                                        Dr. {member.clinicianFirstName} {member.clinicianLastName}
+                                                    </p>
+                                                    <p className="mt-1 text-sm text-slate-500">{member.role}</p>
+                                                </div>
+                                                <Badge variant="success">Linked</Badge>
+                                            </div>
+                                            <p className="mt-3 text-sm text-slate-500">{member.clinicName || member.specialtyContext || "Care team active"}</p>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <EmptyState
+                                    description="Add a clinic invite code to connect your account with a care team."
+                                    icon="MD"
+                                    title="No care teams linked yet"
+                                />
+                            )}
+                        </Card>
+
+                        <Card className="space-y-4">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Join another clinic</p>
+                                <h3 className="mt-1 text-lg font-semibold text-slate-900">Add care team access</h3>
+                                <p className="mt-1 text-sm text-slate-500">
+                                    If another clinic shares a code with you, enter it here to link that team to your account.
+                                </p>
+                            </div>
+                            <form className="space-y-3" onSubmit={handleJoinClinic}>
+                                <Input
+                                    label="Clinic invite code"
+                                    onChange={(event) => {
+                                        setInviteCode(event.target.value);
+                                        if (joinError) {
+                                            setJoinError("");
+                                        }
+                                        if (joinSuccess) {
+                                            setJoinSuccess("");
+                                        }
+                                    }}
+                                    placeholder="CITY-8832"
+                                    value={inviteCode}
+                                />
+                                {joinError ? <p className="text-sm text-red-600">{joinError}</p> : null}
+                                {joinSuccess ? <p className="text-sm text-green-600">{joinSuccess}</p> : null}
+                                <Button disabled={joining} fullWidth type="submit">
+                                    {joining ? "Joining clinic..." : "Join clinic"}
+                                </Button>
+                            </form>
+                        </Card>
+
+                        <Card className="space-y-3 border-red-100 bg-red-50/70">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-wide text-red-400">Account</p>
+                                <h3 className="mt-1 text-lg font-semibold text-slate-900">Sign out safely</h3>
+                                <p className="mt-1 text-sm text-slate-600">
+                                    Use this if you are on a shared phone or finished reviewing your care plan.
+                                </p>
+                            </div>
+                            <Button fullWidth onClick={handleLogout} variant="danger">
+                                Sign out
+                            </Button>
+                        </Card>
+                    </>
+                ) : null}
             </div>
         </div>
     );

--- a/apps/patient-portal/src/app/(app)/profile/page.tsx
+++ b/apps/patient-portal/src/app/(app)/profile/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useDispatch } from "react-redux";
 import { PageHeader } from "@/components/layouts";
+import { clearStoredSession } from "@/services/auth-session";
 import { Badge, Button, Card } from "@/components/ui";
 import { logout } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
@@ -37,7 +38,7 @@ export default function ProfilePage() {
     const router = useRouter();
 
     function handleLogout() {
-        window.localStorage.removeItem("mediagent-patient-auth");
+        clearStoredSession();
         dispatch(logout());
         router.replace("/login");
     }

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { HiOutlineBeaker, HiOutlineClipboardDocumentList, HiOutlineDocumentText, HiOutlineFolder } from "react-icons/hi2";
 import { DocumentCard } from "@/components/features";
 import { PageHeader } from "@/components/layouts";
 import { Button, EmptyState, ErrorState, Modal, ProgressBar } from "@/components/ui";
@@ -10,7 +12,7 @@ import type { RootState } from "@/store/store";
 import { DocumentType, type Document } from "@/types";
 import { useSelector } from "react-redux";
 
-type PortalDocument = Document & { icon: string; provider: string };
+type PortalDocument = Document & { icon: ReactNode; provider: string };
 
 interface DocumentApiRecord {
     id: string;
@@ -35,15 +37,15 @@ interface DocumentApiRecord {
 function getDocumentIcon(documentType: DocumentType) {
     switch (documentType) {
         case DocumentType.LAB_REPORT:
-            return "🩸";
+            return <HiOutlineBeaker />;
         case DocumentType.PRESCRIPTION:
-            return "💊";
+            return <HiOutlineClipboardDocumentList />;
         case DocumentType.DISCHARGE_SUMMARY:
-            return "🏥";
+            return <HiOutlineDocumentText />;
         case DocumentType.DIAGNOSTIC_REPORT:
-            return "🧪";
+            return <HiOutlineBeaker />;
         default:
-            return "📄";
+            return <HiOutlineDocumentText />;
     }
 }
 
@@ -345,7 +347,7 @@ export default function RecordsPage() {
                     <p className="text-sm text-slate-500">Loading documents...</p>
                 ) : null}
                 {!loading && !pageError && documents.length === 0 ? (
-                    <EmptyState description="Upload PDFs or images from your clinic visits." icon="📁" title="No records yet" />
+                    <EmptyState description="Upload PDFs or images from your clinic visits." icon={<HiOutlineFolder />} title="No records yet" />
                 ) : null}
                 {documents.map((document) => {
                     const displayDocument = parsingDocIds.has(document.id)

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -116,17 +116,17 @@ export default function RecordsPage() {
     const [uploadProgress, setUploadProgress] = useState(0);
     const [uploading, setUploading] = useState(false);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
-    const { token, user } = useSelector((state: RootState) => state.auth);
+    const { accessToken, user } = useSelector((state: RootState) => state.auth);
 
     const loadDocuments = useCallback(async () => {
-        if (!token) {
+        if (!accessToken) {
             return;
         }
 
         setLoading(true);
         try {
             const result = await api.get<DocumentApiRecord[]>("/api/v1/documents/", {
-                token,
+                token: accessToken,
             });
             setDocuments(result.map(mapDocument));
             setPageError(null);
@@ -135,15 +135,15 @@ export default function RecordsPage() {
         } finally {
             setLoading(false);
         }
-    }, [token]);
+    }, [accessToken]);
 
     useEffect(() => {
-        if (!token) {
+        if (!accessToken) {
             return;
         }
 
         void loadDocuments();
-    }, [loadDocuments, token]);
+    }, [accessToken, loadDocuments]);
 
     async function pollForParsedStatus(docId: string) {
         setParsingDocIds((current) => new Set(current).add(docId));
@@ -154,7 +154,7 @@ export default function RecordsPage() {
             try {
                 const record = await api.get<DocumentApiRecord>(
                     `/api/v1/documents/${docId}`,
-                    { token: token ?? undefined },
+                    { token: accessToken ?? undefined },
                 );
                 const nextDocument = mapDocument(record);
 
@@ -205,7 +205,7 @@ export default function RecordsPage() {
             return;
         }
 
-        if (!token || !user) {
+        if (!accessToken || !user) {
             setPageError("Please sign in again before uploading a document.");
             return;
         }
@@ -222,7 +222,7 @@ export default function RecordsPage() {
             const filePath = await uploadDocumentToStorage({
                 file,
                 patientId: user.id,
-                token,
+                token: accessToken,
             });
             const created = await api.post<DocumentApiRecord>(
                 "/api/v1/documents/",
@@ -233,7 +233,7 @@ export default function RecordsPage() {
                     file_size_bytes: file.size,
                     mime_type: file.type || "application/octet-stream",
                 },
-                { token },
+                { token: accessToken },
             );
             const nextDocument = mapDocument(created);
             setDocuments((current) => [nextDocument, ...current]);
@@ -267,7 +267,7 @@ export default function RecordsPage() {
             const result = await api.post<{ summary: string }>(
                 `/api/v1/documents/${selectedDocument.id}/explain`,
                 { language: lang },
-                { token: token ?? undefined },
+                { token: accessToken ?? undefined },
             );
             setExplanationText(result.summary);
         } catch {

--- a/apps/patient-portal/src/app/(app)/today/page.tsx
+++ b/apps/patient-portal/src/app/(app)/today/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { HiOutlineCalendarDays, HiOutlineCheck } from "react-icons/hi2";
 import { CircularProgress, MedicationCard, ObligationCard } from "@/components/features";
 import { Badge, Card, EmptyState, Skeleton } from "@/components/ui";
 import { useFeedData } from "@/hooks/use-feed-data";
@@ -97,7 +98,7 @@ export default function TodayPage() {
                 {tasks.length === 0 ? (
                     <EmptyState
                         description="Your clinicians have not assigned anything for today."
-                        icon="🗓️"
+                        icon={<HiOutlineCalendarDays />}
                         title="Nothing scheduled"
                     />
                 ) : null}
@@ -118,7 +119,7 @@ export default function TodayPage() {
                         return (
                             <div className="relative pb-6 last:pb-0" key={task.id}>
                                 <span className={`absolute -left-[34px] top-5 flex h-5 w-5 items-center justify-center rounded-full border-4 border-white ${dotClasses}`}>
-                                    {status === "completed" ? "✓" : null}
+                                    {status === "completed" ? <HiOutlineCheck className="h-3.5 w-3.5" /> : null}
                                 </span>
                                 <p className={`mb-2 text-xs font-medium ${status === "active" ? "text-sky-700" : "text-slate-400"}`}>
                                     {formatTimeLabel(task.scheduledTime, task.status)}
@@ -140,7 +141,7 @@ export default function TodayPage() {
                     return (
                         <div className="relative pb-6 last:pb-0" key={task.id}>
                             <span className={`absolute -left-[34px] top-5 flex h-5 w-5 items-center justify-center rounded-full border-4 border-white ${dotClasses}`}>
-                                {status === "completed" ? "✓" : null}
+                                {status === "completed" ? <HiOutlineCheck className="h-3.5 w-3.5" /> : null}
                             </span>
                             <p className={`mb-2 text-xs font-medium ${status === "active" ? "text-sky-700" : "text-slate-400"}`}>
                                 {formatTimeLabel(task.scheduledTime, task.status)}

--- a/apps/patient-portal/src/app/(app)/visits/page.tsx
+++ b/apps/patient-portal/src/app/(app)/visits/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { HiOutlineCalendarDays } from "react-icons/hi2";
 import { PageHeader } from "@/components/layouts";
 import { Badge, Button, Card, EmptyState, Modal } from "@/components/ui";
 import type { Appointment } from "@/types";
@@ -45,7 +46,11 @@ export default function VisitsPage() {
                     </Card>
                 ) : null}
                 {appointments.length === 0 ? (
-                    <EmptyState description="Your upcoming appointments will appear here." icon="📅" title="No visits scheduled" />
+                    <EmptyState
+                        description="Your upcoming appointments will appear here."
+                        icon={<HiOutlineCalendarDays />}
+                        title="No visits scheduled"
+                    />
                 ) : null}
                 {appointments.map((appointment) => (
                     <button className="w-full text-left" key={appointment.id} onClick={() => setSelected(appointment)} type="button">

--- a/apps/patient-portal/src/app/(auth)/onboarding/page.tsx
+++ b/apps/patient-portal/src/app/(auth)/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useDispatch, useSelector } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
@@ -10,33 +10,31 @@ import type { AppDispatch, RootState } from "@/store/store";
 
 export default function OnboardingPage() {
     const router = useRouter();
-    const token = useSelector((state: RootState) => state.auth.token);
+    const accessToken = useSelector((state: RootState) => state.auth.accessToken);
     const profileDraft = useSelector((state: RootState) => state.onboarding.profileDraft);
     const dispatch = useDispatch<AppDispatch>();
+    const [error, setError] = useState("");
+    const [submitting, setSubmitting] = useState(false);
     const [step, setStep] = useState(1);
-    const [formData, setFormData] = useState({
+    const [formData, setFormData] = useState(() => ({
         allergies: "",
         conditions: "",
-        dateOfBirth: "",
-        firstName: "",
+        dateOfBirth: profileDraft?.dateOfBirth ?? "",
+        firstName: profileDraft?.firstName ?? "",
         gender: "",
         inviteCode: "",
         language: "en",
-        lastName: "",
-    });
-
-    useEffect(() => {
-        if (!profileDraft) {
-            return;
-        }
-        setFormData((current) => ({ ...current, ...profileDraft }));
-    }, [profileDraft]);
+        lastName: profileDraft?.lastName ?? "",
+    }));
 
     async function handleFinish() {
-        if (!token) {
+        if (!accessToken) {
             router.replace("/login");
             return;
         }
+
+        setSubmitting(true);
+        setError("");
 
         try {
             await api.put(
@@ -47,26 +45,37 @@ export default function OnboardingPage() {
                     last_name: formData.lastName,
                     preferred_language: formData.language,
                 },
-                { token },
+                { token: accessToken },
             );
 
             if (formData.inviteCode.trim()) {
-                await api.post(
+                await api.post<{ clinician_first_name: string }>(
                     `/api/v1/patients/me/care-team/join?invite_code=${encodeURIComponent(formData.inviteCode.trim())}`,
                     undefined,
-                    { token },
+                    { token: accessToken },
                 );
             }
-        } catch {
-            // Keep onboarding resilient even while backend support for all fields is still evolving.
-        } finally {
-            dispatch(clearOnboardingProfile());
-            router.replace("/today");
+        } catch (submissionError) {
+            setError((submissionError as Error).message);
+            setSubmitting(false);
+            return;
+        }
+
+        dispatch(clearOnboardingProfile());
+        router.replace("/today");
+    }
+    function updateField(field: keyof typeof formData, value: string) {
+        setFormData((current) => ({ ...current, [field]: value }));
+        if (error) {
+            setError("");
         }
     }
 
-    function updateField(field: keyof typeof formData, value: string) {
-        setFormData((current) => ({ ...current, [field]: value }));
+    function handleContinueAfterInviteError() {
+        updateField("inviteCode", "");
+        setSubmitting(false);
+        dispatch(clearOnboardingProfile());
+        router.replace("/today");
     }
 
     return (
@@ -86,7 +95,7 @@ export default function OnboardingPage() {
             </div>
 
             <div className="-mt-4 px-5">
-            <Card className="space-y-6 shadow-lg shadow-slate-100" padding="lg">
+                <Card className="space-y-6 shadow-lg shadow-slate-100" padding="lg">
                 {step === 1 ? (
                     <div className="space-y-4">
                         <div>
@@ -142,17 +151,32 @@ export default function OnboardingPage() {
                     </div>
                 ) : null}
 
+                {error ? (
+                    <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                        {error}
+                    </div>
+                ) : null}
+
                 <div className="flex items-center justify-between gap-3">
-                    <Button disabled={step === 1} onClick={() => setStep((current) => Math.max(1, current - 1))} variant="secondary">
+                    <Button disabled={step === 1 || submitting} onClick={() => setStep((current) => Math.max(1, current - 1))} variant="secondary">
                         Back
                     </Button>
                     {step < 4 ? (
-                        <Button onClick={() => setStep((current) => Math.min(4, current + 1))}>Next</Button>
+                        <Button disabled={submitting} onClick={() => setStep((current) => Math.min(4, current + 1))}>Next</Button>
                     ) : (
-                        <Button onClick={handleFinish}>Finish setup</Button>
+                        <div className="flex items-center gap-3">
+                            {error && formData.inviteCode.trim() ? (
+                                <Button disabled={submitting} onClick={handleContinueAfterInviteError} variant="secondary">
+                                    Skip clinic for now
+                                </Button>
+                            ) : null}
+                            <Button disabled={submitting} onClick={handleFinish}>
+                                {submitting ? "Saving..." : "Finish setup"}
+                            </Button>
+                        </div>
                     )}
                 </div>
-            </Card>
+                </Card>
             </div>
         </div>
     );

--- a/apps/patient-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/patient-portal/src/app/(auth)/signup/page.tsx
@@ -6,15 +6,16 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
 import { api } from "@/services/api";
-import { hydrateSession } from "@/store/slices/auth-slice";
+import { writeStoredSession } from "@/services/auth-session";
+import { hydrateSession, type PatientAuthSession } from "@/store/slices/auth-slice";
 import { setOnboardingProfile } from "@/store/slices/onboarding-slice";
 import type { AppDispatch } from "@/store/store";
-
-const authStorageKey = "mediagent-patient-auth";
 
 interface SignupResponse {
     tokens: {
         access_token: string;
+        expires_at: number;
+        refresh_token: string;
     };
     user: {
         email: string;
@@ -54,8 +55,17 @@ export default function SignupPage() {
                 password: formData.password,
             });
 
-            const session = { token: response.tokens.access_token, user: response.user };
-            window.localStorage.setItem(authStorageKey, JSON.stringify(session));
+            if (response.user.role !== "patient") {
+                throw new Error("Signup did not create a patient account.");
+            }
+
+            const session: PatientAuthSession = {
+                accessToken: response.tokens.access_token,
+                expiresAt: response.tokens.expires_at,
+                refreshToken: response.tokens.refresh_token,
+                user: { ...response.user, role: "patient" },
+            };
+            writeStoredSession(session);
             dispatch(
                 setOnboardingProfile({
                     dateOfBirth: formData.dateOfBirth,

--- a/apps/patient-portal/src/app/login/page.tsx
+++ b/apps/patient-portal/src/app/login/page.tsx
@@ -6,15 +6,15 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
 import { api } from "@/services/api";
-import { hydrateSession } from "@/store/slices/auth-slice";
+import { writeStoredSession } from "@/services/auth-session";
+import { hydrateSession, type PatientAuthSession } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
-
-const storageKey = "mediagent-patient-auth";
-const isDevelopment = process.env.NODE_ENV === "development";
 
 interface AuthResponse {
     tokens: {
         access_token: string;
+        expires_at: number;
+        refresh_token: string;
     };
     user: {
         email: string;
@@ -26,8 +26,8 @@ interface AuthResponse {
 export default function LoginPage() {
     const router = useRouter();
     const dispatch = useDispatch<AppDispatch>();
-    const [email, setEmail] = useState(isDevelopment ? "sarah@example.com" : "");
-    const [password, setPassword] = useState(isDevelopment ? "password123" : "");
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
     const [error, setError] = useState("");
     const [submitting, setSubmitting] = useState(false);
 
@@ -41,9 +41,13 @@ export default function LoginPage() {
             if (response.user.role !== "patient") {
                 throw new Error("This login belongs to a clinician account.");
             }
-
-            const session = { token: response.tokens.access_token, user: response.user };
-            window.localStorage.setItem(storageKey, JSON.stringify(session));
+            const session: PatientAuthSession = {
+                accessToken: response.tokens.access_token,
+                expiresAt: response.tokens.expires_at,
+                refreshToken: response.tokens.refresh_token,
+                user: { ...response.user, role: "patient" },
+            };
+            writeStoredSession(session);
             dispatch(hydrateSession(session));
             router.replace("/today");
         } catch (submissionError) {

--- a/apps/patient-portal/src/components/features/document-card.tsx
+++ b/apps/patient-portal/src/components/features/document-card.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+import { HiOutlineChevronRight } from "react-icons/hi2";
 import { Badge, Card } from "@/components/ui";
 
 interface DocumentCardProps {
@@ -6,7 +8,7 @@ interface DocumentCardProps {
     type: string;
     date: string;
     provider: string;
-    icon: string;
+    icon: ReactNode;
     hasAiSummary: boolean;
     statusLabel?: string;
     statusVariant?: "success" | "warning" | "danger" | "info" | "neutral";
@@ -39,7 +41,7 @@ export function DocumentCard({
                         <div className="flex items-center gap-2">
                             {statusLabel ? <Badge variant={statusVariant}>{statusLabel}</Badge> : null}
                             {!statusLabel && hasAiSummary ? <Badge variant="info">AI Summary</Badge> : null}
-                            <span className="text-sm text-slate-300">→</span>
+                            <HiOutlineChevronRight className="text-sm text-slate-300" />
                         </div>
                     </div>
                     <div className="flex items-center gap-2 text-xs text-slate-500">

--- a/apps/patient-portal/src/components/layouts/bottom-nav.tsx
+++ b/apps/patient-portal/src/components/layouts/bottom-nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import type { ReactNode } from "react";
+import { HiSparkles } from "react-icons/hi2";
 
 interface BottomNavProps {
     currentPath: string;
@@ -89,7 +90,7 @@ export function BottomNav({ currentPath }: BottomNavProps) {
                 className="flex h-14 w-14 -translate-y-5 items-center justify-center rounded-full border-4 border-white bg-sky-700 text-2xl text-white shadow-[0_10px_18px_-8px_rgba(2,132,199,0.65)]"
                 href="/chat"
             >
-                ✦
+                <HiSparkles className="h-6 w-6" />
             </Link>
             <NavItem active={currentPath === "/visits"} href="/visits" icon={<CalendarIcon active={currentPath === "/visits"} />} label="Visits" />
             <NavItem active={currentPath === "/profile"} href="/profile" icon={<UserIcon active={currentPath === "/profile"} />} label="Profile" />

--- a/apps/patient-portal/src/components/ui/empty-state.tsx
+++ b/apps/patient-portal/src/components/ui/empty-state.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from "react";
+import { HiOutlineInbox } from "react-icons/hi2";
 
 interface EmptyStateProps {
-    icon: string;
+    icon?: ReactNode;
     title: string;
     description?: string;
     action?: ReactNode;
@@ -10,7 +11,7 @@ interface EmptyStateProps {
 export function EmptyState({ action, description, icon, title }: EmptyStateProps) {
     return (
         <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-gray-300 bg-white px-6 py-10 text-center shadow-sm">
-            <span className="text-4xl">{icon}</span>
+            <span className="text-4xl text-slate-400">{icon ?? <HiOutlineInbox />}</span>
             <div className="space-y-1">
                 <h3 className="text-base font-semibold text-gray-900">{title}</h3>
                 {description ? <p className="text-sm text-gray-500">{description}</p> : null}

--- a/apps/patient-portal/src/components/ui/error-state.tsx
+++ b/apps/patient-portal/src/components/ui/error-state.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from "react";
+import { HiOutlineExclamationTriangle } from "react-icons/hi2";
 
 interface ErrorStateProps {
     title?: string;
     description?: string;
-    icon?: string;
+    icon?: ReactNode;
     onRetry?: () => void;
     action?: ReactNode;
 }
@@ -11,13 +12,13 @@ interface ErrorStateProps {
 export function ErrorState({
     action,
     description = "Something went wrong. Please try again.",
-    icon = "⚠️",
+    icon = <HiOutlineExclamationTriangle />,
     onRetry,
     title = "Error",
 }: ErrorStateProps) {
     return (
         <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-red-200 bg-red-50 px-6 py-10 text-center shadow-sm">
-            <span className="text-4xl">{icon}</span>
+            <span className="text-4xl text-red-500">{icon}</span>
             <div className="space-y-1">
                 <h3 className="text-base font-semibold text-gray-900">{title}</h3>
                 <p className="text-sm text-gray-600">{description}</p>

--- a/apps/patient-portal/src/hooks/use-feed-data.ts
+++ b/apps/patient-portal/src/hooks/use-feed-data.ts
@@ -99,22 +99,22 @@ function getMissedTaskIds(tasks: FeedTask[]) {
 export function useFeedData() {
     const dispatch = useDispatch<AppDispatch>();
     const feed = useSelector((state: RootState) => state.feed);
-    const token = useSelector((state: RootState) => state.auth.token);
+    const accessToken = useSelector((state: RootState) => state.auth.accessToken);
     const [adherenceStats, setAdherenceStats] = useState<AdherenceStats>(mockAdherenceStats);
 
     useEffect(() => {
-        dispatch(fetchTodayFeed({ token }))
+        dispatch(fetchTodayFeed({ token: accessToken }))
             .unwrap()
             .catch(() => {
                 dispatch(loadMockFeed({ summary: mockFeedSummary, tasks: mockFeedTasks }));
             });
-    }, [dispatch, token]);
+    }, [accessToken, dispatch]);
 
     useEffect(() => {
-        api.get<AdherenceStats>("/api/v1/adherence/stats", { token: token ?? undefined })
+        api.get<AdherenceStats>("/api/v1/adherence/stats", { token: accessToken ?? undefined })
             .then((response) => setAdherenceStats(response))
             .catch(() => setAdherenceStats(mockAdherenceStats));
-    }, [token]);
+    }, [accessToken]);
 
     useEffect(() => {
         const missedIds = getMissedTaskIds(feed.tasks);
@@ -127,7 +127,7 @@ export function useFeedData() {
         const completedAt = new Date().toISOString();
         dispatch(markTaskComplete({ completedAt, taskId: task.id }));
 
-        if (!token) {
+        if (!accessToken) {
             return;
         }
 
@@ -139,7 +139,7 @@ export function useFeedData() {
                     target_id: task.targetId,
                     target_type: task.type,
                 },
-                { token },
+                { token: accessToken },
             );
         } catch {
             // Keep optimistic UI state even when backend is unavailable.

--- a/apps/patient-portal/src/services/auth-session.ts
+++ b/apps/patient-portal/src/services/auth-session.ts
@@ -1,98 +1,20 @@
+import { createAuthSessionStorage } from "../../../../packages/shared/src/utils/auth-session";
 import type { PatientAuthSession, PatientAuthUser } from "@/store/slices/auth-slice";
 
-export const PATIENT_AUTH_STORAGE_KEY = "mediagent-patient-auth";
-const REFRESH_WINDOW_SECONDS = 60;
+const patientAuthSessionStorage = createAuthSessionStorage<
+    "patient",
+    PatientAuthUser,
+    PatientAuthSession
+>({
+    role: "patient",
+    storageKey: "mediagent-patient-auth",
+});
 
-interface LegacyStoredSession {
-    token?: string | null;
-    refreshToken?: string | null;
-    expiresAt?: number | null;
-    user?: PatientAuthUser | null;
-}
-
-interface RestoreSessionParams {
-    refreshSession: (refreshToken: string) => Promise<PatientAuthSession>;
-}
-
-function normalizeStoredSession(value: string | null): PatientAuthSession | null {
-    if (!value) {
-        return null;
-    }
-
-    try {
-        const parsed = JSON.parse(value) as PatientAuthSession | LegacyStoredSession;
-        const user = parsed.user;
-        if (!user || user.role !== "patient") {
-            return null;
-        }
-
-        if ("accessToken" in parsed && "refreshToken" in parsed && "expiresAt" in parsed) {
-            if (!parsed.accessToken || !parsed.refreshToken || !parsed.expiresAt) {
-                return null;
-            }
-
-            return {
-                accessToken: parsed.accessToken,
-                refreshToken: parsed.refreshToken,
-                expiresAt: parsed.expiresAt,
-                user,
-            };
-        }
-
-        if (!parsed.token || !parsed.refreshToken || !parsed.expiresAt) {
-            return null;
-        }
-
-        return {
-            accessToken: parsed.token,
-            refreshToken: parsed.refreshToken,
-            expiresAt: parsed.expiresAt,
-            user,
-        };
-    } catch {
-        return null;
-    }
-}
-
-export function isSessionExpiring(expiresAt: number, nowSeconds = Math.floor(Date.now() / 1000)) {
-    return expiresAt - nowSeconds <= REFRESH_WINDOW_SECONDS;
-}
-
-export function readStoredSession() {
-    return normalizeStoredSession(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY));
-}
-
-export function writeStoredSession(session: PatientAuthSession) {
-    window.localStorage.setItem(PATIENT_AUTH_STORAGE_KEY, JSON.stringify(session));
-}
-
-export function clearStoredSession() {
-    window.localStorage.removeItem(PATIENT_AUTH_STORAGE_KEY);
-}
-
-export async function restoreStoredSession({
-    refreshSession,
-}: RestoreSessionParams): Promise<PatientAuthSession | null> {
-    const storedSession = readStoredSession();
-    if (!storedSession) {
-        clearStoredSession();
-        return null;
-    }
-
-    if (!isSessionExpiring(storedSession.expiresAt)) {
-        return storedSession;
-    }
-
-    try {
-        const refreshedSession = await refreshSession(storedSession.refreshToken);
-        if (refreshedSession.user.role !== "patient") {
-            clearStoredSession();
-            return null;
-        }
-        writeStoredSession(refreshedSession);
-        return refreshedSession;
-    } catch {
-        clearStoredSession();
-        return null;
-    }
-}
+export const PATIENT_AUTH_STORAGE_KEY = patientAuthSessionStorage.storageKey;
+export const {
+    clearStoredSession,
+    isSessionExpiring,
+    readStoredSession,
+    restoreStoredSession,
+    writeStoredSession,
+} = patientAuthSessionStorage;

--- a/apps/patient-portal/src/services/auth-session.ts
+++ b/apps/patient-portal/src/services/auth-session.ts
@@ -1,0 +1,98 @@
+import type { PatientAuthSession, PatientAuthUser } from "@/store/slices/auth-slice";
+
+export const PATIENT_AUTH_STORAGE_KEY = "mediagent-patient-auth";
+const REFRESH_WINDOW_SECONDS = 60;
+
+interface LegacyStoredSession {
+    token?: string | null;
+    refreshToken?: string | null;
+    expiresAt?: number | null;
+    user?: PatientAuthUser | null;
+}
+
+interface RestoreSessionParams {
+    refreshSession: (refreshToken: string) => Promise<PatientAuthSession>;
+}
+
+function normalizeStoredSession(value: string | null): PatientAuthSession | null {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(value) as PatientAuthSession | LegacyStoredSession;
+        const user = parsed.user;
+        if (!user || user.role !== "patient") {
+            return null;
+        }
+
+        if ("accessToken" in parsed && "refreshToken" in parsed && "expiresAt" in parsed) {
+            if (!parsed.accessToken || !parsed.refreshToken || !parsed.expiresAt) {
+                return null;
+            }
+
+            return {
+                accessToken: parsed.accessToken,
+                refreshToken: parsed.refreshToken,
+                expiresAt: parsed.expiresAt,
+                user,
+            };
+        }
+
+        if (!parsed.token || !parsed.refreshToken || !parsed.expiresAt) {
+            return null;
+        }
+
+        return {
+            accessToken: parsed.token,
+            refreshToken: parsed.refreshToken,
+            expiresAt: parsed.expiresAt,
+            user,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function isSessionExpiring(expiresAt: number, nowSeconds = Math.floor(Date.now() / 1000)) {
+    return expiresAt - nowSeconds <= REFRESH_WINDOW_SECONDS;
+}
+
+export function readStoredSession() {
+    return normalizeStoredSession(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY));
+}
+
+export function writeStoredSession(session: PatientAuthSession) {
+    window.localStorage.setItem(PATIENT_AUTH_STORAGE_KEY, JSON.stringify(session));
+}
+
+export function clearStoredSession() {
+    window.localStorage.removeItem(PATIENT_AUTH_STORAGE_KEY);
+}
+
+export async function restoreStoredSession({
+    refreshSession,
+}: RestoreSessionParams): Promise<PatientAuthSession | null> {
+    const storedSession = readStoredSession();
+    if (!storedSession) {
+        clearStoredSession();
+        return null;
+    }
+
+    if (!isSessionExpiring(storedSession.expiresAt)) {
+        return storedSession;
+    }
+
+    try {
+        const refreshedSession = await refreshSession(storedSession.refreshToken);
+        if (refreshedSession.user.role !== "patient") {
+            clearStoredSession();
+            return null;
+        }
+        writeStoredSession(refreshedSession);
+        return refreshedSession;
+    } catch {
+        clearStoredSession();
+        return null;
+    }
+}

--- a/apps/patient-portal/src/store/provider.tsx
+++ b/apps/patient-portal/src/store/provider.tsx
@@ -25,7 +25,10 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                             id: string;
                             role: "patient" | "clinician";
                         };
-                    }>("/api/v1/auth/refresh", { refresh_token: refreshToken });
+                    }>("/api/v1/auth/refresh", {
+                        expected_role: "patient",
+                        refresh_token: refreshToken,
+                    });
 
                     if (response.user.role !== "patient") {
                         throw new Error("This session belongs to a clinician account.");

--- a/apps/patient-portal/src/store/provider.tsx
+++ b/apps/patient-portal/src/store/provider.tsx
@@ -1,35 +1,66 @@
 "use client";
 
 import { useEffect } from "react";
+import { api } from "@/services/api";
+import { clearStoredSession, restoreStoredSession } from "@/services/auth-session";
 import { Provider } from "react-redux";
-import { finishHydration, hydrateSession, type PatientAuthUser } from "./slices/auth-slice";
+import { finishHydration, hydrateSession, type PatientAuthSession } from "./slices/auth-slice";
 import { store } from "./store";
-
-const PATIENT_AUTH_STORAGE_KEY = "mediagent-patient-auth";
 
 export function StoreProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
-        try {
-            const storedValue = window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY);
-            if (!storedValue) {
+        let isMounted = true;
+
+        async function bootstrapAuth() {
+            const session = await restoreStoredSession({
+                refreshSession: async (refreshToken) => {
+                    const response = await api.post<{
+                        tokens: {
+                            access_token: string;
+                            refresh_token: string;
+                            expires_at: number;
+                        };
+                        user: {
+                            email: string;
+                            id: string;
+                            role: "patient" | "clinician";
+                        };
+                    }>("/api/v1/auth/refresh", { refresh_token: refreshToken });
+
+                    if (response.user.role !== "patient") {
+                        throw new Error("This session belongs to a clinician account.");
+                    }
+
+                    return {
+                        accessToken: response.tokens.access_token,
+                        expiresAt: response.tokens.expires_at,
+                        refreshToken: response.tokens.refresh_token,
+                        user: {
+                            email: response.user.email,
+                            id: response.user.id,
+                            role: "patient",
+                        },
+                    } satisfies PatientAuthSession;
+                },
+            });
+
+            if (!isMounted) {
+                return;
+            }
+
+            if (session) {
+                store.dispatch(hydrateSession(session));
+            } else {
+                clearStoredSession();
                 store.dispatch(finishHydration());
-                return;
             }
-
-            const parsed = JSON.parse(storedValue) as {
-                token: string | null;
-                user: PatientAuthUser;
-            };
-
-            if (parsed.user) {
-                store.dispatch(hydrateSession(parsed));
-                return;
-            }
-        } catch {
-            window.localStorage.removeItem(PATIENT_AUTH_STORAGE_KEY);
         }
 
-        store.dispatch(finishHydration());
+        void bootstrapAuth();
+
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
     return <Provider store={store}>{children}</Provider>;

--- a/apps/patient-portal/src/store/slices/auth-slice.ts
+++ b/apps/patient-portal/src/store/slices/auth-slice.ts
@@ -4,19 +4,30 @@ import { createSlice } from "@reduxjs/toolkit";
 export interface PatientAuthUser {
     id: string;
     email: string;
-    role: "patient" | "clinician";
+    role: "patient";
+}
+
+export interface PatientAuthSession {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    user: PatientAuthUser;
 }
 
 interface AuthState {
     user: PatientAuthUser | null;
-    token: string | null;
+    accessToken: string | null;
+    refreshToken: string | null;
+    expiresAt: number | null;
     isAuthenticated: boolean;
     loading: boolean;
 }
 
 const initialState: AuthState = {
     user: null,
-    token: null,
+    accessToken: null,
+    refreshToken: null,
+    expiresAt: null,
     isAuthenticated: false,
     loading: true,
 };
@@ -27,10 +38,12 @@ export const authSlice = createSlice({
     reducers: {
         hydrateSession: (
             state,
-            action: PayloadAction<{ token: string | null; user: PatientAuthUser } | null>,
+            action: PayloadAction<PatientAuthSession | null>,
         ) => {
             state.user = action.payload?.user ?? null;
-            state.token = action.payload?.token ?? null;
+            state.accessToken = action.payload?.accessToken ?? null;
+            state.refreshToken = action.payload?.refreshToken ?? null;
+            state.expiresAt = action.payload?.expiresAt ?? null;
             state.isAuthenticated = !!action.payload?.user;
             state.loading = false;
         },
@@ -39,19 +52,28 @@ export const authSlice = createSlice({
             state.isAuthenticated = !!action.payload;
             state.loading = false;
         },
-        setToken: (state, action: PayloadAction<string | null>) => {
-            state.token = action.payload;
+        setAccessToken: (state, action: PayloadAction<string | null>) => {
+            state.accessToken = action.payload;
+        },
+        setRefreshToken: (state, action: PayloadAction<string | null>) => {
+            state.refreshToken = action.payload;
+        },
+        setExpiresAt: (state, action: PayloadAction<number | null>) => {
+            state.expiresAt = action.payload;
         },
         finishHydration: (state) => {
             state.loading = false;
         },
         logout: (state) => {
             state.user = null;
-            state.token = null;
+            state.accessToken = null;
+            state.refreshToken = null;
+            state.expiresAt = null;
             state.isAuthenticated = false;
             state.loading = false;
         },
     },
 });
 
-export const { hydrateSession, setUser, setToken, finishHydration, logout } = authSlice.actions;
+export const { hydrateSession, setUser, setAccessToken, setRefreshToken, setExpiresAt, finishHydration, logout } =
+    authSlice.actions;

--- a/backend/cleanup-policy.json
+++ b/backend/cleanup-policy.json
@@ -1,11 +1,27 @@
-{
-  "name": "keep-latest-only",
-  "action": "DELETE",
-  "condition": {
-    "tagState": "ANY",
-    "olderThan": "0s"
+[
+  {
+    "name": "keep-most-recent-backend-image",
+    "action": {
+      "type": "Keep"
+    },
+    "mostRecentVersions": {
+      "packageNamePrefixes": [
+        "mediagent-backend"
+      ],
+      "keepCount": 1
+    }
   },
-  "mostRecentVersions": {
-    "keepCount": 1
+  {
+    "name": "delete-old-untagged-backend-images",
+    "action": {
+      "type": "Delete"
+    },
+    "condition": {
+      "tagState": "untagged",
+      "olderThan": "1d",
+      "packageNamePrefixes": [
+        "mediagent-backend"
+      ]
+    }
   }
-}
+]

--- a/backend/src/app/models/auth.py
+++ b/backend/src/app/models/auth.py
@@ -8,11 +8,14 @@ request validation; the service returns these for responses.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, EmailStr, Field
 
 from app.models.enums import Language
+
+AuthRole = Literal["patient", "clinician"]
 
 # ── Requests ────────────────────────────────────────────────
 
@@ -55,6 +58,7 @@ class TokenRefreshRequest(BaseModel):
     """Exchange a refresh token for a new access token."""
 
     refresh_token: str = Field(..., min_length=1)
+    expected_role: AuthRole | None = None
 
 
 class PasswordResetRequest(BaseModel):
@@ -80,7 +84,7 @@ class UserInfo(BaseModel):
 
     id: UUID
     email: str
-    role: str = Field(description="'patient' or 'clinician'")
+    role: AuthRole = Field(description="'patient' or 'clinician'")
     created_at: datetime | None = None
 
     model_config = {"from_attributes": True}

--- a/backend/src/app/routers/auth.py
+++ b/backend/src/app/routers/auth.py
@@ -120,7 +120,10 @@ async def refresh_token(
     body: TokenRefreshRequest,
     service: AuthService = Depends(_get_auth_service),
 ) -> AuthResponse:
-    result = await service.refresh_token(body.refresh_token)
+    result = await service.refresh_token(
+        body.refresh_token,
+        expected_role=body.expected_role,
+    )
     return AuthResponse(
         tokens=AuthTokens(**result["tokens"]),
         user=UserInfo(**result["user"]),

--- a/backend/src/app/routers/clinicians.py
+++ b/backend/src/app/routers/clinicians.py
@@ -14,7 +14,7 @@ from supabase import Client
 from app.core.security import require_role
 from app.db.connection import get_db
 from app.models.auth import CurrentUser
-from app.models.clinician import ClinicianRead
+from app.models.clinician import ClinicianRead, ClinicianUpdate
 from app.models.patient import PatientRead
 from app.services.clinician_service import ClinicianService
 
@@ -33,6 +33,15 @@ async def get_my_profile(
     service: ClinicianService = Depends(_get_service),
 ) -> Any:
     return await service.get_profile(user.id)
+
+
+@router.put("/me", response_model=ClinicianRead, summary="Update my clinician profile")
+async def update_my_profile(
+    data: ClinicianUpdate,
+    user: CurrentUser = Depends(_clinician_dep),
+    service: ClinicianService = Depends(_get_service),
+) -> Any:
+    return await service.update_profile(user.id, data.model_dump(exclude_unset=True))
 
 
 @router.get(

--- a/backend/src/app/services/auth_service.py
+++ b/backend/src/app/services/auth_service.py
@@ -23,6 +23,7 @@ from supabase import Client
 from app.core.exceptions import AuthenticationError, ValidationError
 
 logger = logging.getLogger(__name__)
+_SUPPORTED_ROLES = {"patient", "clinician"}
 
 
 class AuthService:
@@ -81,7 +82,16 @@ class AuthService:
             self.db.auth.admin.delete_user(user_id)
             raise ValidationError(f"Profile creation failed: {e}") from e
 
-        return self._format_session(auth_response)
+        try:
+            return self._sign_in_and_format(
+                email=email,
+                password=password,
+                expected_role="patient",
+            )
+        except Exception as e:
+            logger.error("Failed to finalize patient signup for %s: %s", user_id, e)
+            self._cleanup_signup("patients", user_id)
+            raise
 
     async def signup_clinician(
         self,
@@ -123,24 +133,22 @@ class AuthService:
             self.db.auth.admin.delete_user(user_id)
             raise ValidationError(f"Profile creation failed: {e}") from e
 
-        return self._format_session(auth_response)
+        try:
+            return self._sign_in_and_format(
+                email=email,
+                password=password,
+                expected_role="clinician",
+            )
+        except Exception as e:
+            logger.error("Failed to finalize clinician signup for %s: %s", user_id, e)
+            self._cleanup_signup("clinicians", user_id)
+            raise
 
     # ── Login ───────────────────────────────────────────────
 
     async def login(self, email: str, password: str) -> Any:
         """Authenticate with email + password. Works for both roles."""
-        try:
-            response = self.db.auth.sign_in_with_password(
-                {
-                    "email": email,
-                    "password": password,
-                }
-            )
-        except Exception as e:
-            logger.warning("Login failed for %s: %s", email, e)
-            raise AuthenticationError("Invalid email or password") from None
-
-        return self._format_session(response)
+        return self._sign_in_and_format(email=email, password=password)
 
     # ── Token Refresh ───────────────────────────────────────
 
@@ -166,14 +174,62 @@ class AuthService:
 
     # ── Helpers ─────────────────────────────────────────────
 
+    def _sign_in_and_format(
+        self,
+        *,
+        email: str,
+        password: str,
+        expected_role: str | None = None,
+    ) -> Any:
+        """Sign in with email/password and validate the returned role."""
+        try:
+            response = self.db.auth.sign_in_with_password(
+                {
+                    "email": email,
+                    "password": password,
+                }
+            )
+        except Exception as e:
+            logger.warning("Login failed for %s: %s", email, e)
+            raise AuthenticationError("Invalid email or password") from None
+
+        return self._format_session(response, expected_role=expected_role)
+
+    def _cleanup_signup(self, profile_table: str, user_id: str) -> None:
+        """Best-effort rollback for partially created signup records."""
+        try:
+            self.db.table(profile_table).delete().eq("id", user_id).execute()
+        except Exception as e:
+            logger.warning("Failed to delete %s profile for %s: %s", profile_table, user_id, e)
+
+        try:
+            self.db.auth.admin.delete_user(user_id)
+        except Exception as e:
+            logger.warning("Failed to delete auth user %s during rollback: %s", user_id, e)
+
     @staticmethod
-    def _format_session(response: Any) -> Any:
+    def _validate_role(role: str, expected_role: str | None = None) -> str:
+        """Reject unknown roles and mismatched role expectations."""
+        if role not in _SUPPORTED_ROLES:
+            raise AuthenticationError("Authentication failed — invalid user role")
+        if expected_role and role != expected_role:
+            raise AuthenticationError(
+                f"Authentication failed — expected '{expected_role}' role but received '{role}'"
+            )
+        return role
+
+    @classmethod
+    def _format_session(cls, response: Any, expected_role: str | None = None) -> Any:
         """Normalize Supabase auth response into our standard shape."""
         session = response.session
         user = response.user
 
         if not session or not user:
             raise AuthenticationError("Authentication failed — no session returned")
+
+        role = cls._validate_role(
+            (user.app_metadata or {}).get("user_role", "unknown"), expected_role
+        )
 
         return {
             "tokens": {
@@ -185,7 +241,7 @@ class AuthService:
             "user": {
                 "id": str(user.id),
                 "email": user.email or "",
-                "role": (user.app_metadata or {}).get("user_role", "unknown"),
+                "role": role,
                 "created_at": user.created_at,
             },
         }

--- a/backend/src/app/services/auth_service.py
+++ b/backend/src/app/services/auth_service.py
@@ -152,7 +152,11 @@ class AuthService:
 
     # ── Token Refresh ───────────────────────────────────────
 
-    async def refresh_token(self, refresh_token: str) -> Any:
+    async def refresh_token(
+        self,
+        refresh_token: str,
+        expected_role: str | None = None,
+    ) -> Any:
         """Exchange a refresh token for a new access token."""
         try:
             response = self.db.auth.refresh_session(refresh_token)
@@ -160,7 +164,7 @@ class AuthService:
             logger.warning("Token refresh failed: %s", e)
             raise AuthenticationError("Invalid or expired refresh token") from None
 
-        return self._format_session(response)
+        return self._format_session(response, expected_role=expected_role)
 
     # ── Password Reset ──────────────────────────────────────
 

--- a/backend/src/app/services/clinician_service.py
+++ b/backend/src/app/services/clinician_service.py
@@ -38,6 +38,17 @@ class ClinicianService:
             raise NotFoundError("Clinician", str(clinician_id))
         return result.data
 
+    async def update_profile(self, clinician_id: UUID, updates: dict[str, Any]) -> Any:
+        """Partial update for the clinician's own profile."""
+        clean = {key: value for key, value in updates.items() if value is not None}
+        if not clean:
+            return await self.get_profile(clinician_id)
+
+        result = self.db.table("clinicians").update(clean).eq("id", str(clinician_id)).execute()
+        if not result.data:
+            raise NotFoundError("Clinician", str(clinician_id))
+        return result.data[0]
+
     # ── Patient List ────────────────────────────────────
 
     async def get_patients(self, clinician_id: UUID) -> Any:

--- a/backend/tests/integration/routers/test_auth_api.py
+++ b/backend/tests/integration/routers/test_auth_api.py
@@ -183,18 +183,32 @@ class TestRefresh:
 
         response = client.post(
             "/api/v1/auth/refresh",
-            json={"refresh_token": "refresh-token-123"},
+            json={"expected_role": "patient", "refresh_token": "refresh-token-123"},
         )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["tokens"]["access_token"] == "patient-access-token"
+
+    def test_rejects_mismatched_expected_role(self, client, override_db, mock_supabase_db):
+        mock_supabase_db.auth.refresh_session.return_value = _make_auth_response(
+            user_id=str(uuid4()),
+            email="doctor@example.com",
+            role="clinician",
+        )
+
+        response = client.post(
+            "/api/v1/auth/refresh",
+            json={"expected_role": "patient", "refresh_token": "refresh-token-123"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_invalid_token(self, client, override_db, mock_supabase_db):
         mock_supabase_db.auth.refresh_session.side_effect = Exception("Invalid refresh")
 
         response = client.post(
             "/api/v1/auth/refresh",
-            json={"refresh_token": "bad-token"},
+            json={"expected_role": "patient", "refresh_token": "bad-token"},
         )
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/integration/routers/test_auth_api.py
+++ b/backend/tests/integration/routers/test_auth_api.py
@@ -1,0 +1,255 @@
+"""Integration tests for Auth API endpoints."""
+
+from unittest.mock import MagicMock, Mock
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+
+from app.core.security import get_current_user
+from app.db.connection import get_db
+from app.main import app
+from app.models.auth import CurrentUser
+
+
+@pytest.fixture
+def mock_supabase_db():
+    """Mock Supabase client with auth and table access."""
+    db = MagicMock()
+    db.auth = MagicMock()
+    db.auth.admin = MagicMock()
+    table = MagicMock()
+    db.table.return_value = table
+    for method in ["insert", "delete", "eq", "execute"]:
+        getattr(table, method).return_value = table
+    return db
+
+
+@pytest.fixture
+def override_db(mock_supabase_db):
+    """Override database dependency."""
+
+    def _get_db_override():
+        return mock_supabase_db
+
+    app.dependency_overrides[get_db] = _get_db_override
+    yield
+    app.dependency_overrides.clear()
+
+
+def _make_auth_response(*, user_id: str, email: str, role: str) -> Mock:
+    user = Mock()
+    user.id = user_id
+    user.email = email
+    user.created_at = "2026-01-01T00:00:00Z"
+    user.app_metadata = {"user_role": role}
+
+    session = Mock()
+    session.access_token = f"{role}-access-token"
+    session.refresh_token = f"{role}-refresh-token"
+    session.expires_at = 1234567890
+
+    response = Mock()
+    response.user = user
+    response.session = session
+    return response
+
+
+class TestPatientSignup:
+    def test_success(self, client, override_db, mock_supabase_db):
+        user_id = str(uuid4())
+        signup_response = Mock()
+        signup_response.user = Mock(id=user_id)
+        mock_supabase_db.auth.sign_up.return_value = signup_response
+        mock_supabase_db.auth.sign_in_with_password.return_value = _make_auth_response(
+            user_id=user_id,
+            email="patient@example.com",
+            role="patient",
+        )
+
+        response = client.post(
+            "/api/v1/auth/signup/patient",
+            json={
+                "email": "patient@example.com",
+                "password": "SecurePass123!",
+                "first_name": "Sarah",
+                "last_name": "Jones",
+                "date_of_birth": "1990-01-01",
+                "preferred_language": "en",
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["user"]["role"] == "patient"
+        assert data["tokens"]["refresh_token"] == "patient-refresh-token"
+
+    def test_duplicate_email(self, client, override_db, mock_supabase_db):
+        signup_response = Mock()
+        signup_response.user = None
+        mock_supabase_db.auth.sign_up.return_value = signup_response
+
+        response = client.post(
+            "/api/v1/auth/signup/patient",
+            json={
+                "email": "patient@example.com",
+                "password": "SecurePass123!",
+                "first_name": "Sarah",
+                "last_name": "Jones",
+                "date_of_birth": "1990-01-01",
+                "preferred_language": "en",
+            },
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestClinicianSignup:
+    def test_success(self, client, override_db, mock_supabase_db):
+        user_id = str(uuid4())
+        signup_response = Mock()
+        signup_response.user = Mock(id=user_id)
+        mock_supabase_db.auth.sign_up.return_value = signup_response
+        mock_supabase_db.auth.sign_in_with_password.return_value = _make_auth_response(
+            user_id=user_id,
+            email="doctor@example.com",
+            role="clinician",
+        )
+
+        response = client.post(
+            "/api/v1/auth/signup/clinician",
+            json={
+                "email": "doctor@example.com",
+                "password": "SecurePass123!",
+                "first_name": "Amir",
+                "last_name": "Khan",
+                "clinic_name": "City Health",
+                "specialty": "Primary Care",
+                "npi_number": "1234567890",
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["user"]["role"] == "clinician"
+
+
+class TestLogin:
+    def test_success_for_both_roles(self, client, override_db, mock_supabase_db):
+        mock_supabase_db.auth.sign_in_with_password.side_effect = [
+            _make_auth_response(
+                user_id=str(uuid4()),
+                email="patient@example.com",
+                role="patient",
+            ),
+            _make_auth_response(
+                user_id=str(uuid4()),
+                email="doctor@example.com",
+                role="clinician",
+            ),
+        ]
+
+        patient_response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "patient@example.com", "password": "SecurePass123!"},
+        )
+        clinician_response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "doctor@example.com", "password": "SecurePass123!"},
+        )
+
+        assert patient_response.status_code == status.HTTP_200_OK
+        assert patient_response.json()["user"]["role"] == "patient"
+        assert clinician_response.status_code == status.HTTP_200_OK
+        assert clinician_response.json()["user"]["role"] == "clinician"
+
+    def test_invalid_credentials(self, client, override_db, mock_supabase_db):
+        mock_supabase_db.auth.sign_in_with_password.side_effect = Exception("Invalid login")
+
+        response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "patient@example.com", "password": "wrong"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestRefresh:
+    def test_success(self, client, override_db, mock_supabase_db):
+        mock_supabase_db.auth.refresh_session.return_value = _make_auth_response(
+            user_id=str(uuid4()),
+            email="patient@example.com",
+            role="patient",
+        )
+
+        response = client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": "refresh-token-123"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["tokens"]["access_token"] == "patient-access-token"
+
+    def test_invalid_token(self, client, override_db, mock_supabase_db):
+        mock_supabase_db.auth.refresh_session.side_effect = Exception("Invalid refresh")
+
+        response = client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": "bad-token"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestPasswordReset:
+    def test_success(self, client, override_db, mock_supabase_db):
+        response = client.post(
+            "/api/v1/auth/password-reset",
+            json={"email": "patient@example.com"},
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_supabase_db.auth.reset_password_email.assert_called_once_with("patient@example.com")
+
+
+class TestGetMe:
+    def test_patient_success(self, client):
+        current_user = CurrentUser(
+            id=uuid4(),
+            email="patient@example.com",
+            role="patient",
+        )
+
+        def _get_current_user_override():
+            return current_user
+
+        app.dependency_overrides[get_current_user] = _get_current_user_override
+        try:
+            response = client.get("/api/v1/auth/me")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["role"] == "patient"
+
+    def test_clinician_success(self, client):
+        current_user = CurrentUser(
+            id=uuid4(),
+            email="doctor@example.com",
+            role="clinician",
+        )
+
+        def _get_current_user_override():
+            return current_user
+
+        app.dependency_overrides[get_current_user] = _get_current_user_override
+        try:
+            response = client.get("/api/v1/auth/me")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["role"] == "clinician"
+
+    def test_missing_auth(self, client):
+        response = client.get("/api/v1/auth/me")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/integration/routers/test_clinician_api.py
+++ b/backend/tests/integration/routers/test_clinician_api.py
@@ -35,7 +35,7 @@ def mock_supabase_db():
     db.table.return_value = table
 
     # Make all query methods chainable
-    for method in ["select", "eq", "single", "insert", "order"]:
+    for method in ["select", "eq", "single", "insert", "order", "update"]:
         getattr(table, method).return_value = table
 
     return db
@@ -151,6 +151,37 @@ class TestGetMyPatients:
         data = response.json()
         assert isinstance(data, list)
         assert len(data) == 0
+
+
+class TestUpdateMyProfile:
+    """PUT /api/v1/clinicians/me - Update clinician profile."""
+
+    def test_success(self, client, override_auth, override_db, mock_supabase_db, clinician_id):
+        updated_data = {
+            "id": str(clinician_id),
+            "email": "clinician@test.com",
+            "first_name": "Dr. Sarah",
+            "last_name": "Smith",
+            "specialty": "Internal Medicine",
+            "clinic_name": "City Health",
+            "npi_number": "1234567890",
+            "role": "provider",
+            "avatar_url": None,
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-15T00:00:00Z",
+        }
+
+        mock_supabase_db.table().update().eq().execute.return_value = MagicMock(data=[updated_data])
+
+        response = client.put(
+            "/api/v1/clinicians/me",
+            json={"specialty": "Internal Medicine", "clinic_name": "City Health"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["specialty"] == "Internal Medicine"
+        assert data["clinic_name"] == "City Health"
 
 
 class TestGetPatientDetail:

--- a/backend/tests/unit/services/test_auth_service.py
+++ b/backend/tests/unit/services/test_auth_service.py
@@ -332,7 +332,10 @@ async def test_refresh_token_success(auth_service, mock_supabase_client):
     mock_supabase_client.auth.refresh_session.return_value = mock_auth_response
 
     # Call refresh_token
-    result = await auth_service.refresh_token(refresh_token="old-refresh-token")
+    result = await auth_service.refresh_token(
+        refresh_token="old-refresh-token",
+        expected_role="patient",
+    )
 
     # Verify refresh_session was called
     mock_supabase_client.auth.refresh_session.assert_called_once_with("old-refresh-token")
@@ -340,6 +343,33 @@ async def test_refresh_token_success(auth_service, mock_supabase_client):
     # Verify response format
     assert result["tokens"]["access_token"] == "new-access-token"
     assert result["tokens"]["refresh_token"] == "new-refresh-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_rejects_mismatched_role(auth_service, mock_supabase_client):
+    """Reject refresh responses that do not match the expected role."""
+    mock_user = Mock()
+    mock_user.id = "user-123"
+    mock_user.email = "user@example.com"
+    mock_user.created_at = "2024-01-01T00:00:00Z"
+    mock_user.app_metadata = {"user_role": "clinician"}
+
+    mock_session = Mock()
+    mock_session.access_token = "new-access-token"
+    mock_session.refresh_token = "new-refresh-token"
+    mock_session.expires_at = 1234567890
+
+    mock_auth_response = Mock()
+    mock_auth_response.user = mock_user
+    mock_auth_response.session = mock_session
+
+    mock_supabase_client.auth.refresh_session.return_value = mock_auth_response
+
+    with pytest.raises(AuthenticationError, match="expected 'patient' role"):
+        await auth_service.refresh_token(
+            refresh_token="old-refresh-token",
+            expected_role="patient",
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/services/test_auth_service.py
+++ b/backend/tests/unit/services/test_auth_service.py
@@ -30,23 +30,28 @@ def auth_service(mock_supabase_client):
 @pytest.mark.asyncio
 async def test_signup_patient_success(auth_service, mock_supabase_client):
     """Test successful patient signup."""
-    # Mock auth.sign_up response
-    mock_user = Mock()
-    mock_user.id = "user-123"
-    mock_user.email = "patient@example.com"
-    mock_user.created_at = "2024-01-01T00:00:00Z"
-    mock_user.app_metadata = {"user_role": "patient"}
+    signup_user = Mock()
+    signup_user.id = "user-123"
+    signup_response = Mock()
+    signup_response.user = signup_user
+    mock_supabase_client.auth.sign_up.return_value = signup_response
 
-    mock_session = Mock()
-    mock_session.access_token = "access-token-123"
-    mock_session.refresh_token = "refresh-token-123"
-    mock_session.expires_at = 1234567890
+    login_user = Mock()
+    login_user.id = "user-123"
+    login_user.email = "patient@example.com"
+    login_user.created_at = "2024-01-01T00:00:00Z"
+    login_user.app_metadata = {"user_role": "patient"}
 
-    mock_auth_response = Mock()
-    mock_auth_response.user = mock_user
-    mock_auth_response.session = mock_session
+    login_session = Mock()
+    login_session.access_token = "access-token-123"
+    login_session.refresh_token = "refresh-token-123"
+    login_session.expires_at = 1234567890
 
-    mock_supabase_client.auth.sign_up.return_value = mock_auth_response
+    login_response = Mock()
+    login_response.user = login_user
+    login_response.session = login_session
+
+    mock_supabase_client.auth.sign_in_with_password.return_value = login_response
 
     # Mock table insert
     mock_insert = MagicMock()
@@ -72,7 +77,10 @@ async def test_signup_patient_success(auth_service, mock_supabase_client):
     mock_supabase_client.table.assert_called_once_with("patients")
     mock_supabase_client.table.return_value.insert.assert_called_once()
 
-    # Verify response format
+    mock_supabase_client.auth.sign_in_with_password.assert_called_once_with(
+        {"email": "patient@example.com", "password": "SecurePass123!"}
+    )
+
     assert result["tokens"]["access_token"] == "access-token-123"
     assert result["tokens"]["refresh_token"] == "refresh-token-123"
     assert result["user"]["id"] == "user-123"
@@ -137,23 +145,28 @@ async def test_signup_patient_profile_creation_failure(auth_service, mock_supaba
 @pytest.mark.asyncio
 async def test_signup_clinician_success(auth_service, mock_supabase_client):
     """Test successful clinician signup."""
-    # Mock auth.sign_up response
-    mock_user = Mock()
-    mock_user.id = "clinician-123"
-    mock_user.email = "doctor@example.com"
-    mock_user.created_at = "2024-01-01T00:00:00Z"
-    mock_user.app_metadata = {"user_role": "clinician"}
+    signup_user = Mock()
+    signup_user.id = "clinician-123"
+    signup_response = Mock()
+    signup_response.user = signup_user
+    mock_supabase_client.auth.sign_up.return_value = signup_response
 
-    mock_session = Mock()
-    mock_session.access_token = "access-token-456"
-    mock_session.refresh_token = "refresh-token-456"
-    mock_session.expires_at = 1234567890
+    login_user = Mock()
+    login_user.id = "clinician-123"
+    login_user.email = "doctor@example.com"
+    login_user.created_at = "2024-01-01T00:00:00Z"
+    login_user.app_metadata = {"user_role": "clinician"}
 
-    mock_auth_response = Mock()
-    mock_auth_response.user = mock_user
-    mock_auth_response.session = mock_session
+    login_session = Mock()
+    login_session.access_token = "access-token-456"
+    login_session.refresh_token = "refresh-token-456"
+    login_session.expires_at = 1234567890
 
-    mock_supabase_client.auth.sign_up.return_value = mock_auth_response
+    login_response = Mock()
+    login_response.user = login_user
+    login_response.session = login_session
+
+    mock_supabase_client.auth.sign_in_with_password.return_value = login_response
 
     # Mock table insert
     mock_insert = MagicMock()
@@ -179,7 +192,10 @@ async def test_signup_clinician_success(auth_service, mock_supabase_client):
     # Verify clinician profile was created
     mock_supabase_client.table.assert_called_once_with("clinicians")
 
-    # Verify response format
+    mock_supabase_client.auth.sign_in_with_password.assert_called_once_with(
+        {"email": "doctor@example.com", "password": "SecurePass123!"}
+    )
+
     assert result["tokens"]["access_token"] == "access-token-456"
     assert result["user"]["id"] == "clinician-123"
     assert result["user"]["role"] == "clinician"
@@ -265,6 +281,30 @@ async def test_login_invalid_credentials(auth_service, mock_supabase_client):
     # Should raise AuthenticationError
     with pytest.raises(AuthenticationError, match="Invalid email or password"):
         await auth_service.login(email="wrong@example.com", password="wrongpass")
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_unknown_role(auth_service, mock_supabase_client):
+    """Reject sessions that do not include a supported user_role claim."""
+    mock_user = Mock()
+    mock_user.id = "user-123"
+    mock_user.email = "user@example.com"
+    mock_user.created_at = "2024-01-01T00:00:00Z"
+    mock_user.app_metadata = {}
+
+    mock_session = Mock()
+    mock_session.access_token = "login-access-token"
+    mock_session.refresh_token = "login-refresh-token"
+    mock_session.expires_at = 1234567890
+
+    mock_auth_response = Mock()
+    mock_auth_response.user = mock_user
+    mock_auth_response.session = mock_session
+
+    mock_supabase_client.auth.sign_in_with_password.return_value = mock_auth_response
+
+    with pytest.raises(AuthenticationError, match="invalid user role"):
+        await auth_service.login(email="user@example.com", password="password123")
 
 
 # ── Token Refresh Tests ───────────────────────────────────────
@@ -395,7 +435,7 @@ async def test_format_session_missing_email(auth_service):
 
 @pytest.mark.asyncio
 async def test_format_session_missing_app_metadata(auth_service):
-    """Test _format_session with missing app_metadata."""
+    """Reject sessions with missing role metadata."""
     mock_user = Mock()
     mock_user.id = "user-123"
     mock_user.email = "user@example.com"
@@ -411,10 +451,8 @@ async def test_format_session_missing_app_metadata(auth_service):
     mock_response.user = mock_user
     mock_response.session = mock_session
 
-    result = auth_service._format_session(mock_response)
-
-    # Should default to "unknown"
-    assert result["user"]["role"] == "unknown"
+    with pytest.raises(AuthenticationError, match="invalid user role"):
+        auth_service._format_session(mock_response)
 
 
 @pytest.mark.asyncio

--- a/docs/qa-auth-accounts.md
+++ b/docs/qa-auth-accounts.md
@@ -1,0 +1,49 @@
+# QA Auth Accounts
+
+Use real environment-specific accounts created through the normal signup flows. Do not commit live credentials to the repo.
+
+## Required Accounts
+
+Create one account for each shared QA environment:
+
+- `Patient QA account`
+- `Clinician QA account`
+
+## Patient Account Checklist
+
+1. Sign up through the patient portal `/signup`
+2. Complete onboarding
+3. Keep the account usable for:
+   - login verification
+   - onboarding verification
+   - document upload verification
+   - invite-code join verification
+
+## Clinician Account Checklist
+
+1. Sign up through the clinician portal `/signup`
+2. Verify clinic profile fields are populated
+3. Keep the account usable for:
+   - login verification
+   - dashboard access verification
+   - invite-code generation
+   - patient linking workflows
+
+## Linking the Accounts
+
+1. Sign in as the clinician QA user
+2. Generate an invite code
+3. Sign in as the patient QA user
+4. Join the clinician with that invite code during onboarding or later through the patient flow
+
+## Credential Sharing
+
+- Share credentials with teammates out-of-band only
+- Never place live passwords in the repo, screenshots, or committed environment files
+- If a password changes, notify teammates in the same out-of-band channel
+
+## Reset / Recovery
+
+- If the patient account drifts, recreate it through the patient signup flow
+- If the clinician account drifts, recreate it through the clinician signup flow
+- Re-link the accounts with a fresh invite code after recreation

--- a/packages/shared/src/utils/auth-session.ts
+++ b/packages/shared/src/utils/auth-session.ts
@@ -1,0 +1,136 @@
+export interface SharedAuthUser<Role extends string> {
+    email: string;
+    id: string;
+    role: Role;
+}
+
+export interface SharedAuthSession<
+    Role extends string,
+    User extends SharedAuthUser<Role> = SharedAuthUser<Role>,
+> {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    user: User;
+}
+
+interface LegacyStoredSession<Role extends string, User extends SharedAuthUser<Role>> {
+    token?: string | null;
+    refreshToken?: string | null;
+    expiresAt?: number | null;
+    user?: User | null;
+}
+
+interface CreateAuthSessionStorageConfig<Role extends string> {
+    refreshWindowSeconds?: number;
+    role: Role;
+    storageKey: string;
+}
+
+interface RestoreSessionParams<Session> {
+    refreshSession: (refreshToken: string) => Promise<Session>;
+}
+
+const DEFAULT_REFRESH_WINDOW_SECONDS = 300;
+
+export function createAuthSessionStorage<
+    Role extends string,
+    User extends SharedAuthUser<Role>,
+    Session extends SharedAuthSession<Role, User>,
+>({ refreshWindowSeconds = DEFAULT_REFRESH_WINDOW_SECONDS, role, storageKey }: CreateAuthSessionStorageConfig<Role>) {
+    function normalizeStoredSession(value: string | null): Session | null {
+        if (!value) {
+            return null;
+        }
+
+        try {
+            const parsed = JSON.parse(value) as Session | LegacyStoredSession<Role, User>;
+            const user = parsed.user;
+
+            if (!user || user.role !== role) {
+                return null;
+            }
+
+            if ("accessToken" in parsed && "refreshToken" in parsed && "expiresAt" in parsed) {
+                if (!parsed.accessToken || !parsed.refreshToken || !parsed.expiresAt) {
+                    return null;
+                }
+
+                return {
+                    accessToken: parsed.accessToken,
+                    expiresAt: parsed.expiresAt,
+                    refreshToken: parsed.refreshToken,
+                    user,
+                } as Session;
+            }
+
+            if (!parsed.token || !parsed.refreshToken || !parsed.expiresAt) {
+                return null;
+            }
+
+            return {
+                accessToken: parsed.token,
+                expiresAt: parsed.expiresAt,
+                refreshToken: parsed.refreshToken,
+                user,
+            } as Session;
+        } catch {
+            return null;
+        }
+    }
+
+    function isSessionExpiring(expiresAt: number, nowSeconds = Math.floor(Date.now() / 1000)) {
+        return expiresAt - nowSeconds <= refreshWindowSeconds;
+    }
+
+    function readStoredSession() {
+        return normalizeStoredSession(window.localStorage.getItem(storageKey));
+    }
+
+    function writeStoredSession(session: Session) {
+        window.localStorage.setItem(storageKey, JSON.stringify(session));
+    }
+
+    function clearStoredSession() {
+        window.localStorage.removeItem(storageKey);
+    }
+
+    async function restoreStoredSession({
+        refreshSession,
+    }: RestoreSessionParams<Session>): Promise<Session | null> {
+        const storedSession = readStoredSession();
+
+        if (!storedSession) {
+            clearStoredSession();
+            return null;
+        }
+
+        if (!isSessionExpiring(storedSession.expiresAt)) {
+            return storedSession;
+        }
+
+        try {
+            const refreshedSession = await refreshSession(storedSession.refreshToken);
+
+            if (refreshedSession.user.role !== role) {
+                clearStoredSession();
+                return null;
+            }
+
+            writeStoredSession(refreshedSession);
+            return refreshedSession;
+        } catch {
+            clearStoredSession();
+            return null;
+        }
+    }
+
+    return {
+        clearStoredSession,
+        isSessionExpiring,
+        readStoredSession,
+        restoreStoredSession,
+        storageKey,
+        writeStoredSession,
+    };
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -38,3 +38,5 @@ export function formatRelativeTime(date: string | Date): string {
 export function clamp(value: number, min: number, max: number): number {
     return Math.min(Math.max(value, min), max);
 }
+
+export * from "./auth-session";


### PR DESCRIPTION
## Description
- Context: Complete the Supabase-based auth flow planned in the repo docs and TASKS.md while keeping FastAPI as the only auth API consumed by both portals.
- What changed: tightened backend auth contract and role validation, added clinician profile update support and auth router coverage, normalized persisted session lifecycle in both portals, added clinician signup UI, surfaced onboarding and login errors properly, added a QA auth account runbook, and included the pending Artifact Registry cleanup policy fix that was already in the worktree.

## Related Tasks
- Resolves: TASKS.md Phase 3.2 Patient Portal Auth, Phase 3.5 Clinician Portal Auth, and the agreed Supabase auth completion follow-up.

## Verification Checklist
- [x] I have read CONTRIBUTING.md and .agent/CODING_STANDARDS.md.
- [x] My code matches existing architecture patterns from .agent/ARCHITECTURE.md.
- [x] I have verified that tests pass.
- [x] I have run local linting.
- [x] I have added or updated tests for this feature.
- [x] There are no new warnings, secrets, or hallucinated dependencies.

## Verification
- backend/.venv/bin/ruff check backend/src backend/tests
- backend/.venv/bin/python -m pytest backend/tests/unit/services/test_auth_service.py backend/tests/integration/routers/test_auth_api.py backend/tests/integration/routers/test_patient_api.py backend/tests/integration/routers/test_clinician_api.py --no-cov -q
- cd apps/patient-portal && npm run lint && npx vitest run && npm run build
- cd apps/clinician-portal && npm run lint && npx vitest run && npm run build

## Testing Notes
- Backend auth tests mock the Supabase client boundary rather than hitting a live Supabase project. The mocked calls mirror the real sign_up, sign_in_with_password, refresh_session, reset_password_email, and user/profile table operations already used by AuthService, so the tests verify our contract and orchestration logic without environment-coupled flakiness.
- Frontend tests exercise role rejection, persisted session restore and refresh, patient onboarding error recovery, and clinician signup and login flows. They are functional component and integration-style tests around the real page and store logic rather than snapshot-only checks.

## Screenshots
- None