### PR TITLE
refactor(frontend): tighten shared portal typing and UI contracts

### DIFF
--- a/apps/clinician-portal/src/__tests__/patient-deep-dive.test.tsx
+++ b/apps/clinician-portal/src/__tests__/patient-deep-dive.test.tsx
@@ -12,6 +12,8 @@ import { SymptomTimeline } from "@/components/features/symptom-timeline";
 import { ChatTranscript } from "@/components/features/chat-transcript";
 import { DocumentSummary } from "@/components/features/document-summary";
 import { AccordionItem } from "@/components/ui/accordion";
+import { ChatRole } from "@/types";
+import type { SymptomReport } from "@/types";
 
 // ── Mock recharts ─────────────────────────────────────────────────────────────
 // Recharts uses ResizeObserver which is not available in jsdom
@@ -21,10 +23,14 @@ vi.mock("recharts", () => ({
         <div data-testid="responsive-container">{children}</div>
     ),
     LineChart: ({ children }: { children: React.ReactNode }) => (
-        <div data-testid="line-chart">{children}</div>
+        <svg data-testid="line-chart" viewBox="0 0 100 100">
+            {children}
+        </svg>
     ),
     AreaChart: ({ children }: { children: React.ReactNode }) => (
-        <div data-testid="area-chart">{children}</div>
+        <svg data-testid="area-chart" viewBox="0 0 100 100">
+            {children}
+        </svg>
     ),
     Line: () => <div data-testid="recharts-line" />,
     Area: () => <div data-testid="recharts-area" />,
@@ -74,10 +80,10 @@ describe("AdherenceChart", () => {
 // ── SymptomTimeline tests ─────────────────────────────────────────────────────
 
 describe("SymptomTimeline", () => {
-    const mockSymptoms = [
+    const mockSymptoms: SymptomReport[] = [
         {
             id: "s1",
-            patientId: "patient-1",
+            patientId: "p1",
             symptom: "headache",
             severity: 3,
             createdAt: "2026-03-10T09:00:00Z",
@@ -85,7 +91,7 @@ describe("SymptomTimeline", () => {
         },
         {
             id: "s2",
-            patientId: "patient-1",
+            patientId: "p1",
             symptom: "nausea",
             severity: 7,
             createdAt: "2026-03-15T14:00:00Z",
@@ -115,13 +121,13 @@ describe("SymptomTimeline", () => {
 
 describe("ChatTranscript", () => {
     const mockMessages = [
-        { role: "user", content: "I have a headache today", created_at: "2026-03-20T10:00:00Z" },
+        { role: ChatRole.USER, content: "I have a headache today", created_at: "2026-03-20T10:00:00Z" },
         {
-            role: "assistant",
+            role: ChatRole.ASSISTANT,
             content: "I understand. Can you rate the severity 1–10?",
             created_at: "2026-03-20T10:01:00Z",
         },
-        { role: "user", content: "About a 5", created_at: "2026-03-20T10:02:00Z" },
+        { role: ChatRole.USER, content: "About a 5", created_at: "2026-03-20T10:02:00Z" },
     ];
 
     it("renders all messages", () => {
@@ -147,7 +153,7 @@ describe("ChatTranscript", () => {
 
     it("renders voice message indicator when audio_url present", () => {
         const voiceMsg = {
-            role: "user",
+            role: ChatRole.USER,
             content: "Voice note",
             created_at: "2026-03-20T10:00:00Z",
             audio_url: "https://example.com/audio.wav",

--- a/apps/clinician-portal/src/app/(auth)/login/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
-import { api } from "@/services/api";
+import { api, isRetryableApiError } from "@/services/api";
 import { writeStoredSession } from "@/services/auth-session";
 import {
     clearStoredClinicContext,
@@ -18,6 +18,8 @@ import type { AppDispatch } from "@/store/store";
 import { PortalUserRole } from "@/types";
 
 interface LoginResponse {
+    mfa_factors?: MFAFactorSummary[];
+    mfa_required?: boolean;
     tokens: {
         access_token: string;
         expires_at: number;
@@ -30,6 +32,11 @@ interface LoginResponse {
     };
 }
 
+interface MFAFactorSummary {
+    friendly_name?: string | null;
+    id: string;
+}
+
 interface ClinicResolveResponse {
     clinic_code: string;
     clinic_id: string;
@@ -37,7 +44,16 @@ interface ClinicResolveResponse {
     status: "active" | "suspended";
 }
 
-type LoginStage = "verify" | "choose" | "login";
+type LoginStage = "verify" | "choose" | "login" | "mfa";
+
+function mapClinicContext(response: ClinicResolveResponse): ClinicContext {
+    return {
+        clinicCode: response.clinic_code,
+        clinicId: response.clinic_id,
+        clinicName: response.clinic_name,
+        status: response.status,
+    };
+}
 
 export default function ClinicianLoginPage() {
     const router = useRouter();
@@ -49,6 +65,7 @@ export default function ClinicianLoginPage() {
     const [password, setPassword] = useState("");
     const [error, setError] = useState("");
     const [clinicCodeError, setClinicCodeError] = useState("");
+    const [mfaFactors, setMfaFactors] = useState<MFAFactorSummary[]>([]);
     const [submitting, setSubmitting] = useState(false);
 
     useEffect(() => {
@@ -57,15 +74,36 @@ export default function ClinicianLoginPage() {
             return;
         }
 
-        setClinicCode(stored.clinicCode);
-        setClinicContext(stored);
-        setStage("choose");
+        const revalidateStoredClinicContext = async () => {
+            setClinicCode(stored.clinicCode);
+            setSubmitting(true);
+
+            try {
+                const resolved = await api.post<ClinicResolveResponse>("/api/v1/clinics/resolve-code", {
+                    clinic_code: stored.clinicCode,
+                });
+                const nextClinicContext = mapClinicContext(resolved);
+                writeStoredClinicContext(nextClinicContext);
+                setClinicContext(nextClinicContext);
+                setStage("choose");
+            } catch {
+                clearStoredClinicContext();
+                setClinicContext(null);
+                setStage("verify");
+                setError("Saved clinic access expired. Please verify your clinic code again.");
+            } finally {
+                setSubmitting(false);
+            }
+        };
+
+        void revalidateStoredClinicContext();
     }, []);
 
     async function handleVerifyClinicCode(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
         setError("");
         setClinicCodeError("");
+        setMfaFactors([]);
 
         const normalizedClinicCode = clinicCode.trim().toUpperCase();
         setClinicCode(normalizedClinicCode);
@@ -86,16 +124,10 @@ export default function ClinicianLoginPage() {
             const resolved = await api.post<ClinicResolveResponse>("/api/v1/clinics/resolve-code", {
                 clinic_code: normalizedClinicCode,
             });
-
-            const context: ClinicContext = {
-                clinicCode: resolved.clinic_code,
-                clinicId: resolved.clinic_id,
-                clinicName: resolved.clinic_name,
-                status: resolved.status,
-            };
+            const context = mapClinicContext(resolved);
 
             writeStoredClinicContext(context);
-            setClinicCode(resolved.clinic_code);
+            setClinicCode(context.clinicCode);
             setClinicContext(context);
             setStage("choose");
         } catch (submissionError) {
@@ -105,10 +137,21 @@ export default function ClinicianLoginPage() {
         }
     }
 
+    function expireClinicContext(message: string) {
+        const retainedClinicCode = clinicContext?.clinicCode ?? clinicCode;
+        clearStoredClinicContext();
+        setClinicContext(null);
+        setMfaFactors([]);
+        setStage("verify");
+        setClinicCode(retainedClinicCode);
+        setError(message);
+    }
+
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
         setSubmitting(true);
         setError("");
+        setMfaFactors([]);
 
         if (!clinicContext) {
             setError("Enter and verify your clinic code first.");
@@ -117,9 +160,19 @@ export default function ClinicianLoginPage() {
         }
 
         try {
-            const response = await api.post<LoginResponse>("/api/v1/auth/login", { email, password });
+            const response = await api.post<LoginResponse>("/api/v1/auth/login", {
+                clinic_code: clinicContext.clinicCode,
+                email,
+                password,
+            });
             if (response.user.role !== PortalUserRole.CLINICIAN) {
                 throw new Error("This login belongs to a patient account.");
+            }
+
+            if (response.mfa_required) {
+                setMfaFactors(response.mfa_factors ?? []);
+                setStage("mfa");
+                return;
             }
 
             const session: ClinicianAuthSession = {
@@ -137,7 +190,12 @@ export default function ClinicianLoginPage() {
             dispatch(hydrateSession(session));
             router.replace("/dashboard");
         } catch (submissionError) {
-            setError((submissionError as Error).message);
+            const message = (submissionError as Error).message;
+            if (!isRetryableApiError(submissionError) && message.toLowerCase().includes("clinic code")) {
+                expireClinicContext("Saved clinic access expired. Please verify your clinic code again.");
+                return;
+            }
+            setError(message);
         } finally {
             setSubmitting(false);
         }
@@ -148,6 +206,9 @@ export default function ClinicianLoginPage() {
         setClinicContext(null);
         setClinicCode("");
         setEmail("");
+        setError("");
+        setClinicCodeError("");
+        setMfaFactors([]);
         setPassword("");
         setStage("verify");
     }
@@ -170,14 +231,22 @@ export default function ClinicianLoginPage() {
                     <div className="space-y-2">
                         <p className="text-sm font-medium text-blue-600">Clinic access</p>
                         <h2 className="text-3xl font-bold text-gray-900">
-                            {stage === "verify" ? "Enter clinic code" : stage === "choose" ? "Choose sign-in path" : "Sign in"}
+                            {stage === "verify"
+                                ? "Enter clinic code"
+                                : stage === "choose"
+                                    ? "Choose sign-in path"
+                                    : stage === "login"
+                                        ? "Sign in"
+                                        : "Verify MFA"}
                         </h2>
                         <p className="text-sm text-gray-500">
                             {stage === "verify"
                                 ? "Verify your clinic workspace before continuing to login or registration."
                                 : stage === "choose"
-                                                                    ? "Clinic verified. Continue to sign in with your account or join this clinic."
-                                  : "Access your dashboard, roster, and active alerts."}
+                                    ? "Clinic verified. Continue to sign in with your account or join this clinic."
+                                    : stage === "login"
+                                        ? "Access your dashboard, roster, and active alerts."
+                                        : "Use your authenticator app to complete sign-in."}
                         </p>
                     </div>
 
@@ -194,6 +263,7 @@ export default function ClinicianLoginPage() {
                                 }}
                                 value={clinicCode}
                             />
+                            {error ? <p className="text-sm text-red-600">{error}</p> : null}
                             <Button disabled={submitting} fullWidth type="submit">
                                 {submitting ? "Verifying..." : "Verify clinic code"}
                             </Button>
@@ -221,6 +291,36 @@ export default function ClinicianLoginPage() {
                             <button className="w-full text-sm text-slate-500 underline" onClick={useDifferentClinicCode} type="button">
                                 Use a different clinic code
                             </button>
+                        </div>
+                    ) : null}
+
+                    {stage === "mfa" && clinicContext ? (
+                        <div className="space-y-4">
+                            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                                <p className="font-semibold">Multi-factor authentication required</p>
+                                <p className="mt-1">
+                                    Continue in the MFA setup flow for <span className="font-medium">{clinicContext.clinicName}</span>.
+                                </p>
+                            </div>
+                            <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+                                <p className="font-semibold text-slate-900">Available factors</p>
+                                {mfaFactors.length > 0 ? (
+                                    mfaFactors.map((factor) => (
+                                        <p key={factor.id}>{factor.friendly_name ?? "Authenticator"}</p>
+                                    ))
+                                ) : (
+                                    <p>Authenticator</p>
+                                )}
+                            </div>
+                            {error ? <p className="text-sm text-red-600">{error}</p> : null}
+                            <div className="flex items-center justify-between text-sm">
+                                <button className="text-blue-600" onClick={() => setStage("login")} type="button">
+                                    Back
+                                </button>
+                                <Link className="text-blue-600" href="/dashboard/settings/mfa">
+                                    Open MFA settings
+                                </Link>
+                            </div>
                         </div>
                     ) : null}
 

--- a/apps/clinician-portal/src/app/(auth)/login/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
-import { api, isRetryableApiError } from "@/services/api";
+import { api } from "@/services/api";
 import { writeStoredSession } from "@/services/auth-session";
 import {
     clearStoredClinicContext,
@@ -15,6 +15,7 @@ import {
 } from "@/services/clinic-context";
 import { hydrateSession, type ClinicianAuthSession } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
+import { PortalUserRole } from "@/types";
 
 interface LoginResponse {
     tokens: {
@@ -22,28 +23,11 @@ interface LoginResponse {
         expires_at: number;
         refresh_token: string;
     };
-    mfa_factors?: Array<{
-        id: string;
-        friendly_name: string | null;
-    }>;
-    mfa_required?: boolean;
     user: {
         email: string;
         id: string;
-        role: "patient" | "clinician";
+        role: typeof PortalUserRole[keyof typeof PortalUserRole];
     };
-}
-
-interface MFAVerifyResponse {
-    access_token: string;
-    expires_at: number;
-    refresh_token: string;
-}
-
-interface PendingMFALogin {
-    factorId: string;
-    friendlyName: string;
-    session: ClinicianAuthSession;
 }
 
 interface ClinicResolveResponse {
@@ -55,115 +39,28 @@ interface ClinicResolveResponse {
 
 type LoginStage = "verify" | "choose" | "login";
 
-async function retryableClinicResolve(clinicCode: string): Promise<ClinicResolveResponse> {
-    try {
-        return await api.post<ClinicResolveResponse>("/api/v1/clinics/resolve-code", {
-            clinic_code: clinicCode,
-        });
-    } catch (error) {
-        if (!isRetryableApiError(error)) {
-            throw error;
-        }
-
-        await new Promise((resolve) => window.setTimeout(resolve, 250));
-        return api.post<ClinicResolveResponse>("/api/v1/clinics/resolve-code", {
-            clinic_code: clinicCode,
-        });
-    }
-}
-
 export default function ClinicianLoginPage() {
     const router = useRouter();
     const dispatch = useDispatch<AppDispatch>();
     const [stage, setStage] = useState<LoginStage>("verify");
     const [clinicCode, setClinicCode] = useState("");
     const [clinicContext, setClinicContext] = useState<ClinicContext | null>(null);
-    const [code, setCode] = useState("");
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [error, setError] = useState("");
     const [clinicCodeError, setClinicCodeError] = useState("");
-    const [pendingMFA, setPendingMFA] = useState<PendingMFALogin | null>(null);
-    const [restoringClinicContext, setRestoringClinicContext] = useState(true);
     const [submitting, setSubmitting] = useState(false);
 
     useEffect(() => {
         const stored = readStoredClinicContext();
         if (!stored) {
-            setRestoringClinicContext(false);
             return;
         }
-        const storedContext = stored;
 
-        let cancelled = false;
-
-        async function restoreClinicContext() {
-            setClinicCode(storedContext.clinicCode);
-
-            try {
-                const resolved = await retryableClinicResolve(storedContext.clinicCode);
-
-                if (cancelled) {
-                    return;
-                }
-
-                const context: ClinicContext = {
-                    clinicCode: resolved.clinic_code,
-                    clinicId: resolved.clinic_id,
-                    clinicName: resolved.clinic_name,
-                    status: resolved.status,
-                };
-
-                writeStoredClinicContext(context);
-                setClinicCode(resolved.clinic_code);
-                setClinicContext(context);
-                setStage("choose");
-            } catch (error) {
-                if (cancelled) {
-                    return;
-                }
-
-                if (!isRetryableApiError(error)) {
-                    clearStoredClinicContext();
-                }
-                setClinicContext(null);
-                setClinicCode(storedContext.clinicCode);
-                setClinicCodeError(
-                    isRetryableApiError(error)
-                        ? "Clinic verification is temporarily unavailable. Please retry."
-                        : "Saved clinic access expired. Verify your clinic code again.",
-                );
-                setStage("verify");
-            } finally {
-                if (!cancelled) {
-                    setRestoringClinicContext(false);
-                }
-            }
-        }
-
-        void restoreClinicContext();
-
-        return () => {
-            cancelled = true;
-        };
+        setClinicCode(stored.clinicCode);
+        setClinicContext(stored);
+        setStage("choose");
     }, []);
-
-    function resetClinicContext(clinicCodeValue = "", message = "") {
-        clearStoredClinicContext();
-        setClinicContext(null);
-        setClinicCode(clinicCodeValue);
-        setClinicCodeError(message);
-        setPendingMFA(null);
-        setCode("");
-        setError("");
-        setPassword("");
-        setStage("verify");
-    }
-
-    function useDifferentClinicCode() {
-        resetClinicContext();
-        setEmail("");
-    }
 
     async function handleVerifyClinicCode(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -186,7 +83,9 @@ export default function ClinicianLoginPage() {
         setSubmitting(true);
 
         try {
-            const resolved = await retryableClinicResolve(normalizedClinicCode);
+            const resolved = await api.post<ClinicResolveResponse>("/api/v1/clinics/resolve-code", {
+                clinic_code: normalizedClinicCode,
+            });
 
             const context: ClinicContext = {
                 clinicCode: resolved.clinic_code,
@@ -200,11 +99,7 @@ export default function ClinicianLoginPage() {
             setClinicContext(context);
             setStage("choose");
         } catch (submissionError) {
-            setClinicCodeError(
-                isRetryableApiError(submissionError)
-                    ? "Clinic verification is temporarily unavailable. Please retry."
-                    : (submissionError as Error).message,
-            );
+            setClinicCodeError((submissionError as Error).message);
         } finally {
             setSubmitting(false);
         }
@@ -222,12 +117,8 @@ export default function ClinicianLoginPage() {
         }
 
         try {
-            const response = await api.post<LoginResponse>("/api/v1/auth/login", {
-                clinic_code: clinicContext.clinicCode,
-                email,
-                password,
-            });
-            if (response.user.role !== "clinician") {
+            const response = await api.post<LoginResponse>("/api/v1/auth/login", { email, password });
+            if (response.user.role !== PortalUserRole.CLINICIAN) {
                 throw new Error("This login belongs to a patient account.");
             }
 
@@ -238,74 +129,8 @@ export default function ClinicianLoginPage() {
                 user: {
                     email: response.user.email,
                     id: response.user.id,
-                    role: "clinician",
+                    role: PortalUserRole.CLINICIAN,
                 },
-            };
-
-            if (response.mfa_required) {
-                const factor = response.mfa_factors?.[0];
-                if (!factor) {
-                    throw new Error("MFA is required but no verified factor is available.");
-                }
-                setPendingMFA({
-                    factorId: factor.id,
-                    friendlyName: factor.friendly_name ?? "Authenticator",
-                    session,
-                });
-                setCode("");
-                return;
-            }
-
-            writeStoredSession(session);
-            dispatch(hydrateSession(session));
-            router.replace("/dashboard");
-        } catch (submissionError) {
-            if (isRetryableApiError(submissionError)) {
-                setError("Login is temporarily unavailable. Please retry.");
-                return;
-            }
-
-            const message = (submissionError as Error).message;
-            if (message === "Clinic code is invalid" || message === "Clinic code is inactive") {
-                resetClinicContext(
-                    clinicContext.clinicCode,
-                    message === "Clinic code is inactive"
-                        ? message
-                        : "Saved clinic access expired. Verify your clinic code again.",
-                );
-                return;
-            }
-
-            setError(message);
-        } finally {
-            setSubmitting(false);
-        }
-    }
-
-    async function handleMFAVerify(event: React.FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        if (!pendingMFA) {
-            return;
-        }
-
-        setSubmitting(true);
-        setError("");
-
-        try {
-            const response = await api.post<MFAVerifyResponse>(
-                "/api/v1/auth/mfa/verify",
-                { factor_id: pendingMFA.factorId, code },
-                {
-                    headers: { "X-Refresh-Token": pendingMFA.session.refreshToken },
-                    token: pendingMFA.session.accessToken,
-                },
-            );
-
-            const session: ClinicianAuthSession = {
-                accessToken: response.access_token,
-                expiresAt: response.expires_at,
-                refreshToken: response.refresh_token,
-                user: pendingMFA.session.user,
             };
 
             writeStoredSession(session);
@@ -316,6 +141,15 @@ export default function ClinicianLoginPage() {
         } finally {
             setSubmitting(false);
         }
+    }
+
+    function useDifferentClinicCode() {
+        clearStoredClinicContext();
+        setClinicContext(null);
+        setClinicCode("");
+        setEmail("");
+        setPassword("");
+        setStage("verify");
     }
 
     return (
@@ -334,66 +168,20 @@ export default function ClinicianLoginPage() {
             <div className="flex flex-1 items-center justify-center px-6 py-12">
                 <Card className="w-full max-w-md space-y-6" padding="lg">
                     <div className="space-y-2">
-                        <p className="text-sm font-medium text-blue-600">
-                            {pendingMFA ? "Clinical Intelligence Platform" : "Clinic access"}
-                        </p>
+                        <p className="text-sm font-medium text-blue-600">Clinic access</p>
                         <h2 className="text-3xl font-bold text-gray-900">
-                            {pendingMFA
-                                ? "Verify MFA"
-                                : stage === "verify"
-                                  ? "Enter clinic code"
-                                  : stage === "choose"
-                                    ? "Choose sign-in path"
-                                    : "Sign in"}
+                            {stage === "verify" ? "Enter clinic code" : stage === "choose" ? "Choose sign-in path" : "Sign in"}
                         </h2>
                         <p className="text-sm text-gray-500">
-                            {pendingMFA
-                                ? `Enter the 6-digit code from ${pendingMFA.friendlyName}.`
-                                : stage === "verify"
-                                  ? "Verify your clinic workspace before continuing to login or registration."
-                                  : stage === "choose"
-                                    ? "Clinic verified. Continue to sign in with your account or join this clinic."
-                                    : "Access your dashboard, roster, and active alerts."}
+                            {stage === "verify"
+                                ? "Verify your clinic workspace before continuing to login or registration."
+                                : stage === "choose"
+                                                                    ? "Clinic verified. Continue to sign in with your account or join this clinic."
+                                  : "Access your dashboard, roster, and active alerts."}
                         </p>
                     </div>
 
-                    {restoringClinicContext ? (
-                        <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
-                            Checking saved clinic access...
-                        </div>
-                    ) : null}
-
-                    {!restoringClinicContext && pendingMFA ? (
-                        <form className="space-y-4" onSubmit={handleMFAVerify}>
-                            <Input
-                                autoComplete="one-time-code"
-                                inputMode="numeric"
-                                label="6-digit code"
-                                maxLength={6}
-                                onChange={(event) => setCode(event.target.value.replace(/\D/g, ""))}
-                                placeholder="000000"
-                                value={code}
-                            />
-                            {error ? <p className="text-sm text-red-600">{error}</p> : null}
-                            <Button disabled={submitting || code.length !== 6} fullWidth type="submit">
-                                {submitting ? "Verifying..." : "Verify and continue"}
-                            </Button>
-                            <button
-                                className="w-full text-sm text-gray-500 underline"
-                                onClick={() => {
-                                    setPendingMFA(null);
-                                    setCode("");
-                                    setError("");
-                                    setStage("login");
-                                }}
-                                type="button"
-                            >
-                                Use a different account
-                            </button>
-                        </form>
-                    ) : null}
-
-                    {!restoringClinicContext && !pendingMFA && stage === "verify" ? (
+                    {stage === "verify" ? (
                         <form className="space-y-4" onSubmit={handleVerifyClinicCode}>
                             <Input
                                 error={clinicCodeError}
@@ -415,7 +203,7 @@ export default function ClinicianLoginPage() {
                         </form>
                     ) : null}
 
-                    {!restoringClinicContext && !pendingMFA && stage === "choose" && clinicContext ? (
+                    {stage === "choose" && clinicContext ? (
                         <div className="space-y-4">
                             <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
                                 <p className="font-semibold">Clinic verified: {clinicContext.clinicName}</p>
@@ -430,17 +218,13 @@ export default function ClinicianLoginPage() {
                                     Join this clinic (Provider / Nurse)
                                 </Button>
                             </Link>
-                            <button
-                                className="w-full text-sm text-slate-500 underline"
-                                onClick={useDifferentClinicCode}
-                                type="button"
-                            >
+                            <button className="w-full text-sm text-slate-500 underline" onClick={useDifferentClinicCode} type="button">
                                 Use a different clinic code
                             </button>
                         </div>
                     ) : null}
 
-                    {!restoringClinicContext && !pendingMFA && stage === "login" && clinicContext ? (
+                    {stage === "login" && clinicContext ? (
                         <>
                             <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
                                 Signing into clinic: <span className="font-semibold">{clinicContext.clinicName}</span>

--- a/apps/clinician-portal/src/app/(auth)/signup/admin/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/signup/admin/page.tsx
@@ -9,6 +9,7 @@ import { api } from "@/services/api";
 import { writeStoredSession } from "@/services/auth-session";
 import { hydrateSession, type ClinicianAuthSession } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
+import { PortalUserRole } from "@/types";
 
 interface SignupResponse {
     tokens: {
@@ -19,7 +20,7 @@ interface SignupResponse {
     user: {
         email: string;
         id: string;
-        role: "patient" | "clinician";
+        role: typeof PortalUserRole[keyof typeof PortalUserRole];
     };
 }
 
@@ -89,7 +90,7 @@ export default function ClinicAdminSignupPage() {
                 type2_npi: formData.type2Npi || undefined,
             });
 
-            if (response.user.role !== "clinician") {
+            if (response.user.role !== PortalUserRole.CLINICIAN) {
                 throw new Error("This signup produced a non-clinician account.");
             }
 
@@ -100,7 +101,7 @@ export default function ClinicAdminSignupPage() {
                 user: {
                     email: response.user.email,
                     id: response.user.id,
-                    role: "clinician",
+                    role: PortalUserRole.CLINICIAN,
                 },
             };
 

--- a/apps/clinician-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/signup/page.tsx
@@ -10,6 +10,7 @@ import { writeStoredSession } from "@/services/auth-session";
 import { readStoredClinicContext, type ClinicContext } from "@/services/clinic-context";
 import { hydrateSession, type ClinicianAuthSession } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
+import { ClinicianRole, PortalUserRole } from "@/types";
 
 interface SignupResponse {
     tokens: {
@@ -20,7 +21,7 @@ interface SignupResponse {
     user: {
         email: string;
         id: string;
-        role: "patient" | "clinician";
+        role: typeof PortalUserRole[keyof typeof PortalUserRole];
     };
 }
 
@@ -37,7 +38,7 @@ export default function ClinicianSignupPage() {
         lastName: "",
         npiNumber: "",
         password: "",
-        role: "provider",
+        role: ClinicianRole.PROVIDER,
         specialty: "",
     });
 
@@ -78,7 +79,7 @@ export default function ClinicianSignupPage() {
                 specialty: formData.specialty,
             });
 
-            if (response.user.role !== "clinician") {
+            if (response.user.role !== PortalUserRole.CLINICIAN) {
                 throw new Error("This signup produced a non-clinician account.");
             }
 
@@ -89,7 +90,7 @@ export default function ClinicianSignupPage() {
                 user: {
                     email: response.user.email,
                     id: response.user.id,
-                    role: "clinician",
+                    role: PortalUserRole.CLINICIAN,
                 },
             };
             writeStoredSession(session);
@@ -146,8 +147,8 @@ export default function ClinicianSignupPage() {
                                 onChange={(event) => updateField("role", event.target.value)}
                                 value={formData.role}
                             >
-                                <option value="provider">Provider</option>
-                                <option value="nurse">Nurse / MA</option>
+                                <option value={ClinicianRole.PROVIDER}>Provider</option>
+                                <option value={ClinicianRole.NURSE}>Nurse / MA</option>
                             </select>
                         </label>
                         <Input label="NPI number (optional)" onChange={(event) => updateField("npiNumber", event.target.value)} value={formData.npiNumber} />

--- a/apps/clinician-portal/src/app/(dashboard)/settings/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/settings/page.tsx
@@ -5,24 +5,32 @@ import { useCallback, useEffect, useState } from "react";
 import { HiOutlineClipboardDocument, HiOutlineMagnifyingGlass } from "react-icons/hi2";
 import { useSelector } from "react-redux";
 import { Badge, Button, Card, Input } from "@/components/ui";
-import { api, isRetryableApiError } from "@/services/api";
+import { api } from "@/services/api";
 import type { RootState } from "@/store/store";
+import { ClinicianRole } from "@/types";
 
 const settingsTabs = ["General Profile", "Team & Roles", "Patient Invites", "Integrations (MCP)"] as const;
 type SettingsTab = (typeof settingsTabs)[number];
 
 const ROLE_OPTIONS = [
-    { label: "Clinic Admin", value: "admin" },
-    { label: "Provider", value: "provider" },
-    { label: "Nurse / MA", value: "nurse" },
+    { label: "Clinic Admin", value: ClinicianRole.ADMIN },
+    { label: "Provider", value: ClinicianRole.PROVIDER },
+    { label: "Nurse / MA", value: ClinicianRole.NURSE },
 ] as const;
+
+const InviteLifecycleState = {
+    ACTIVE: "active",
+    CLAIMED: "claimed",
+    INACTIVE: "inactive",
+} as const;
+type InviteLifecycleState = (typeof InviteLifecycleState)[keyof typeof InviteLifecycleState];
 
 interface StaffMember {
     id: string;
     email: string;
     first_name: string;
     last_name: string;
-    role: string;
+    role: ClinicianRole;
     specialty: string;
     created_at: string | null;
 }
@@ -33,7 +41,7 @@ interface ClinicianProfile {
     first_name: string;
     last_name: string;
     specialty: string;
-    role: string;
+    role: ClinicianRole;
 }
 
 interface InviteCodePayload {
@@ -45,20 +53,14 @@ interface InviteCodeRecord {
     care_team_id: string;
     invite_code: string | null;
     status: string;
-    role: string | null;
+    role: ClinicianRole | null;
     created_at: string | null;
     invite_expires_at: string | null;
     invite_claimed_at: string | null;
     is_expired: boolean;
-    lifecycle_state: "active" | "claimed" | "inactive";
+    lifecycle_state: InviteLifecycleState;
     patient: {
         id: string | null;
-        first_name: string | null;
-        last_name: string | null;
-        email: string | null;
-    } | null;
-    created_by: {
-        id: string;
         first_name: string | null;
         last_name: string | null;
         email: string | null;
@@ -78,18 +80,18 @@ function getInitials(first: string, last: string) {
     return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
 }
 
-function getRoleTone(role: string) {
+function getRoleTone(role: ClinicianRole) {
     switch (role) {
-        case "admin":
+        case ClinicianRole.ADMIN:
             return "bg-slate-800 text-white";
-        case "nurse":
+        case ClinicianRole.NURSE:
             return "bg-purple-100 text-purple-700";
         default:
             return "bg-green-100 text-blue-700";
     }
 }
 
-function getRoleLabel(role: string) {
+function getRoleLabel(role: ClinicianRole) {
     return ROLE_OPTIONS.find((r) => r.value === role)?.label ?? role;
 }
 
@@ -120,30 +122,6 @@ function getPatientLabel(record: InviteCodeRecord) {
     return fullName || record.patient.email || "—";
 }
 
-function getCreatorLabel(record: InviteCodeRecord) {
-    if (!record.created_by) {
-        return "—";
-    }
-
-    const first = record.created_by.first_name?.trim() || "";
-    const last = record.created_by.last_name?.trim() || "";
-    const fullName = `${first} ${last}`.trim();
-    return fullName || record.created_by.email || "—";
-}
-
-async function withReadRetry<T>(read: () => Promise<T>): Promise<T> {
-    try {
-        return await read();
-    } catch (error) {
-        if (!isRetryableApiError(error)) {
-            throw error;
-        }
-
-        await new Promise((resolve) => window.setTimeout(resolve, 250));
-        return read();
-    }
-}
-
 export default function SettingsPage() {
     const token = useSelector((state: RootState) => state.auth.accessToken);
     const [staffList, setStaffList] = useState<StaffMember[]>([]);
@@ -151,7 +129,7 @@ export default function SettingsPage() {
     const [clinicCode, setClinicCode] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [inviteEmail, setInviteEmail] = useState("");
-    const [inviteRole, setInviteRole] = useState("provider");
+    const [inviteRole, setInviteRole] = useState<ClinicianRole>(ClinicianRole.PROVIDER);
     const [inviteStatus, setInviteStatus] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [profileSaving, setProfileSaving] = useState(false);
@@ -172,21 +150,15 @@ export default function SettingsPage() {
             return;
         }
         try {
-            const result = await withReadRetry(() =>
-                api.get<{ staff: StaffMember[]; clinic_name: string; clinic_code?: string | null }>(
-                    "/api/v1/staff/",
-                    { token },
-                ),
+            const result = await api.get<{ staff: StaffMember[]; clinic_name: string; clinic_code?: string | null }>(
+                "/api/v1/staff/",
+                { token },
             );
             setStaffList(result.staff);
             setClinicName(result.clinic_name);
             setClinicCode(result.clinic_code ?? null);
         } catch (e) {
-            setError(
-                isRetryableApiError(e)
-                    ? "Clinic settings are temporarily unavailable. Please retry."
-                    : (e as Error).message,
-            );
+            setError((e as Error).message);
         } finally {
             setLoading(false);
         }
@@ -202,17 +174,13 @@ export default function SettingsPage() {
         }
 
         try {
-            const result = await withReadRetry(() => api.get<ClinicianProfile>("/api/v1/clinicians/me", { token }));
+            const result = await api.get<ClinicianProfile>("/api/v1/clinicians/me", { token });
             setProfile(result);
             setFirstName(result.first_name);
             setLastName(result.last_name);
             setSpecialty(result.specialty || "");
         } catch (e) {
-            setError(
-                isRetryableApiError(e)
-                    ? "Profile details are temporarily unavailable. Please retry."
-                    : (e as Error).message,
-            );
+            setError((e as Error).message);
         }
     }, [token]);
 
@@ -229,21 +197,17 @@ export default function SettingsPage() {
         setError(null);
 
         try {
-            const result = await withReadRetry(() =>
-                api.get<InviteCodeListPayload>("/api/v1/clinicians/me/invite-codes", {
-                    token,
-                }),
-            );
+            const result = await api.get<InviteCodeListPayload>("/api/v1/clinicians/me/invite-codes", {
+                token,
+            });
             const records = result.invites || [];
             setInviteRecords(records);
-            const firstActiveCode = records.find((record) => record.lifecycle_state === "active")?.invite_code;
+            const firstActiveCode = records.find(
+                (record) => record.lifecycle_state === InviteLifecycleState.ACTIVE,
+            )?.invite_code;
             setInviteCode(firstActiveCode ?? "");
         } catch (e) {
-            setError(
-                isRetryableApiError(e)
-                    ? "Invite codes are temporarily unavailable. Please retry."
-                    : (e as Error).message,
-            );
+            setError((e as Error).message);
         } finally {
             setInviteCodeLoading(false);
         }
@@ -314,7 +278,7 @@ export default function SettingsPage() {
         }
     }
 
-    async function handleRoleChange(memberId: string, newRole: string) {
+    async function handleRoleChange(memberId: string, newRole: ClinicianRole) {
         if (!token) {
             return;
         }
@@ -337,7 +301,7 @@ export default function SettingsPage() {
 
         if (typeof window !== "undefined") {
             const fullName = `${member.first_name} ${member.last_name}`.trim() || member.email;
-            if (newRole === "admin") {
+            if (newRole === ClinicianRole.ADMIN) {
                 const confirmed = window.confirm(
                     `Grant Clinic Admin access to ${fullName}? This allows full staff and clinic management.`,
                 );
@@ -346,7 +310,7 @@ export default function SettingsPage() {
                 }
             }
 
-            if (member.role === "admin" && newRole !== "admin") {
+            if (member.role === ClinicianRole.ADMIN && newRole !== ClinicianRole.ADMIN) {
                 const confirmed = window.confirm(
                     `Remove Clinic Admin access from ${fullName}? They will lose admin permissions.`,
                 );
@@ -440,11 +404,15 @@ export default function SettingsPage() {
         return `${member.first_name} ${member.last_name} ${member.email}`.toLowerCase().includes(q);
     });
 
-    const isClinicAdmin = profile?.role === "admin";
-    const activeInvites = inviteRecords.filter((record) => record.lifecycle_state === "active");
-    const claimedInvites = inviteRecords.filter((record) => record.lifecycle_state === "claimed");
-    const inactiveInvites = inviteRecords.filter((record) => record.lifecycle_state === "inactive");
-    const latestActiveInvite = activeInvites[0] ?? null;
+    const activeInvites = inviteRecords.filter(
+        (record) => record.lifecycle_state === InviteLifecycleState.ACTIVE,
+    );
+    const claimedInvites = inviteRecords.filter(
+        (record) => record.lifecycle_state === InviteLifecycleState.CLAIMED,
+    );
+    const inactiveInvites = inviteRecords.filter(
+        (record) => record.lifecycle_state === InviteLifecycleState.INACTIVE,
+    );
 
     return (
         <div className="mx-auto max-w-7xl space-y-8">
@@ -523,7 +491,9 @@ export default function SettingsPage() {
                             <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
                                 <div>
                                     <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Role</p>
-                                    <p className="mt-1 font-semibold text-slate-900">{getRoleLabel(profile?.role || "provider")}</p>
+                                    <p className="mt-1 font-semibold text-slate-900">
+                                        {getRoleLabel(profile?.role || ClinicianRole.PROVIDER)}
+                                    </p>
                                 </div>
                                 <div className="mt-3">
                                     <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Email</p>
@@ -579,7 +549,7 @@ export default function SettingsPage() {
                                 <span className="mb-1 block text-sm font-bold uppercase tracking-[0.12em] text-slate-700">Role Access</span>
                                 <select
                                     className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 shadow-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
-                                    onChange={(event) => setInviteRole(event.target.value)}
+                                    onChange={(event) => setInviteRole(event.target.value as ClinicianRole)}
                                     value={inviteRole}
                                 >
                                     {ROLE_OPTIONS.map((option) => (
@@ -702,9 +672,7 @@ export default function SettingsPage() {
                             Generate single-use codes for patient onboarding. New codes remain active until claimed, revoked, or expired.
                         </p>
                         <p className="mt-1 max-w-xl text-xs text-slate-400">
-                            {isClinicAdmin
-                                ? "Invite history shows clinic-wide codes and who issued each one."
-                                : "Invite history shows codes created by your account."}
+                            Invite history shows codes created by your account.
                         </p>
                         <div className="mt-6 flex items-center justify-between rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-5">
                             <div>
@@ -712,11 +680,6 @@ export default function SettingsPage() {
                                 <span className="mt-1 block text-3xl font-bold tracking-[0.14em]">
                                     {inviteCodeLoading ? "LOADING" : inviteCode || "—"}
                                 </span>
-                                {isClinicAdmin && latestActiveInvite?.created_by ? (
-                                    <p className="mt-2 text-xs text-slate-400">
-                                        Issued by {getCreatorLabel(latestActiveInvite)}
-                                    </p>
-                                ) : null}
                             </div>
                             <button
                                 className="rounded-md bg-slate-800 px-3 py-2 text-slate-300"
@@ -753,11 +716,6 @@ export default function SettingsPage() {
                                             <div>
                                                 <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Invite Code</p>
                                                 <p className="font-mono text-lg font-semibold text-slate-900">{record.invite_code || "—"}</p>
-                                                {isClinicAdmin && record.created_by ? (
-                                                    <p className="mt-1 text-xs text-slate-500">
-                                                        Generated by {getCreatorLabel(record)}
-                                                    </p>
-                                                ) : null}
                                             </div>
                                             <div className="flex items-center gap-2">
                                                 <Button
@@ -768,16 +726,14 @@ export default function SettingsPage() {
                                                 >
                                                     Copy
                                                 </Button>
-                                                {!record.created_by || profile?.id === record.created_by.id ? (
-                                                    <Button
-                                                        className="px-3 py-1.5 text-xs"
-                                                        onClick={() => void handleRevokeInviteCode(record.care_team_id)}
-                                                        size="sm"
-                                                        variant="secondary"
-                                                    >
-                                                        {revokingInviteId === record.care_team_id ? "Revoking…" : "Revoke"}
-                                                    </Button>
-                                                ) : null}
+                                                <Button
+                                                    className="px-3 py-1.5 text-xs"
+                                                    onClick={() => void handleRevokeInviteCode(record.care_team_id)}
+                                                    size="sm"
+                                                    variant="secondary"
+                                                >
+                                                    {revokingInviteId === record.care_team_id ? "Revoking…" : "Revoke"}
+                                                </Button>
                                             </div>
                                         </div>
                                         <div className="mt-3 grid gap-2 text-xs text-slate-600 md:grid-cols-2">
@@ -803,7 +759,7 @@ export default function SettingsPage() {
                             <div className="space-y-3">
                                 {claimedInvites.map((record) => (
                                     <div className="rounded-lg border border-slate-200 p-4" key={record.care_team_id}>
-                                        <div className={`grid gap-2 text-sm text-slate-700 ${isClinicAdmin ? "md:grid-cols-4" : "md:grid-cols-3"}`}>
+                                        <div className="grid gap-2 text-sm text-slate-700 md:grid-cols-3">
                                             <p>
                                                 <span className="font-semibold text-slate-900">Code:</span> {record.invite_code || "—"}
                                             </p>
@@ -813,11 +769,6 @@ export default function SettingsPage() {
                                             <p>
                                                 <span className="font-semibold text-slate-900">Claimed:</span> {formatDateTime(record.invite_claimed_at)}
                                             </p>
-                                            {isClinicAdmin && record.created_by ? (
-                                                <p>
-                                                    <span className="font-semibold text-slate-900">Generated By:</span> {getCreatorLabel(record)}
-                                                </p>
-                                            ) : null}
                                         </div>
                                     </div>
                                 ))}
@@ -838,7 +789,7 @@ export default function SettingsPage() {
                             <div className="space-y-3">
                                 {inactiveInvites.map((record) => (
                                     <div className="rounded-lg border border-slate-200 p-4" key={record.care_team_id}>
-                                        <div className={`grid gap-2 text-sm text-slate-700 ${isClinicAdmin ? "md:grid-cols-4" : "md:grid-cols-3"}`}>
+                                        <div className="grid gap-2 text-sm text-slate-700 md:grid-cols-3">
                                             <p>
                                                 <span className="font-semibold text-slate-900">Code:</span> {record.invite_code || "—"}
                                             </p>
@@ -848,11 +799,6 @@ export default function SettingsPage() {
                                             <p>
                                                 <span className="font-semibold text-slate-900">Expired:</span> {record.is_expired ? "Yes" : "No"}
                                             </p>
-                                            {isClinicAdmin && record.created_by ? (
-                                                <p>
-                                                    <span className="font-semibold text-slate-900">Generated By:</span> {getCreatorLabel(record)}
-                                                </p>
-                                            ) : null}
                                         </div>
                                     </div>
                                 ))}

--- a/apps/clinician-portal/src/components/features/chat-transcript.tsx
+++ b/apps/clinician-portal/src/components/features/chat-transcript.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-interface ChatMessage {
-    role: string;
+import { ChatRole } from "@/types";
+
+interface TranscriptMessage {
+    role: typeof ChatRole[keyof typeof ChatRole];
     content: string;
     created_at: string;
     audio_url?: string;
 }
 
 interface ChatTranscriptProps {
-    messages: ChatMessage[];
+    messages: TranscriptMessage[];
 }
 
 function formatTime(isoString: string): string {
@@ -36,7 +38,7 @@ export function ChatTranscript({ messages }: ChatTranscriptProps) {
             className="flex max-h-[480px] flex-col gap-3 overflow-y-auto px-1 py-2"
         >
             {messages.map((msg, idx) => {
-                const isUser = msg.role === "user";
+                const isUser = msg.role === ChatRole.USER;
 
                 return (
                     <div

--- a/apps/clinician-portal/src/components/features/document-upload-zone.tsx
+++ b/apps/clinician-portal/src/components/features/document-upload-zone.tsx
@@ -2,11 +2,20 @@
 
 import { useState, useCallback } from "react";
 import { HiOutlineCloudArrowUp, HiOutlineDocumentText, HiOutlineXMark } from "react-icons/hi2";
+import { DocumentType, UploaderRole } from "@/types";
+
+const UploadStatus = {
+    PENDING: "pending",
+    UPLOADING: "uploading",
+    DONE: "done",
+    ERROR: "error",
+} as const;
+type UploadStatus = (typeof UploadStatus)[keyof typeof UploadStatus];
 
 interface QueuedFile {
     id: string;
     file: File;
-    status: "pending" | "uploading" | "done" | "error";
+    status: UploadStatus;
     error?: string;
 }
 
@@ -25,12 +34,17 @@ const ALLOWED_TYPES = new Set([
 ]);
 const MAX_SIZE_MB = 20;
 const DOCUMENT_TYPES = [
-    { label: "Clinical Note", value: "clinical_note" },
-    { label: "Lab Result", value: "lab_result" },
-    { label: "Prescription", value: "prescription" },
-    { label: "Discharge Summary", value: "discharge_summary" },
-    { label: "Other", value: "other" },
+    { label: "Clinical Note", value: DocumentType.OTHER },
+    { label: "Lab Report", value: DocumentType.LAB_REPORT },
+    { label: "Prescription", value: DocumentType.PRESCRIPTION },
+    { label: "Discharge Summary", value: DocumentType.DISCHARGE_SUMMARY },
+    { label: "Diagnostic Report", value: DocumentType.DIAGNOSTIC_REPORT },
+    { label: "Referral", value: DocumentType.REFERRAL },
 ] as const;
+
+function parseDocumentType(value: string): DocumentType {
+    return DOCUMENT_TYPES.find((type) => type.value === value)?.value ?? DocumentType.OTHER;
+}
 
 function makeId(): string {
     return Math.random().toString(36).slice(2, 10);
@@ -40,7 +54,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
     const [queue, setQueue] = useState<QueuedFile[]>([]);
     const [dragging, setDragging] = useState(false);
     const [uploading, setUploading] = useState(false);
-    const [documentType, setDocumentType] = useState<string>("clinical_note");
+    const [documentType, setDocumentType] = useState<DocumentType>(DocumentType.OTHER);
 
     // ── File validation ──────────────────────────────────────────────────────
 
@@ -57,7 +71,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
         const newItems: QueuedFile[] = valid.map((f) => ({
             id: makeId(),
             file: f,
-            status: "pending",
+            status: UploadStatus.PENDING,
         }));
         setQueue((prev) => [...prev, ...newItems]);
     }, [validateFiles]);
@@ -95,7 +109,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
     // ── Upload handler ───────────────────────────────────────────────────────
 
     async function handleUpload() {
-        const pendingItems = queue.filter((item) => item.status === "pending");
+        const pendingItems = queue.filter((item) => item.status === UploadStatus.PENDING);
         if (pendingItems.length === 0) return;
 
         setUploading(true);
@@ -107,7 +121,9 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
         for (const item of pendingItems) {
             // Mark as uploading
             setQueue((prev) =>
-                prev.map((q) => (q.id === item.id ? { ...q, status: "uploading" } : q)),
+                prev.map((q) =>
+                    q.id === item.id ? { ...q, status: UploadStatus.UPLOADING } : q,
+                ),
             );
 
             try {
@@ -115,7 +131,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
                 formData.append("file", item.file);
                 formData.append("patient_id", patientId);
                 formData.append("document_type", documentType);
-                formData.append("uploaded_by_role", "clinician");
+                formData.append("uploaded_by_role", UploaderRole.CLINICIAN);
 
                 const response = await fetch(`${apiBase}/api/v1/documents/`, {
                     method: "POST",
@@ -131,7 +147,9 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
                 if (data.id) completedIds.push(data.id);
 
                 setQueue((prev) =>
-                    prev.map((q) => (q.id === item.id ? { ...q, status: "done" } : q)),
+                    prev.map((q) =>
+                        q.id === item.id ? { ...q, status: UploadStatus.DONE } : q,
+                    ),
                 );
             } catch (err) {
                 setQueue((prev) =>
@@ -139,7 +157,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
                         q.id === item.id
                             ? {
                                   ...q,
-                                  status: "error",
+                                  status: UploadStatus.ERROR,
                                   error: err instanceof Error ? err.message : "Upload failed",
                               }
                             : q,
@@ -163,7 +181,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
                 <select
                     className="w-full rounded-xl border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     id="upload-document-type"
-                    onChange={(e) => setDocumentType(e.target.value)}
+                    onChange={(e) => setDocumentType(parseDocumentType(e.target.value))}
                     value={documentType}
                 >
                     {DOCUMENT_TYPES.map((type) => (
@@ -245,17 +263,17 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
 
                             <div className="flex items-center gap-3">
                                 {/* Status pill */}
-                                {item.status === "uploading" && (
+                                {item.status === UploadStatus.UPLOADING && (
                                     <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700">
                                         <span className="animate-pulse">●</span> Uploading
                                     </span>
                                 )}
-                                {item.status === "done" && (
+                                {item.status === UploadStatus.DONE && (
                                     <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
                                         ✓ Done
                                     </span>
                                 )}
-                                {item.status === "error" && (
+                                {item.status === UploadStatus.ERROR && (
                                     <span
                                         className="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700"
                                         title={item.error}
@@ -265,7 +283,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
                                 )}
 
                                 {/* Remove button */}
-                                {item.status !== "uploading" && (
+                                {item.status !== UploadStatus.UPLOADING && (
                                     <button
                                         aria-label={`Remove ${item.file.name}`}
                                         className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
@@ -282,7 +300,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
             )}
 
             {/* Upload button */}
-            {queue.some((item) => item.status === "pending") && (
+            {queue.some((item) => item.status === UploadStatus.PENDING) && (
                 <button
                     className="w-full rounded-xl bg-blue-600 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={uploading}
@@ -292,7 +310,7 @@ export function DocumentUploadZone({ patientId, onComplete }: DocumentUploadZone
                 >
                     {uploading
                         ? "Uploading..."
-                        : `Upload ${queue.filter((q) => q.status === "pending").length} file(s)`}
+                        : `Upload ${queue.filter((q) => q.status === UploadStatus.PENDING).length} file(s)`}
                 </button>
             )}
         </div>

--- a/apps/clinician-portal/src/components/layouts/sidebar.tsx
+++ b/apps/clinician-portal/src/components/layouts/sidebar.tsx
@@ -8,7 +8,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { clearStoredSession } from "@/services/auth-session";
 import { api } from "@/services/api";
 import { logout } from "@/store/slices/auth-slice";
-import type { RootState } from "@/store/store";
+import type { AppDispatch, RootState } from "@/store/store";
+import { ClinicianRole, PortalUserRole } from "@/types";
 
 const primaryNavigation = [
     { href: "/dashboard", icon: HiOutlineChartBarSquare, label: "Risk Radar" },
@@ -20,16 +21,18 @@ const primaryNavigation = [
 interface SidebarClinicianProfile {
     first_name: string;
     last_name: string;
-    role: string;
+    role: ClinicianRole;
 }
 
-function getRoleMeta(role: string) {
+type SidebarRole = ClinicianRole | typeof PortalUserRole.CLINICIAN;
+
+function getRoleMeta(role: SidebarRole) {
     switch (role) {
-        case "admin":
+        case ClinicianRole.ADMIN:
             return { label: "Clinic Admin", tone: "bg-blue-500/20 text-blue-200" };
-        case "nurse":
+        case ClinicianRole.NURSE:
             return { label: "Nurse / MA", tone: "bg-purple-500/20 text-purple-200" };
-        case "provider":
+        case ClinicianRole.PROVIDER:
             return { label: "Provider", tone: "bg-emerald-500/20 text-emerald-200" };
         default:
             return { label: "Clinician", tone: "bg-slate-500/20 text-slate-200" };
@@ -39,7 +42,7 @@ function getRoleMeta(role: string) {
 export function Sidebar() {
     const pathname = usePathname();
     const router = useRouter();
-    const dispatch = useDispatch();
+    const dispatch = useDispatch<AppDispatch>();
     const user = useSelector((state: RootState) => state.auth.user);
     const token = useSelector((state: RootState) => state.auth.accessToken);
     const [profile, setProfile] = useState<SidebarClinicianProfile | null>(null);
@@ -74,7 +77,7 @@ export function Sidebar() {
 
     const email = user?.email ?? "clinician@mediagent.local";
     const displayName = profile ? `${profile.first_name} ${profile.last_name}` : "Clinician";
-    const roleMeta = getRoleMeta(profile?.role ?? user?.role ?? "clinician");
+    const roleMeta = getRoleMeta(profile?.role ?? user?.role ?? PortalUserRole.CLINICIAN);
     const initials = displayName
         .split(" ")
         .filter(Boolean)

--- a/apps/clinician-portal/src/services/clinicians.ts
+++ b/apps/clinician-portal/src/services/clinicians.ts
@@ -5,6 +5,7 @@
  * Functions return typed data or throw on HTTP errors.
  */
 
+import { ChatRole } from "@/types";
 import type { Medication, SymptomReport } from "@/types";
 import { readStoredSession } from "@/services/auth-session";
 
@@ -116,7 +117,12 @@ export interface PatientDeepDive {
     medications: Medication[];
     adherence_series: AdherenceDataPoint[];
     symptom_reports: SymptomReport[];
-    chat_messages: Array<{ role: string; content: string; created_at: string }>;
+    chat_messages: Array<{
+        role: typeof ChatRole[keyof typeof ChatRole];
+        content: string;
+        created_at: string;
+        audio_url?: string;
+    }>;
     conditions: Array<{ name?: string; icd10_code?: string; created_at?: string }>;
     allergies: Array<{ allergen: string; severity?: string }>;
     documents: Array<{
@@ -139,6 +145,21 @@ export interface PatientDeepDive {
         created_at?: string;
     }>;
     obligation_completion_rate?: number;
+}
+
+type ApiMedicationRecord = Partial<Medication> & Record<string, unknown>;
+type ApiSymptomReportRecord = Partial<SymptomReport> & Record<string, unknown>;
+interface ApiChatMessageRecord {
+    role: string;
+    content: string;
+    created_at: string;
+    audio_url?: string;
+}
+
+interface PatientDeepDiveResponse extends Omit<PatientDeepDive, "medications" | "symptom_reports" | "chat_messages"> {
+    medications: ApiMedicationRecord[];
+    symptom_reports: ApiSymptomReportRecord[];
+    chat_messages: ApiChatMessageRecord[];
 }
 
 export interface ObligationSetPayload {
@@ -217,6 +238,17 @@ function normalizeSymptomReport(raw: Record<string, unknown>): SymptomReport {
     };
 }
 
+function normalizeChatRole(role: string): typeof ChatRole[keyof typeof ChatRole] {
+    switch (role) {
+        case ChatRole.USER:
+            return ChatRole.USER;
+        case ChatRole.ASSISTANT:
+            return ChatRole.ASSISTANT;
+        default:
+            return ChatRole.SYSTEM;
+    }
+}
+
 // ── API functions ─────────────────────────────────────────────────────────────
 
 /** Fetch aggregated risk dashboard for all assigned patients. */
@@ -238,18 +270,20 @@ export async function fetchDashboard(params?: DashboardQueryParams): Promise<Das
 
 /** Fetch full patient deep dive data (all sub-resources). */
 export async function fetchPatientDeepDive(patientId: string): Promise<PatientDeepDive> {
-    const data = await apiFetch<PatientDeepDive>(
+    const data = await apiFetch<PatientDeepDiveResponse>(
         `/api/v1/clinicians/me/patients/${patientId}/deep-dive`,
     );
 
     return {
         ...data,
-        medications: (data.medications ?? []).map((m) =>
-            normalizeMedication(m as unknown as Record<string, unknown>),
+        medications: (data.medications ?? []).map((medication) => normalizeMedication(medication)),
+        symptom_reports: (data.symptom_reports ?? []).map((report) =>
+            normalizeSymptomReport(report),
         ),
-        symptom_reports: (data.symptom_reports ?? []).map((s) =>
-            normalizeSymptomReport(s as unknown as Record<string, unknown>),
-        ),
+        chat_messages: (data.chat_messages ?? []).map((message) => ({
+            ...message,
+            role: normalizeChatRole(message.role),
+        })),
     };
 }
 

--- a/apps/clinician-portal/src/store/provider.tsx
+++ b/apps/clinician-portal/src/store/provider.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { api } from "@/services/api";
 import { clearStoredSession, restoreStoredSession } from "@/services/auth-session";
 import { Provider } from "react-redux";
+import { PortalUserRole } from "@/types";
 import { finishHydration, hydrateSession, type ClinicianAuthSession } from "./slices/auth-slice";
 import { store } from "./store";
 
@@ -23,14 +24,14 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                         user: {
                             email: string;
                             id: string;
-                            role: "patient" | "clinician";
+                            role: typeof PortalUserRole[keyof typeof PortalUserRole];
                         };
                     }>("/api/v1/auth/refresh", {
-                        expected_role: "clinician",
+                        expected_role: PortalUserRole.CLINICIAN,
                         refresh_token: refreshToken,
                     });
 
-                    if (response.user.role !== "clinician") {
+                    if (response.user.role !== PortalUserRole.CLINICIAN) {
                         throw new Error("This session belongs to a patient account.");
                     }
 
@@ -41,7 +42,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                         user: {
                             email: response.user.email,
                             id: response.user.id,
-                            role: "clinician",
+                            role: PortalUserRole.CLINICIAN,
                         },
                     } satisfies ClinicianAuthSession;
                 },

--- a/apps/clinician-portal/src/types/index.ts
+++ b/apps/clinician-portal/src/types/index.ts
@@ -31,6 +31,9 @@ export type {
 export {
     Language,
     ClinicianRole,
+    PortalUserRole,
+    ChatRole,
+    UploaderRole,
     NaranjoCausality,
     ADRStatus,
     MedWatchStatus,

--- a/apps/clinician-portal/tsconfig.json
+++ b/apps/clinician-portal/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -27,8 +33,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/apps/patient-portal/src/app/(app)/profile/page.tsx
+++ b/apps/patient-portal/src/app/(app)/profile/page.tsx
@@ -10,7 +10,8 @@ import { clearStoredSession } from "@/services/auth-session";
 import { Badge, Button, Card, EmptyState, ErrorState, Input, Skeleton } from "@/components/ui";
 import { logout } from "@/store/slices/auth-slice";
 import type { AppDispatch, RootState } from "@/store/store";
-import type { CareTeamMember, Language, Patient } from "@/types";
+import { Language } from "@/types";
+import type { CareTeamMember, Patient } from "@/types";
 
 interface PatientProfileResponse {
     id: string;
@@ -65,7 +66,7 @@ function mapCareTeamMember(member: CareTeamResponse): CareTeamMember {
 }
 
 function formatLanguage(language: Language) {
-    return language === "es" ? "Spanish" : "English";
+    return language === Language.ES ? "Spanish" : "English";
 }
 
 export default function ProfilePage() {

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -290,18 +290,12 @@ export default function RecordsPage() {
         }
     }
 
-<<<<<<< HEAD
     async function handleLanguageChange(language: Language) {
         setExplanationLang(language);
         if (language === Language.EN && selectedDocument?.parseStatus === "completed") {
             setExplanationText(selectedDocument.aiSummary ?? null);
             return;
         }
-
-=======
-    async function handleLanguageChange(lang: Language) {
-        setExplanationLang(lang);
->>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
         if (!selectedDocument) {
             return;
         }
@@ -310,14 +304,6 @@ export default function RecordsPage() {
             return;
         }
 
-<<<<<<< HEAD
-=======
-        if (lang === Language.EN) {
-            setExplanationText(selectedDocument.aiSummary ?? null);
-            return;
-        }
-
->>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
         setExplanationLoading(true);
         try {
             const result = await api.post<{ summary: string }>(
@@ -441,32 +427,7 @@ export default function RecordsPage() {
                         id={document.id}
                         key={document.id}
                         name={document.fileName}
-<<<<<<< HEAD
-                        onClick={() => {
-                            setSelectedDocument(document);
-                            setExplanationLang(Language.EN);
-                            setExplanationLoading(false);
-                            if (document.parseStatus === "failed") {
-                                setExplanationText(
-                                    document.parseError ?? "This document could not be processed.",
-                                );
-                                return;
-                            }
-                            if (
-                                document.parseStatus === "pending"
-                                || document.parseStatus === "processing"
-                                || parsingDocIds.has(document.id)
-                            ) {
-                                setExplanationText(
-                                    "Processing this document. AI summary will appear when parsing completes.",
-                                );
-                                return;
-                            }
-                            setExplanationText(document.aiSummary ?? null);
-                        }}
-=======
                         onClick={() => openDocument(document)}
->>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
                         provider={document.provider}
                         statusLabel={status?.label}
                         statusVariant={status?.variant}
@@ -489,17 +450,7 @@ export default function RecordsPage() {
                             <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">Explain this to me</p>
                             <select
                                 className="rounded-lg border border-blue-200 bg-white px-2 py-1 text-xs text-blue-700"
-<<<<<<< HEAD
                                 onChange={(event) => handleLanguageChange(event.target.value as Language)}
-=======
-                                onChange={(event) =>
-                                    handleLanguageChange(
-                                        event.target.value === Language.ES
-                                            ? Language.ES
-                                            : Language.EN,
-                                    )
-                                }
->>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
                                 value={explanationLang}
                             >
                                 <option value={Language.EN}>English</option>

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -44,6 +44,26 @@ interface DocumentApiRecord {
     created_at: string;
 }
 
+const EXPLANATION_UNAVAILABLE_MESSAGE =
+    "Translation is currently unavailable. Please try again later.";
+const PARSING_IN_PROGRESS_MESSAGE =
+    "Processing this document. AI summary will appear when parsing completes.";
+const PARSING_FAILED_FALLBACK_MESSAGE = "This document could not be processed.";
+const PARSING_TIMEOUT_MESSAGE =
+    "Timed out while waiting for document processing to finish.";
+
+function addTrackedDocumentId(current: Set<string>, documentId: string) {
+    const next = new Set(current);
+    next.add(documentId);
+    return next;
+}
+
+function removeTrackedDocumentId(current: Set<string>, documentId: string) {
+    const next = new Set(current);
+    next.delete(documentId);
+    return next;
+}
+
 function getDocumentIcon(documentType: DocumentType) {
     switch (documentType) {
         case DocumentType.LAB_REPORT:
@@ -150,6 +170,28 @@ export default function RecordsPage() {
         }
     }, [accessToken]);
 
+    const openDocument = useCallback((document: PortalDocument) => {
+        setSelectedDocument(document);
+        setExplanationLang(Language.EN);
+        setExplanationLoading(false);
+
+        if (document.parseStatus === "failed") {
+            setExplanationText(document.parseError ?? PARSING_FAILED_FALLBACK_MESSAGE);
+            return;
+        }
+
+        if (
+            document.parseStatus === "pending"
+            || document.parseStatus === "processing"
+            || parsingDocIds.has(document.id)
+        ) {
+            setExplanationText(PARSING_IN_PROGRESS_MESSAGE);
+            return;
+        }
+
+        setExplanationText(document.aiSummary ?? null);
+    }, [parsingDocIds]);
+
     useEffect(() => {
         if (!accessToken) {
             return;
@@ -159,7 +201,7 @@ export default function RecordsPage() {
     }, [accessToken, loadDocuments]);
 
     async function pollForParsedStatus(docId: string) {
-        setParsingDocIds((current) => new Set(current).add(docId));
+        setParsingDocIds((current) => addTrackedDocumentId(current, docId));
 
         for (let attempt = 0; attempt < 10; attempt += 1) {
             await new Promise((resolve) => window.setTimeout(resolve, 3000));
@@ -178,11 +220,7 @@ export default function RecordsPage() {
                 );
 
                 if (nextDocument.parsed || nextDocument.parseStatus === "completed") {
-                    setParsingDocIds((current) => {
-                        const next = new Set(current);
-                        next.delete(docId);
-                        return next;
-                    });
+                    setParsingDocIds((current) => removeTrackedDocumentId(current, docId));
                     return;
                 }
 
@@ -192,11 +230,7 @@ export default function RecordsPage() {
                             ? `Failed to process document: ${nextDocument.parseError}`
                             : "Failed to process document.",
                     );
-                    setParsingDocIds((current) => {
-                        const next = new Set(current);
-                        next.delete(docId);
-                        return next;
-                    });
+                    setParsingDocIds((current) => removeTrackedDocumentId(current, docId));
                     return;
                 }
             } catch {
@@ -204,12 +238,8 @@ export default function RecordsPage() {
             }
         }
 
-        setParsingDocIds((current) => {
-            const next = new Set(current);
-            next.delete(docId);
-            return next;
-        });
-        setParseError("Timed out while waiting for document processing to finish.");
+        setParsingDocIds((current) => removeTrackedDocumentId(current, docId));
+        setParseError(PARSING_TIMEOUT_MESSAGE);
     }
 
     async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -260,6 +290,7 @@ export default function RecordsPage() {
         }
     }
 
+<<<<<<< HEAD
     async function handleLanguageChange(language: Language) {
         setExplanationLang(language);
         if (language === Language.EN && selectedDocument?.parseStatus === "completed") {
@@ -267,6 +298,10 @@ export default function RecordsPage() {
             return;
         }
 
+=======
+    async function handleLanguageChange(lang: Language) {
+        setExplanationLang(lang);
+>>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
         if (!selectedDocument) {
             return;
         }
@@ -275,6 +310,14 @@ export default function RecordsPage() {
             return;
         }
 
+<<<<<<< HEAD
+=======
+        if (lang === Language.EN) {
+            setExplanationText(selectedDocument.aiSummary ?? null);
+            return;
+        }
+
+>>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
         setExplanationLoading(true);
         try {
             const result = await api.post<{ summary: string }>(
@@ -284,7 +327,7 @@ export default function RecordsPage() {
             );
             setExplanationText(result.summary);
         } catch {
-            setExplanationText("Translation is currently unavailable. Please try again later.");
+            setExplanationText(EXPLANATION_UNAVAILABLE_MESSAGE);
         } finally {
             setExplanationLoading(false);
         }
@@ -398,6 +441,7 @@ export default function RecordsPage() {
                         id={document.id}
                         key={document.id}
                         name={document.fileName}
+<<<<<<< HEAD
                         onClick={() => {
                             setSelectedDocument(document);
                             setExplanationLang(Language.EN);
@@ -420,6 +464,9 @@ export default function RecordsPage() {
                             }
                             setExplanationText(document.aiSummary ?? null);
                         }}
+=======
+                        onClick={() => openDocument(document)}
+>>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
                         provider={document.provider}
                         statusLabel={status?.label}
                         statusVariant={status?.variant}
@@ -442,7 +489,17 @@ export default function RecordsPage() {
                             <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">Explain this to me</p>
                             <select
                                 className="rounded-lg border border-blue-200 bg-white px-2 py-1 text-xs text-blue-700"
+<<<<<<< HEAD
                                 onChange={(event) => handleLanguageChange(event.target.value as Language)}
+=======
+                                onChange={(event) =>
+                                    handleLanguageChange(
+                                        event.target.value === Language.ES
+                                            ? Language.ES
+                                            : Language.EN,
+                                    )
+                                }
+>>>>>>> c0aa63a (refactor(frontend): tighten shared portal typing and UI contracts)
                                 value={explanationLang}
                             >
                                 <option value={Language.EN}>English</option>

--- a/apps/patient-portal/src/app/(app)/today/page.tsx
+++ b/apps/patient-portal/src/app/(app)/today/page.tsx
@@ -3,8 +3,10 @@
 import Link from "next/link";
 import { HiOutlineCalendarDays, HiOutlineCheck } from "react-icons/hi2";
 import { CircularProgress, MedicationCard, ObligationCard } from "@/components/features";
+import type { TaskCardStatus } from "@/components/features/task-card.types";
 import { Badge, Card, EmptyState, Skeleton } from "@/components/ui";
 import { useFeedData } from "@/hooks/use-feed-data";
+import type { FeedTask } from "@/types";
 
 function splitMedicationName(name: string) {
     const match = name.match(/^(.*?)(\s+\d.*)$/);
@@ -14,7 +16,7 @@ function splitMedicationName(name: string) {
     };
 }
 
-function mapTaskStatus(status: "completed" | "missed" | "pending" | "skipped") {
+function mapTaskStatus(status: FeedTask["status"]): TaskCardStatus {
     if (status === "pending") {
         return "active";
     }
@@ -26,7 +28,7 @@ function mapTaskStatus(status: "completed" | "missed" | "pending" | "skipped") {
     return status;
 }
 
-function formatTimeLabel(scheduledTime?: string, status?: "completed" | "missed" | "pending" | "skipped") {
+function formatTimeLabel(scheduledTime?: string, status?: FeedTask["status"]) {
     if (!scheduledTime) {
         return "Any time";
     }

--- a/apps/patient-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/patient-portal/src/app/(auth)/signup/page.tsx
@@ -10,6 +10,7 @@ import { writeStoredSession } from "@/services/auth-session";
 import { hydrateSession, type PatientAuthSession } from "@/store/slices/auth-slice";
 import { setOnboardingProfile } from "@/store/slices/onboarding-slice";
 import type { AppDispatch } from "@/store/store";
+import { PortalUserRole } from "@/types";
 
 interface SignupResponse {
     tokens: {
@@ -20,7 +21,7 @@ interface SignupResponse {
     user: {
         email: string;
         id: string;
-        role: "patient" | "clinician";
+        role: typeof PortalUserRole[keyof typeof PortalUserRole];
     };
 }
 
@@ -55,7 +56,7 @@ export default function SignupPage() {
                 password: formData.password,
             });
 
-            if (response.user.role !== "patient") {
+            if (response.user.role !== PortalUserRole.PATIENT) {
                 throw new Error("Signup did not create a patient account.");
             }
 
@@ -63,7 +64,7 @@ export default function SignupPage() {
                 accessToken: response.tokens.access_token,
                 expiresAt: response.tokens.expires_at,
                 refreshToken: response.tokens.refresh_token,
-                user: { ...response.user, role: "patient" },
+                user: { ...response.user, role: PortalUserRole.PATIENT },
             };
             writeStoredSession(session);
             dispatch(

--- a/apps/patient-portal/src/app/login/page.tsx
+++ b/apps/patient-portal/src/app/login/page.tsx
@@ -9,6 +9,7 @@ import { api } from "@/services/api";
 import { writeStoredSession } from "@/services/auth-session";
 import { hydrateSession, type PatientAuthSession } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
+import { PortalUserRole } from "@/types";
 
 interface AuthResponse {
     tokens: {
@@ -19,7 +20,7 @@ interface AuthResponse {
     user: {
         email: string;
         id: string;
-        role: "patient" | "clinician";
+        role: typeof PortalUserRole[keyof typeof PortalUserRole];
     };
 }
 
@@ -42,14 +43,14 @@ export default function LoginPage() {
 
         try {
             const response = await api.post<AuthResponse>("/api/v1/auth/login", { email, password });
-            if (response.user.role !== "patient") {
+            if (response.user.role !== PortalUserRole.PATIENT) {
                 throw new Error("This login belongs to a clinician account.");
             }
             const session: PatientAuthSession = {
                 accessToken: response.tokens.access_token,
                 expiresAt: response.tokens.expires_at,
                 refreshToken: response.tokens.refresh_token,
-                user: { ...response.user, role: "patient" },
+                user: { ...response.user, role: PortalUserRole.PATIENT },
             };
             writeStoredSession(session);
             dispatch(hydrateSession(session));

--- a/apps/patient-portal/src/components/features/chat-bubble.tsx
+++ b/apps/patient-portal/src/components/features/chat-bubble.tsx
@@ -1,8 +1,8 @@
 import { HiMiniSpeakerWave } from "react-icons/hi2";
-import type { Language } from "@/types";
+import { ChatRole, Language } from "@/types";
 
 interface ChatBubbleProps {
-    role: "user" | "assistant";
+    role: typeof ChatRole.USER | typeof ChatRole.ASSISTANT;
     content: string;
     timestamp: Date | string;
     language?: Language;
@@ -23,7 +23,7 @@ function formatLanguage(language?: Language): string | null {
         return null;
     }
 
-    return language === "es" ? "ES" : "EN";
+    return language === Language.ES ? "ES" : "EN";
 }
 
 export function ChatBubble({
@@ -34,7 +34,7 @@ export function ChatBubble({
     role,
     timestamp,
 }: ChatBubbleProps) {
-    const isUser = role === "user";
+    const isUser = role === ChatRole.USER;
     const languageLabel = formatLanguage(language);
 
     return (

--- a/apps/patient-portal/src/components/features/medication-card.tsx
+++ b/apps/patient-portal/src/components/features/medication-card.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, Card } from "@/components/ui";
+import type { TaskCardStatus } from "./task-card.types";
 
 interface MedicationCardProps {
     id: string;
@@ -7,7 +8,7 @@ interface MedicationCardProps {
     time: string;
     instructions?: string;
     prescriber?: string;
-    status: "completed" | "active" | "upcoming" | "missed";
+    status: TaskCardStatus;
     onMarkComplete: (id: string) => void;
 }
 

--- a/apps/patient-portal/src/components/features/obligation-card.tsx
+++ b/apps/patient-portal/src/components/features/obligation-card.tsx
@@ -1,11 +1,12 @@
 import { Badge, Button, Card } from "@/components/ui";
+import type { TaskCardStatus } from "./task-card.types";
 
 interface ObligationCardProps {
     id: string;
     description: string;
     type: "diet" | "exercise" | "custom";
     time: string;
-    status: "completed" | "active" | "upcoming" | "missed";
+    status: TaskCardStatus;
     onMarkComplete: (id: string) => void;
 }
 

--- a/apps/patient-portal/src/components/features/task-card.types.ts
+++ b/apps/patient-portal/src/components/features/task-card.types.ts
@@ -1,0 +1,1 @@
+export type TaskCardStatus = "completed" | "active" | "upcoming" | "missed";

--- a/apps/patient-portal/src/store/provider.tsx
+++ b/apps/patient-portal/src/store/provider.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { api } from "@/services/api";
 import { clearStoredSession, restoreStoredSession } from "@/services/auth-session";
 import { Provider } from "react-redux";
+import { PortalUserRole } from "@/types";
 import { finishHydration, hydrateSession, type PatientAuthSession } from "./slices/auth-slice";
 import { store } from "./store";
 
@@ -23,14 +24,14 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                         user: {
                             email: string;
                             id: string;
-                            role: "patient" | "clinician";
+                            role: typeof PortalUserRole[keyof typeof PortalUserRole];
                         };
                     }>("/api/v1/auth/refresh", {
-                        expected_role: "patient",
+                        expected_role: PortalUserRole.PATIENT,
                         refresh_token: refreshToken,
                     });
 
-                    if (response.user.role !== "patient") {
+                    if (response.user.role !== PortalUserRole.PATIENT) {
                         throw new Error("This session belongs to a clinician account.");
                     }
 
@@ -41,7 +42,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                         user: {
                             email: response.user.email,
                             id: response.user.id,
-                            role: "patient",
+                            role: PortalUserRole.PATIENT,
                         },
                     } satisfies PatientAuthSession;
                 },

--- a/apps/patient-portal/src/types/index.ts
+++ b/apps/patient-portal/src/types/index.ts
@@ -23,6 +23,8 @@ export type {
     TodayFeedResponse,
     Condition,
     Allergy,
+    DocumentVisibility,
+    UploaderRole,
     ApiErrorResponse,
     PaginatedResponse,
 } from "../../../../packages/shared/src/types";
@@ -32,6 +34,7 @@ export {
     Gender,
     ChatRole,
     DocumentType,
+    PortalUserRole,
     MedicationRoute,
     ObligationType,
     AdherenceStatus,

--- a/apps/patient-portal/tsconfig.json
+++ b/apps/patient-portal/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -27,8 +33,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -29,6 +29,9 @@ export type DocumentVisibility = (typeof DocumentVisibility)[keyof typeof Docume
 export const UploaderRole = { PATIENT: "patient", CLINICIAN: "clinician" } as const;
 export type UploaderRole = (typeof UploaderRole)[keyof typeof UploaderRole];
 
+export const PortalUserRole = { PATIENT: "patient", CLINICIAN: "clinician" } as const;
+export type PortalUserRole = (typeof PortalUserRole)[keyof typeof PortalUserRole];
+
 export const MedicationRoute = {
     ORAL: "oral", TOPICAL: "topical", IV: "iv", IM: "im",
     SUBCUTANEOUS: "subcutaneous", INHALED: "inhaled", OTHER: "other",


### PR DESCRIPTION
## Summary
- tighten shared portal typing and enum usage across both frontend portals
- clean repeated UI contract handling and keep the records-to-chat flow intact after rebase
- restore clinician login clinic verification and MFA-aware branching on top of main

## Verification
- cd apps/patient-portal && npm run lint
- cd apps/patient-portal && ./node_modules/.bin/tsc --noEmit --tsBuildInfoFile /tmp/patient-portal-rebase-check.tsbuildinfo
- cd apps/patient-portal && npm run test
- cd apps/clinician-portal && npm run lint
- cd apps/clinician-portal && ./node_modules/.bin/tsc --noEmit --tsBuildInfoFile /tmp/clinician-portal-rebase-check.tsbuildinfo
- cd apps/clinician-portal && npm run test