### PR TITLE
fix(clinician-portal): redirect legacy MFA route to /settings/mfa

### DIFF
--- a/apps/clinician-portal/next.config.ts
+++ b/apps/clinician-portal/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/dashboard/settings/mfa",
+        destination: "/settings/mfa",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/clinician-portal/src/__tests__/login-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/login-page.test.tsx
@@ -178,6 +178,10 @@ describe("Clinician login page", () => {
         });
         expect(await screen.findByText(/verify mfa/i)).toBeInTheDocument();
         expect(screen.getByText(/clinic authenticator/i)).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /open mfa settings/i })).toHaveAttribute(
+            "href",
+            "/settings/mfa",
+        );
         expect(writeStoredSession).not.toHaveBeenCalled();
         expect(replace).not.toHaveBeenCalled();
     });

--- a/apps/clinician-portal/src/app/(auth)/login/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/login/page.tsx
@@ -317,7 +317,7 @@ export default function ClinicianLoginPage() {
                                 <button className="text-blue-600" onClick={() => setStage("login")} type="button">
                                     Back
                                 </button>
-                                <Link className="text-blue-600" href="/dashboard/settings/mfa">
+                                <Link className="text-blue-600" href="/settings/mfa">
                                     Open MFA settings
                                 </Link>
                             </div>


### PR DESCRIPTION
## Summary
- add a Next.js redirect from legacy `/dashboard/settings/mfa` to canonical `/settings/mfa`
- prevent 404 during MFA setup flow from stale/deployed frontend links

## Why
Production traffic requests `/dashboard/settings/mfa?_rsc=...` and receives 404, while `/settings/mfa` exists and returns 200.

## Validation
- `cd apps/clinician-portal && npm run lint`
- `cd apps/clinician-portal && npm run build`
- confirmed canonical route `/settings/mfa` exists
- redirect now handles legacy path safely
