### PR TITLE
fix(clinician-portal): complete MFA verification during login

### DIFF
--- a/apps/clinician-portal/src/__tests__/login-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/login-page.test.tsx
@@ -177,13 +177,86 @@ describe("Clinician login page", () => {
             password: "SecurePass123!",
         });
         expect(await screen.findByText(/verify mfa/i)).toBeInTheDocument();
-        expect(screen.getByText(/clinic authenticator/i)).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /open mfa settings/i })).toHaveAttribute(
-            "href",
-            "/settings/mfa",
-        );
+        expect(screen.getAllByText(/clinic authenticator/i).length).toBeGreaterThan(0);
+        expect(screen.getByLabelText(/6-digit code/i)).toBeInTheDocument();
         expect(writeStoredSession).not.toHaveBeenCalled();
         expect(replace).not.toHaveBeenCalled();
+    });
+
+    it("verifies MFA code and completes login", async () => {
+        post.mockResolvedValueOnce({
+            clinic_code: "ABC123",
+            clinic_id: "clinic-1",
+            clinic_name: "City Health",
+            status: "active",
+        });
+        post.mockResolvedValueOnce({
+            tokens: {
+                access_token: "aal1-access-token",
+                expires_at: 1234567890,
+                refresh_token: "aal1-refresh-token",
+            },
+            mfa_factors: [{ id: "factor-1", friendly_name: "Clinic Authenticator" }],
+            mfa_required: true,
+            user: {
+                email: "doctor@example.com",
+                id: "clinician-1",
+                role: "clinician",
+            },
+        });
+        post.mockResolvedValueOnce({
+            access_token: "aal2-access-token",
+            expires_at: 2234567890,
+            refresh_token: "aal2-refresh-token",
+            token_type: "bearer",
+        });
+
+        render(<ClinicianLoginPage />);
+
+        fireEvent.change(await screen.findByLabelText(/clinic code/i), {
+            target: { value: "abc123" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /verify clinic code/i }));
+        fireEvent.click(await screen.findByRole("button", { name: /already have an account/i }));
+
+        fireEvent.change(screen.getByLabelText(/email/i), {
+            target: { value: "doctor@example.com" },
+        });
+        fireEvent.change(screen.getByLabelText(/^password$/i), {
+            target: { value: "SecurePass123!" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+        await screen.findByText(/verify mfa/i);
+
+        fireEvent.change(screen.getByLabelText(/6-digit code/i), {
+            target: { value: "123456" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /verify and continue/i }));
+
+        expect(post).toHaveBeenNthCalledWith(
+            3,
+            "/api/v1/auth/mfa/verify",
+            { code: "123456", factor_id: "factor-1" },
+            {
+                headers: { "X-Refresh-Token": "aal1-refresh-token" },
+                token: "aal1-access-token",
+            },
+        );
+
+        await waitFor(() => {
+            expect(writeStoredSession).toHaveBeenCalledWith({
+                accessToken: "aal2-access-token",
+                expiresAt: 2234567890,
+                refreshToken: "aal2-refresh-token",
+                user: {
+                    email: "doctor@example.com",
+                    id: "clinician-1",
+                    role: "clinician",
+                },
+            });
+            expect(replace).toHaveBeenCalledWith("/dashboard");
+        });
     });
 
     it("revalidates saved clinic context before trusting it", async () => {

--- a/apps/clinician-portal/src/app/(auth)/login/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/login/page.tsx
@@ -37,6 +37,18 @@ interface MFAFactorSummary {
     id: string;
 }
 
+interface MFAVerifyResponse {
+    access_token: string;
+    expires_at: number;
+    refresh_token: string;
+}
+
+interface PendingMFAChallenge {
+    factorId: string;
+    friendlyName: string;
+    session: ClinicianAuthSession;
+}
+
 interface ClinicResolveResponse {
     clinic_code: string;
     clinic_id: string;
@@ -66,6 +78,9 @@ export default function ClinicianLoginPage() {
     const [error, setError] = useState("");
     const [clinicCodeError, setClinicCodeError] = useState("");
     const [mfaFactors, setMfaFactors] = useState<MFAFactorSummary[]>([]);
+    const [mfaCode, setMfaCode] = useState("");
+    const [pendingMFAChallenge, setPendingMFAChallenge] =
+        useState<PendingMFAChallenge | null>(null);
     const [submitting, setSubmitting] = useState(false);
 
     useEffect(() => {
@@ -152,6 +167,8 @@ export default function ClinicianLoginPage() {
         setSubmitting(true);
         setError("");
         setMfaFactors([]);
+        setMfaCode("");
+        setPendingMFAChallenge(null);
 
         if (!clinicContext) {
             setError("Enter and verify your clinic code first.");
@@ -170,7 +187,29 @@ export default function ClinicianLoginPage() {
             }
 
             if (response.mfa_required) {
-                setMfaFactors(response.mfa_factors ?? []);
+                const factors = response.mfa_factors ?? [];
+                const primaryFactor = factors[0];
+                if (!primaryFactor) {
+                    throw new Error("MFA is required but no verified factor is available.");
+                }
+
+                const pendingSession: ClinicianAuthSession = {
+                    accessToken: response.tokens.access_token,
+                    expiresAt: response.tokens.expires_at,
+                    refreshToken: response.tokens.refresh_token,
+                    user: {
+                        email: response.user.email,
+                        id: response.user.id,
+                        role: PortalUserRole.CLINICIAN,
+                    },
+                };
+
+                setMfaFactors(factors);
+                setPendingMFAChallenge({
+                    factorId: primaryFactor.id,
+                    friendlyName: primaryFactor.friendly_name ?? "Authenticator",
+                    session: pendingSession,
+                });
                 setStage("mfa");
                 return;
             }
@@ -196,6 +235,49 @@ export default function ClinicianLoginPage() {
                 return;
             }
             setError(message);
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function handleMFAVerify(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!pendingMFAChallenge) {
+            return;
+        }
+
+        const code = mfaCode.trim();
+        if (!/^\d{6}$/.test(code)) {
+            setError("Enter the 6-digit code from your authenticator app.");
+            return;
+        }
+
+        setSubmitting(true);
+        setError("");
+
+        try {
+            const response = await api.post<MFAVerifyResponse>(
+                "/api/v1/auth/mfa/verify",
+                { factor_id: pendingMFAChallenge.factorId, code },
+                {
+                    headers: {
+                        "X-Refresh-Token": pendingMFAChallenge.session.refreshToken,
+                    },
+                    token: pendingMFAChallenge.session.accessToken,
+                },
+            );
+
+            const session: ClinicianAuthSession = {
+                accessToken: response.access_token,
+                expiresAt: response.expires_at,
+                refreshToken: response.refresh_token,
+                user: pendingMFAChallenge.session.user,
+            };
+            writeStoredSession(session);
+            dispatch(hydrateSession(session));
+            router.replace("/dashboard");
+        } catch (submissionError) {
+            setError((submissionError as Error).message);
         } finally {
             setSubmitting(false);
         }
@@ -312,9 +394,32 @@ export default function ClinicianLoginPage() {
                                     <p>Authenticator</p>
                                 )}
                             </div>
-                            {error ? <p className="text-sm text-red-600">{error}</p> : null}
+                            <form className="space-y-4" onSubmit={handleMFAVerify}>
+                                <Input
+                                    autoComplete="one-time-code"
+                                    inputMode="numeric"
+                                    label={`6-digit code (${pendingMFAChallenge?.friendlyName ?? "Authenticator"})`}
+                                    maxLength={6}
+                                    onChange={(event) => setMfaCode(event.target.value.replace(/\D/g, ""))}
+                                    placeholder="000000"
+                                    value={mfaCode}
+                                />
+                                {error ? <p className="text-sm text-red-600">{error}</p> : null}
+                                <Button disabled={submitting || mfaCode.trim().length !== 6} fullWidth type="submit">
+                                    {submitting ? "Verifying..." : "Verify and continue"}
+                                </Button>
+                            </form>
                             <div className="flex items-center justify-between text-sm">
-                                <button className="text-blue-600" onClick={() => setStage("login")} type="button">
+                                <button
+                                    className="text-blue-600"
+                                    onClick={() => {
+                                        setStage("login");
+                                        setMfaCode("");
+                                        setPendingMFAChallenge(null);
+                                        setError("");
+                                    }}
+                                    type="button"
+                                >
                                     Back
                                 </button>
                                 <Link className="text-blue-600" href="/settings/mfa">


### PR DESCRIPTION
## Summary
- complete clinician MFA in the login flow when `/api/v1/auth/login` returns `mfa_required=true`
- add inline 6-digit code input and call `/api/v1/auth/mfa/verify`
- persist upgraded AAL2 tokens and continue to dashboard after successful verification
- keep link to `/settings/mfa` as fallback

## Why
Previously, login stopped at an MFA-required screen and asked users to open settings instead of finishing verification in-place. This caused sign-in friction and production confusion.

## Validation
- `cd apps/clinician-portal && npm run test -- src/__tests__/login-page.test.tsx`
- `cd apps/clinician-portal && npm run lint`
- Added regression test for inline MFA verify completion
