### PR TITLE
fix(clinician-portal): simplify login MFA challenge messaging

### DIFF
--- a/apps/clinician-portal/src/app/(auth)/login/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/login/page.tsx
@@ -381,7 +381,8 @@ export default function ClinicianLoginPage() {
                             <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
                                 <p className="font-semibold">Multi-factor authentication required</p>
                                 <p className="mt-1">
-                                    Continue in the MFA setup flow for <span className="font-medium">{clinicContext.clinicName}</span>.
+                                    Enter the 6-digit code from your authenticator app to continue signing in to{" "}
+                                    <span className="font-medium">{clinicContext.clinicName}</span>.
                                 </p>
                             </div>
                             <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
@@ -409,7 +410,7 @@ export default function ClinicianLoginPage() {
                                     {submitting ? "Verifying..." : "Verify and continue"}
                                 </Button>
                             </form>
-                            <div className="flex items-center justify-between text-sm">
+                            <div className="flex items-center justify-start text-sm">
                                 <button
                                     className="text-blue-600"
                                     onClick={() => {
@@ -422,9 +423,6 @@ export default function ClinicianLoginPage() {
                                 >
                                     Back
                                 </button>
-                                <Link className="text-blue-600" href="/settings/mfa">
-                                    Open MFA settings
-                                </Link>
                             </div>
                         </div>
                     ) : null}


### PR DESCRIPTION
## Summary
- simplify login MFA challenge messaging to a single clear action
- remove confusing dual-path copy that implied a separate setup flow
- keep user focused on entering the 6-digit authenticator code

## Context
PR #32 already merged the core inline MFA verification flow. This PR only includes the follow-up UX clarity commit that landed afterward.

## Validation
- `cd apps/clinician-portal && npm run test -- src/__tests__/login-page.test.tsx`
- `cd apps/clinician-portal && npm run lint`
