### PR TITLE
fix(chat): improve fallback replies and assistant naming

### DIFF
--- a/apps/patient-portal/src/app/(app)/chat/page.tsx
+++ b/apps/patient-portal/src/app/(app)/chat/page.tsx
@@ -95,7 +95,7 @@ export default function ChatPage() {
                             </div>
                             <div className="space-y-1">
                                 <h1 className="text-[1.45rem] font-black tracking-[-0.03em] text-[#17233a]">
-                                    Care Companion
+                                    Maya
                                 </h1>
                                 <p className="inline-flex items-center gap-2 text-sm font-medium text-[#64748b]">
                                     <span
@@ -141,7 +141,7 @@ export default function ChatPage() {
                     </div>
                 </div>
 
-                <div className="mt-4 flex-1 overflow-y-auto px-1 pb-4">
+                <div className="mt-4 flex-1 overflow-y-auto px-1 pb-44">
                     <div className="mx-auto w-fit rounded-full border border-[#eadfd4] bg-white/82 px-3 py-1 text-[11px] font-bold text-[#64748b] shadow-[0_10px_24px_rgba(42,58,84,0.08)]">
                         {sessionTimeLabel}
                     </div>
@@ -266,7 +266,7 @@ export default function ChatPage() {
 
                             {isTyping && !assistantDraft ? (
                                 <div className="w-fit rounded-full border border-[#eadfd4] bg-white/88 px-3 py-2 text-xs font-bold text-[#64748b] shadow-[0_10px_24px_rgba(42,58,84,0.08)]">
-                                    Care Companion is typing...
+                                    Maya is typing...
                                 </div>
                             ) : null}
                             <div ref={bottomRef} />
@@ -275,7 +275,7 @@ export default function ChatPage() {
                 </div>
 
                 <form
-                    className="sticky bottom-28 mt-2 rounded-[30px] border border-white/75 bg-white/92 px-4 py-4 shadow-[0_20px_48px_rgba(42,58,84,0.14)] ring-1 ring-[#eadfd4]/80 backdrop-blur sm:px-5"
+                    className="sticky bottom-24 mt-2 rounded-[30px] border border-white/75 bg-white/92 px-4 py-4 shadow-[0_20px_48px_rgba(42,58,84,0.14)] ring-1 ring-[#eadfd4]/80 backdrop-blur sm:px-5"
                     onSubmit={handleSend}
                 >
                     <div className="rounded-[26px] bg-[#fffaf4] p-2.5">

--- a/apps/patient-portal/src/components/features/chat-bubble.tsx
+++ b/apps/patient-portal/src/components/features/chat-bubble.tsx
@@ -41,7 +41,7 @@ export function ChatBubble({
         <div className={`flex items-end gap-3 ${isUser ? "justify-end" : ""}`}>
             {!isUser ? (
             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl border border-[#b6d9d2] bg-[#e6f4f1] text-[10px] font-black uppercase tracking-[0.22em] text-[#147465] shadow-[0_10px_24px_rgba(20,116,101,0.10)]">
-                    AI
+                    M
                 </span>
             ) : null}
             <div className={`max-w-[82%] space-y-1.5 ${isUser ? "items-end text-right" : ""}`}>

--- a/backend/src/app/agents/triage/graph.py
+++ b/backend/src/app/agents/triage/graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, Literal, TypedDict
 
@@ -78,6 +79,22 @@ MEDICATION_KEYWORDS = frozenset(
         "refill",
         "side effect",
         "reaction",
+        "aspirin",
+        "ibuprofen",
+        "acetaminophen",
+        "tylenol",
+        "advil",
+    }
+)
+MEDICATION_NAME_HINTS = frozenset(
+    {
+        "amoxicillin",
+        "atorvastatin",
+        "insulin",
+        "lisinopril",
+        "metformin",
+        "omeprazole",
+        "prednisone",
     }
 )
 MENTAL_HEALTH_KEYWORDS = frozenset(
@@ -157,6 +174,10 @@ TRIAGE_COPY = {
             "Thank you for sharing this. Please contact your care team today for timely "
             "clinical guidance."
         ),
+        "fallback_non_clinical": (
+            "I am focused on health support. For medication, symptoms, records, or appointments, "
+            "I can give more specific help."
+        ),
     },
     Language.EN.value: {
         "emergency_response": (
@@ -186,6 +207,10 @@ TRIAGE_COPY = {
             "Thank you for sharing this. Please contact your care team today for timely "
             "clinical guidance."
         ),
+        "fallback_non_clinical": (
+            "I am focused on health support. For medication, symptoms, records, or appointments, "
+            "I can give more specific help."
+        ),
     },
     Language.ES.value: {
         "emergency_response": (
@@ -214,6 +239,10 @@ TRIAGE_COPY = {
         "fallback_urgent": (
             "Gracias por compartir esto. Es importante que hables con tu equipo clínico hoy "
             "mismo para una evaluación oportuna."
+        ),
+        "fallback_non_clinical": (
+            "Estoy enfocada en apoyo de salud. Si tienes preguntas sobre medicamentos, síntomas, "
+            "documentos o citas, puedo ayudarte mejor."
         ),
     },
 }
@@ -295,7 +324,12 @@ async def generate_response(state: TriageState, router: ModelRouter) -> TriageSt
     if response:
         return _merge_response(state, response)
 
-    fallback = _fallback_response(language=context.language, intent=intent, urgency=urgency)
+    fallback = _fallback_response(
+        language=context.language,
+        intent=intent,
+        urgency=urgency,
+        message=context.message,
+    )
     return _merge_response(state, fallback)
 
 
@@ -396,6 +430,13 @@ def _classify_with_rules(context: _MessageContext) -> TriageClassificationResult
             reason="Medication keyword match",
         )
 
+    if _matches_any(normalized, MEDICATION_NAME_HINTS):
+        return TriageClassificationResult(
+            intent="medication_question",
+            urgency="routine",
+            reason="Medication name hint match",
+        )
+
     if _matches_any(normalized, MENTAL_HEALTH_KEYWORDS):
         return TriageClassificationResult(
             intent="mental_health",
@@ -433,7 +474,7 @@ def _emergency_response(language: str) -> str:
     return resolve_locale_resource(language, TRIAGE_COPY)["emergency_response"]
 
 
-def _fallback_response(*, language: str, intent: str, urgency: str) -> str:
+def _fallback_response(*, language: str, intent: str, urgency: str, message: str) -> str:
     localized_copy = resolve_locale_resource(language, TRIAGE_COPY)
     if intent == "medication_question":
         return localized_copy["fallback_medication_question"]
@@ -445,7 +486,21 @@ def _fallback_response(*, language: str, intent: str, urgency: str) -> str:
         return localized_copy["fallback_mental_health"]
     if urgency == "urgent":
         return localized_copy["fallback_urgent"]
+    if _is_non_clinical_math_query(message):
+        return localized_copy["fallback_non_clinical"]
     return localized_copy["fallback_general"]
+
+
+def _is_non_clinical_math_query(message: str) -> bool:
+    cleaned = message.strip().lower()
+    if not cleaned:
+        return False
+    if any(
+        token in cleaned
+        for token in ("symptom", "medication", "medicine", "dolor", "síntoma", "sintoma")
+    ):
+        return False
+    return bool(re.fullmatch(r"[0-9\s+\-*/().=?]+", cleaned))
 
 
 def _build_context(state: TriageState) -> _MessageContext:

--- a/backend/tests/unit/agents/test_triage_agent.py
+++ b/backend/tests/unit/agents/test_triage_agent.py
@@ -100,3 +100,23 @@ async def test_triage_agent_fallback_returns_mental_health_guidance():
     assert output.escalation_required is True
     assert output.response_text is not None
     assert "988" in output.response_text
+
+
+@pytest.mark.asyncio
+async def test_triage_agent_fallback_handles_non_clinical_math_query():
+    agent = TriageAgent(router=_FailingRouter())
+
+    output = await agent.process(
+        TriageInput(
+            user_id=uuid4(),
+            patient_id=uuid4(),
+            message="2 + 2 = ?",
+            language=Language.EN,
+        )
+    )
+
+    assert output.status == "success"
+    assert output.intent == "general"
+    assert output.urgency == "routine"
+    assert output.response_text is not None
+    assert "focused on health support" in output.response_text

--- a/backend/tests/unit/agents/test_triage_routing_golden.py
+++ b/backend/tests/unit/agents/test_triage_routing_golden.py
@@ -37,6 +37,7 @@ GOLDEN_CASES = [
     ("Just checking in with no major issues", "general", "routine", "triage"),
     ("Hello there", "general", "routine", "triage"),
     ("I need refill for my medication", "medication_question", "routine", "triage"),
+    ("Can you explain what aspirin does", "medication_question", "routine", "triage"),
     ("Swelling and faint feeling after dose", "medication_question", "urgent", "triage"),
 ]
 


### PR DESCRIPTION
## Summary
- improve triage fallback behavior so medication-name prompts (for example aspirin) classify as `medication_question` and non-clinical math prompts get a dedicated health-focused fallback
- add backend tests covering the new non-clinical fallback and aspirin golden routing behavior
- update patient chat assistant naming from generic labels to `Maya` and keep composer layout adjustments that avoid overlap

## Test plan
- [x] `./backend/.venv/bin/python -m pytest backend/tests/unit/agents/test_triage_agent.py backend/tests/unit/agents/test_triage_routing_golden.py --no-cov`
- [x] `cd apps/patient-portal && npm run lint`

Made with [Cursor](https://cursor.com)