### PR TITLE
fix(clinician-signup): hydrate invite params

### DIFF
--- a/apps/clinician-portal/src/__tests__/signup-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/signup-page.test.tsx
@@ -1,20 +1,29 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import ClinicianSignupPage from "@/app/(auth)/signup/page";
 
-const { dispatch, post, replace, writeStoredSession } = vi.hoisted(() => ({
-    dispatch: vi.fn(),
-    post: vi.fn(),
-    replace: vi.fn(),
-    writeStoredSession: vi.fn(),
-}));
+const { dispatch, post, replace, writeStoredSession, setSearchParams, getSearchParams } =
+    vi.hoisted(() => {
+        let searchParamsString = "";
+        return {
+            dispatch: vi.fn(),
+            post: vi.fn(),
+            replace: vi.fn(),
+            writeStoredSession: vi.fn(),
+            setSearchParams: (value: string) => {
+                searchParamsString = value;
+            },
+            getSearchParams: () => new URLSearchParams(searchParamsString),
+        };
+    });
 
-const { readStoredClinicContext } = vi.hoisted(() => ({
+const { readStoredClinicContext, writeStoredClinicContext } = vi.hoisted(() => ({
     readStoredClinicContext: vi.fn(),
+    writeStoredClinicContext: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
     useRouter: () => ({ replace }),
+    useSearchParams: () => getSearchParams(),
 }));
 
 vi.mock("react-redux", () => ({
@@ -31,7 +40,10 @@ vi.mock("@/services/auth-session", () => ({
 
 vi.mock("@/services/clinic-context", () => ({
     readStoredClinicContext,
+    writeStoredClinicContext,
 }));
+
+import ClinicianSignupPage from "@/app/(auth)/signup/page";
 
 describe("Clinician signup page", () => {
     beforeEach(() => {
@@ -40,6 +52,8 @@ describe("Clinician signup page", () => {
         post.mockReset();
         writeStoredSession.mockReset();
         readStoredClinicContext.mockReset();
+        writeStoredClinicContext.mockReset();
+        setSearchParams("");
         readStoredClinicContext.mockReturnValue({
             clinicCode: "ABC123",
             clinicId: "clinic-1",
@@ -90,5 +104,58 @@ describe("Clinician signup page", () => {
             expect.objectContaining({ clinic_code: "ABC123", role: "nurse" }),
         );
         expect(replace).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("hydrates invite params and signs up admin invitees", async () => {
+        readStoredClinicContext.mockReturnValue(null);
+        setSearchParams("email=admin%40example.com&role=admin&code=ABC123");
+
+        post.mockResolvedValueOnce({
+            clinic_code: "ABC123",
+            clinic_id: "clinic-1",
+            clinic_name: "City Health",
+            status: "active",
+        });
+        post.mockResolvedValueOnce({
+            tokens: {
+                access_token: "access-token",
+                expires_at: 1234567890,
+                refresh_token: "refresh-token",
+            },
+            user: {
+                email: "admin@example.com",
+                id: "clinician-admin-1",
+                role: "clinician",
+            },
+        });
+
+        render(<ClinicianSignupPage />);
+
+        await waitFor(() => {
+            expect(writeStoredClinicContext).toHaveBeenCalledWith({
+                clinicCode: "ABC123",
+                clinicId: "clinic-1",
+                clinicName: "City Health",
+                status: "active",
+            });
+        });
+
+        expect(screen.getByLabelText(/^email$/i)).toHaveValue("admin@example.com");
+        expect(screen.getByLabelText(/role access/i)).toHaveValue("admin");
+        expect(screen.getByLabelText(/role access/i)).toBeDisabled();
+
+        fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: "Amina" } });
+        fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: "Khan" } });
+        fireEvent.change(screen.getByLabelText(/^specialty$/i), { target: { value: "Primary Care" } });
+        fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: "SecurePass123!" } });
+        fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: "SecurePass123!" } });
+        fireEvent.click(screen.getByRole("button", { name: /create clinician account/i }));
+
+        await waitFor(() => {
+            expect(post).toHaveBeenCalledWith(
+                "/api/v1/auth/signup/clinician",
+                expect.objectContaining({ clinic_code: "ABC123", role: "admin" }),
+            );
+        });
     });
 });

--- a/apps/clinician-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/signup/page.tsx
@@ -53,6 +53,7 @@ export default function ClinicianSignupPage() {
     const [submitting, setSubmitting] = useState(false);
     const [inviteLoading, setInviteLoading] = useState(false);
     const [clinicContext, setClinicContext] = useState<ClinicContext | null>(null);
+    const [inviteRole, setInviteRole] = useState<ClinicianRole | null>(null);
     const inviteHydrated = useRef(false);
     const [formData, setFormData] = useState({
         confirmPassword: "",
@@ -87,8 +88,18 @@ export default function ClinicianSignupPage() {
             updateField("email", emailParam);
         }
 
-        if (roleParam === ClinicianRole.NURSE) {
-            updateField("role", ClinicianRole.NURSE);
+        const resolvedRole =
+            roleParam === ClinicianRole.ADMIN
+                ? ClinicianRole.ADMIN
+                : roleParam === ClinicianRole.NURSE
+                  ? ClinicianRole.NURSE
+                  : roleParam === ClinicianRole.PROVIDER
+                    ? ClinicianRole.PROVIDER
+                    : null;
+
+        if (resolvedRole) {
+            updateField("role", resolvedRole);
+            setInviteRole(resolvedRole);
         }
 
         if (!codeParam) {
@@ -215,12 +226,19 @@ export default function ClinicianSignupPage() {
                             <span className="mb-1 block text-sm font-medium text-gray-700">Role access</span>
                             <select
                                 className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 shadow-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+                                disabled={Boolean(inviteRole)}
                                 onChange={(event) => updateField("role", event.target.value)}
                                 value={formData.role}
                             >
                                 <option value={ClinicianRole.PROVIDER}>Provider</option>
                                 <option value={ClinicianRole.NURSE}>Nurse / MA</option>
+                                {inviteRole === ClinicianRole.ADMIN ? (
+                                    <option value={ClinicianRole.ADMIN}>Clinic Admin (invite)</option>
+                                ) : null}
                             </select>
+                            {inviteRole ? (
+                                <p className="mt-1 text-xs text-slate-500">Role access is set by your invite.</p>
+                            ) : null}
                         </label>
                         <Input label="NPI number (optional)" onChange={(event) => updateField("npiNumber", event.target.value)} value={formData.npiNumber} />
                         <Input label="Password" onChange={(event) => updateField("password", event.target.value)} type="password" value={formData.password} />

--- a/apps/clinician-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
 import { api } from "@/services/api";
@@ -45,7 +45,7 @@ function mapClinicContext(response: ClinicResolveResponse): ClinicContext {
     };
 }
 
-export default function ClinicianSignupPage() {
+function ClinicianSignupPageContent() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const dispatch = useDispatch<AppDispatch>();
@@ -274,5 +274,13 @@ export default function ClinicianSignupPage() {
                 </Card>
             </div>
         </div>
+    );
+}
+
+export default function ClinicianSignupPage() {
+    return (
+        <Suspense fallback={null}>
+            <ClinicianSignupPageContent />
+        </Suspense>
     );
 }

--- a/apps/clinician-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/signup/page.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
 import { api } from "@/services/api";
 import { writeStoredSession } from "@/services/auth-session";
-import { readStoredClinicContext, type ClinicContext } from "@/services/clinic-context";
+import {
+    readStoredClinicContext,
+    writeStoredClinicContext,
+    type ClinicContext,
+} from "@/services/clinic-context";
 import { hydrateSession, type ClinicianAuthSession } from "@/store/slices/auth-slice";
 import type { AppDispatch } from "@/store/store";
 import { ClinicianRole, PortalUserRole } from "@/types";
@@ -25,12 +29,31 @@ interface SignupResponse {
     };
 }
 
+interface ClinicResolveResponse {
+    clinic_code: string;
+    clinic_id: string;
+    clinic_name: string;
+    status: "active" | "suspended";
+}
+
+function mapClinicContext(response: ClinicResolveResponse): ClinicContext {
+    return {
+        clinicCode: response.clinic_code,
+        clinicId: response.clinic_id,
+        clinicName: response.clinic_name,
+        status: response.status,
+    };
+}
+
 export default function ClinicianSignupPage() {
     const router = useRouter();
+    const searchParams = useSearchParams();
     const dispatch = useDispatch<AppDispatch>();
     const [error, setError] = useState("");
     const [submitting, setSubmitting] = useState(false);
+    const [inviteLoading, setInviteLoading] = useState(false);
     const [clinicContext, setClinicContext] = useState<ClinicContext | null>(null);
+    const inviteHydrated = useRef(false);
     const [formData, setFormData] = useState({
         confirmPassword: "",
         email: "",
@@ -50,6 +73,54 @@ export default function ClinicianSignupPage() {
         const stored = readStoredClinicContext();
         setClinicContext(stored);
     }, []);
+
+    useEffect(() => {
+        if (inviteHydrated.current) {
+            return;
+        }
+
+        const emailParam = searchParams?.get("email")?.trim() ?? "";
+        const roleParam = searchParams?.get("role")?.trim().toLowerCase() ?? "";
+        const codeParam = searchParams?.get("code")?.trim() ?? "";
+
+        if (emailParam) {
+            updateField("email", emailParam);
+        }
+
+        if (roleParam === ClinicianRole.NURSE) {
+            updateField("role", ClinicianRole.NURSE);
+        }
+
+        if (!codeParam) {
+            inviteHydrated.current = true;
+            return;
+        }
+
+        inviteHydrated.current = true;
+        setInviteLoading(true);
+        setError("");
+
+        const resolveInviteClinic = async () => {
+            try {
+                const resolved = await api.post<ClinicResolveResponse>(
+                    "/api/v1/clinics/resolve-code",
+                    { clinic_code: codeParam.toUpperCase() },
+                );
+                const context = mapClinicContext(resolved);
+                writeStoredClinicContext(context);
+                setClinicContext(context);
+            } catch (submissionError) {
+                setError(
+                    (submissionError as Error).message ||
+                        "Unable to verify the clinic invite. Please verify your clinic code first.",
+                );
+            } finally {
+                setInviteLoading(false);
+            }
+        };
+
+        void resolveInviteClinic();
+    }, [searchParams]);
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -161,7 +232,11 @@ export default function ClinicianSignupPage() {
                         />
                         {error ? <p className="text-sm text-red-600 md:col-span-2">{error}</p> : null}
                         <div className="md:col-span-2">
-                            <Button disabled={submitting || !clinicContext} fullWidth type="submit">
+                            <Button
+                                disabled={submitting || inviteLoading || !clinicContext}
+                                fullWidth
+                                type="submit"
+                            >
                                 {submitting ? "Creating account..." : "Create clinician account"}
                             </Button>
                         </div>

--- a/apps/clinician-portal/src/app/(auth)/signup/page.tsx
+++ b/apps/clinician-portal/src/app/(auth)/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Card, Input } from "@/components/ui";
 import { api } from "@/services/api";
@@ -66,9 +66,9 @@ export default function ClinicianSignupPage() {
         specialty: "",
     });
 
-    function updateField(field: keyof typeof formData, value: string) {
+    const updateField = useCallback((field: keyof typeof formData, value: string) => {
         setFormData((current) => ({ ...current, [field]: value }));
-    }
+    }, []);
 
     useEffect(() => {
         const stored = readStoredClinicContext();
@@ -131,7 +131,7 @@ export default function ClinicianSignupPage() {
         };
 
         void resolveInviteClinic();
-    }, [searchParams]);
+    }, [searchParams, updateField]);
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();

--- a/backend/src/app/models/auth.py
+++ b/backend/src/app/models/auth.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, EmailStr, Field
 from app.models.enums import Language
 
 AuthRole = Literal["patient", "clinician"]
-ClinicianSignupRole = Literal["provider", "nurse"]
+ClinicianSignupRole = Literal["provider", "nurse", "admin"]
 
 # ── Requests ────────────────────────────────────────────────
 

--- a/backend/src/app/routers/auth.py
+++ b/backend/src/app/routers/auth.py
@@ -110,6 +110,7 @@ async def signup_clinician(
         clinic_code=body.clinic_code,
         type1_npi=body.type1_npi,
         role=body.role,
+        allow_admin_role=body.role == "admin",
     )
     return AuthResponse(
         tokens=AuthTokens(**result["tokens"]),


### PR DESCRIPTION
## Context
Clinician invite emails point to /signup with query params, but the signup page ignored them.

## What Changed
- Hydrate invite params (email/role/code), resolve clinic code, and persist clinic context
- Allow admin role for clinician signup when invited
- Lock role selection when invite supplies a role
- Add signup test coverage for admin invite hydration
- Wrap signup content in Suspense to satisfy Next.js search-params requirement

## Tests
- backend/.venv/bin/ruff check src/
- backend/.venv/bin/ruff format --check src/
- backend/.venv/bin/python -m mypy src/ --ignore-missing-imports
- PYTHONPATH=src backend/.venv/bin/python -m pytest tests/unit/services/test_auth_service.py -v --no-cov
- apps/clinician-portal: npm run lint
- apps/clinician-portal: npm test
- apps/clinician-portal: npm run build

## Checklist
- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Manual Verification
- Not run (needs QA): open invite link with email/role/code, confirm prefill + clinic context, submit signup, land on dashboard.
