### PR TITLE
[codex] Implement document extraction feed and delete

### DIFF
--- a/apps/patient-portal/src/__tests__/feed-slice.test.ts
+++ b/apps/patient-portal/src/__tests__/feed-slice.test.ts
@@ -1,0 +1,64 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { feedSlice, fetchTodayFeed } from "@/store/slices/feed-slice";
+import { FeedTaskStatus, FeedTaskType } from "@/types";
+
+const { get } = vi.hoisted(() => ({
+    get: vi.fn(),
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { get },
+}));
+
+describe("feedSlice", () => {
+    beforeEach(() => {
+        get.mockReset();
+    });
+
+    it("maps real feed API snake_case fields into patient portal task fields", async () => {
+        get.mockResolvedValue({
+            date: "2026-05-08",
+            summary: {
+                completed: 0,
+                missed: 0,
+                pending: 1,
+                skipped: 0,
+                total: 1,
+            },
+            tasks: [
+                {
+                    completed_at: null,
+                    description: "Take with Food",
+                    frequency: "twice daily",
+                    id: "medication:med-1:unscheduled",
+                    name: "Theophylline 200mg",
+                    provider: {
+                        clinic_name: "Document extraction demo",
+                        id: "provider-1",
+                        name: "Dr Adam Careful",
+                        specialty: "Discharge",
+                    },
+                    requires_schedule_configuration: true,
+                    scheduled_at: null,
+                    scheduled_time: null,
+                    status: FeedTaskStatus.PENDING,
+                    target_id: "med-1",
+                    type: FeedTaskType.MEDICATION,
+                },
+            ],
+            timezone: "America/Los_Angeles",
+        });
+        const store = configureStore({ reducer: feedSlice.reducer });
+
+        await store.dispatch(fetchTodayFeed({ token: "token" }));
+
+        expect(get).toHaveBeenCalledWith("/api/v1/feed/today", { token: "token" });
+        expect(store.getState().tasks[0]).toMatchObject({
+            description: "Take with Food",
+            provider: { clinicName: "Document extraction demo" },
+            requiresScheduleConfiguration: true,
+            targetId: "med-1",
+        });
+    });
+});

--- a/apps/patient-portal/src/__tests__/records-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/records-page.test.tsx
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import RecordsPage from "@/app/(app)/records/page";
 import { DocumentParseStatus, DocumentType } from "@/types";
 
-const { get, post, push } = vi.hoisted(() => ({
+const { deleteRequest, get, post, push } = vi.hoisted(() => ({
+    deleteRequest: vi.fn(),
     get: vi.fn(),
     post: vi.fn(),
     push: vi.fn(),
@@ -24,7 +25,7 @@ vi.mock("react-redux", () => ({
 }));
 
 vi.mock("@/services/api", () => ({
-    api: { get, post },
+    api: { delete: deleteRequest, get, post },
 }));
 
 vi.mock("@/services/storage", () => ({
@@ -33,6 +34,7 @@ vi.mock("@/services/storage", () => ({
 
 describe("RecordsPage", () => {
     beforeEach(() => {
+        deleteRequest.mockReset();
         get.mockReset();
         post.mockReset();
         push.mockReset();
@@ -74,5 +76,45 @@ describe("RecordsPage", () => {
         await waitFor(() => {
             expect(push).toHaveBeenCalledWith("/chat?document=doc-1");
         });
+    });
+
+    it("deletes a selected document after confirmation", async () => {
+        get.mockResolvedValue([
+            {
+                ai_summary: "Discharge instructions are ready.",
+                created_at: "2026-04-20T12:00:00Z",
+                document_type: DocumentType.DISCHARGE_SUMMARY,
+                file_name: "Discharge Summary.txt",
+                file_size_bytes: 1200,
+                file_url: "https://example.test/discharge.txt",
+                id: "doc-delete",
+                mime_type: "text/plain",
+                parse_status: DocumentParseStatus.COMPLETED,
+                parsed: true,
+                patient_id: "patient-1",
+                source_clinic: "City Health",
+                uploaded_by: "patient-1",
+                uploaded_by_role: "patient",
+                visibility: "shared",
+            },
+        ]);
+        deleteRequest.mockResolvedValue(undefined);
+
+        render(<RecordsPage />);
+
+        expect(await screen.findByText(/Discharge Summary\.txt/i)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: /Discharge Summary\.txt/i }));
+        fireEvent.click(screen.getByRole("button", { name: /delete document/i }));
+        fireEvent.click(screen.getByRole("button", { name: /delete permanently/i }));
+
+        await waitFor(() => {
+            expect(deleteRequest).toHaveBeenCalledWith("/api/v1/documents/doc-delete", {
+                token: "access-token",
+            });
+        });
+        await waitFor(() => {
+            expect(screen.queryByText(/Discharge Summary\.txt/i)).not.toBeInTheDocument();
+        });
+        expect(screen.getByText(/No records yet/i)).toBeInTheDocument();
     });
 });

--- a/apps/patient-portal/src/__tests__/today-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/today-page.test.tsx
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import TodayPage from "@/app/(app)/today/page";
 import { FeedTaskStatus, FeedTaskType, type FeedTask } from "@/types";
 
-const { markComplete, useFeedData } = vi.hoisted(() => ({
+const { importDemoDocument, markComplete, refreshFeed, useFeedData } = vi.hoisted(() => ({
+    importDemoDocument: vi.fn(),
     markComplete: vi.fn(),
+    refreshFeed: vi.fn(),
     useFeedData: vi.fn(),
 }));
 
@@ -22,20 +24,26 @@ function baseFeedData() {
             currentStreakDays: 4,
             overallScore: 0.5,
         },
+        documentImportError: null,
+        documentImporting: false,
+        error: null,
+        importDemoDocument,
         loading: false,
         markComplete,
+        refreshFeed,
         summary: {
             completed: 1,
             total: 2,
         },
         tasks: [] as FeedTask[],
-        usingMockData: false,
     };
 }
 
 describe("TodayPage", () => {
     beforeEach(() => {
+        importDemoDocument.mockReset();
         markComplete.mockReset();
+        refreshFeed.mockReset();
         useFeedData.mockReset();
     });
 
@@ -108,5 +116,15 @@ describe("TodayPage", () => {
         const setupLink = screen.getByRole("link", { name: /set reminder times/i });
         expect(setupLink).toHaveAttribute("href", "/reminders");
         expect(screen.getByText(/^Set reminder time$/i)).toBeInTheDocument();
+    });
+
+    it("lets patients import a demo clinical document extraction into the real feed pipeline", () => {
+        mockFeedData();
+
+        render(<TodayPage />);
+
+        fireEvent.click(screen.getByRole("button", { name: /^Import$/i }));
+
+        expect(importDemoDocument).toHaveBeenCalledOnce();
     });
 });

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -146,6 +146,9 @@ export default function RecordsPage() {
     const router = useRouter();
     const [documents, setDocuments] = useState<PortalDocument[]>([]);
     const [selectedDocument, setSelectedDocument] = useState<PortalDocument | null>(null);
+    const [deleteConfirming, setDeleteConfirming] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+    const [deletingDocumentId, setDeletingDocumentId] = useState<string | null>(null);
     const [explanationLang, setExplanationLang] = useState<Locale>(DEFAULT_LOCALE);
     const [explanationText, setExplanationText] = useState<string | null>(null);
     const [explanationLoading, setExplanationLoading] = useState(false);
@@ -179,6 +182,8 @@ export default function RecordsPage() {
 
     const openDocument = useCallback((document: PortalDocument) => {
         setSelectedDocument(document);
+        setDeleteConfirming(false);
+        setDeleteError(null);
         setExplanationLang(DEFAULT_LOCALE);
         setExplanationLoading(false);
 
@@ -198,6 +203,12 @@ export default function RecordsPage() {
 
         setExplanationText(document.aiSummary ?? null);
     }, [parsingDocIds]);
+
+    const closeDocumentModal = useCallback(() => {
+        setSelectedDocument(null);
+        setDeleteConfirming(false);
+        setDeleteError(null);
+    }, []);
 
     useEffect(() => {
         if (!accessToken) {
@@ -350,8 +361,36 @@ export default function RecordsPage() {
             summary: explanationText ?? selectedDocument.aiSummary,
         });
 
-        setSelectedDocument(null);
+        closeDocumentModal();
         router.push(buildDocumentChatHref(selectedDocument.id));
+    }
+
+    async function handleDeleteDocument() {
+        if (!selectedDocument) {
+            return;
+        }
+
+        if (!accessToken) {
+            setDeleteError("Please sign in again before deleting this document.");
+            return;
+        }
+
+        setDeletingDocumentId(selectedDocument.id);
+        setDeleteError(null);
+        try {
+            await api.delete<void>(`/api/v1/documents/${selectedDocument.id}`, {
+                token: accessToken,
+            });
+            setDocuments((current) =>
+                current.filter((document) => document.id !== selectedDocument.id),
+            );
+            setParsingDocIds((current) => removeTrackedDocumentId(current, selectedDocument.id));
+            closeDocumentModal();
+        } catch (error) {
+            setDeleteError((error as Error).message || "Delete failed. Please try again.");
+        } finally {
+            setDeletingDocumentId(null);
+        }
     }
 
     const processingCount = documents.filter(
@@ -360,6 +399,7 @@ export default function RecordsPage() {
             || document.parseStatus === "pending"
             || document.parseStatus === "processing",
     ).length;
+    const isDeletingSelectedDocument = deletingDocumentId === selectedDocument?.id;
 
     return (
         <div className="patient-page space-y-4 pb-8">
@@ -447,7 +487,7 @@ export default function RecordsPage() {
                     );
                 })}
             </div>
-            <Modal onClose={() => setSelectedDocument(null)} open={Boolean(selectedDocument)} title={selectedDocument?.fileName ?? "Record details"}>
+            <Modal onClose={closeDocumentModal} open={Boolean(selectedDocument)} title={selectedDocument?.fileName ?? "Record details"}>
                 <div className="space-y-4">
                     <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
                         <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Source</p>
@@ -489,6 +529,48 @@ export default function RecordsPage() {
                                 Upload another
                             </Button>
                         </div>
+                        {deleteError ? (
+                            <ErrorState
+                                description={deleteError}
+                                onRetry={() => void handleDeleteDocument()}
+                                title="Could not delete document"
+                            />
+                        ) : null}
+                        {deleteConfirming ? (
+                            <div className="rounded-3xl border border-[#f0b8ae] bg-[#fff2ef] p-4">
+                                <p className="text-base font-bold text-[#7f2c23]">Delete this document?</p>
+                                <p className="mt-1 text-sm leading-6 text-[#9b4539]">
+                                    This removes the record from your documents. Existing care-plan items created from prior parsing are not removed.
+                                </p>
+                                <div className="mt-3 grid grid-cols-2 gap-3">
+                                    <Button
+                                        disabled={isDeletingSelectedDocument}
+                                        fullWidth
+                                        onClick={() => setDeleteConfirming(false)}
+                                        variant="secondary"
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        disabled={isDeletingSelectedDocument}
+                                        fullWidth
+                                        onClick={() => void handleDeleteDocument()}
+                                        variant="danger"
+                                    >
+                                        {isDeletingSelectedDocument ? "Deleting" : "Delete permanently"}
+                                    </Button>
+                                </div>
+                            </div>
+                        ) : (
+                            <Button
+                                disabled={isDeletingSelectedDocument}
+                                fullWidth
+                                onClick={() => setDeleteConfirming(true)}
+                                variant="danger"
+                            >
+                                Delete document
+                            </Button>
+                        )}
                     </div>
                 </div>
             </Modal>

--- a/apps/patient-portal/src/app/(app)/today/page.tsx
+++ b/apps/patient-portal/src/app/(app)/today/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { HiOutlineCalendarDays, HiOutlineCheck } from "react-icons/hi2";
 import { CircularProgress, MedicationCard, ObligationCard } from "@/components/features";
 import type { TaskCardStatus } from "@/components/features/task-card.types";
-import { Badge, Card, EmptyState, Skeleton } from "@/components/ui";
+import { Button, Card, EmptyState, ErrorState, Skeleton } from "@/components/ui";
 import { useFeedData } from "@/hooks/use-feed-data";
 import { FeedTaskStatus, FeedTaskType, type FeedTask } from "@/types";
 
@@ -48,8 +48,21 @@ function formatTimeLabel(
 }
 
 export default function TodayPage() {
-    const { adherenceStats, loading, markComplete, summary, tasks, usingMockData } = useFeedData();
-    const completionPercent = Math.round(adherenceStats.overallScore * 100);
+    const {
+        adherenceStats,
+        documentImportError,
+        documentImporting,
+        error,
+        importDemoDocument,
+        loading,
+        markComplete,
+        refreshFeed,
+        summary,
+        tasks,
+    } = useFeedData();
+    const completionPercent = Number.isFinite(adherenceStats.overallScore)
+        ? Math.round(adherenceStats.overallScore * 100)
+        : 0;
     const completedLabel = `${summary.completed} of ${summary.total || tasks.length} tasks completed`;
     const hasScheduleGaps = tasks.some((task) => task.requiresScheduleConfiguration);
 
@@ -92,7 +105,6 @@ export default function TodayPage() {
                         <p className="text-sm font-semibold text-white/76">{adherenceStats.currentStreakDays}-day streak</p>
                     </div>
                     <div className="space-y-2 text-right">
-                        {usingMockData ? <Badge variant="info">Demo data</Badge> : null}
                         <CircularProgress
                             percent={completionPercent}
                             progressClassName="stroke-white"
@@ -114,81 +126,108 @@ export default function TodayPage() {
                         </Card>
                     </Link>
                 ) : null}
+                <Card className="flex items-center justify-between gap-4 border-[#b9ded6] bg-[#e7f4f1]">
+                    <div>
+                        <p className="text-base font-black text-[#17233a]">Clinical document</p>
+                        <p className="text-sm font-semibold text-[#48627c]">
+                            {documentImporting ? "Importing..." : "Demo extraction"}
+                        </p>
+                    </div>
+                    <Button disabled={documentImporting} onClick={importDemoDocument} size="sm" variant="secondary">
+                        {documentImporting ? "Importing" : "Import"}
+                    </Button>
+                </Card>
+                {documentImportError ? (
+                    <ErrorState
+                        description={documentImportError}
+                        onRetry={() => void importDemoDocument()}
+                        title="Document import failed"
+                    />
+                ) : null}
+                {error ? (
+                    <ErrorState
+                        description={error}
+                        onRetry={refreshFeed}
+                        title={tasks.length > 0 ? "Schedule may be stale" : "Could not load schedule"}
+                    />
+                ) : null}
                 <div className="flex items-center justify-between">
                     <h2 className="text-xl font-black text-[#17233a]">Today&apos;s schedule</h2>
                     <p className="rounded-full bg-white/80 px-3 py-1 text-sm font-bold text-[#64748b]">{tasks.length} tasks</p>
                 </div>
-                {tasks.length === 0 ? (
+                {!error && tasks.length === 0 ? (
                     <EmptyState
                         description="Your clinicians have not assigned anything for today."
                         icon={<HiOutlineCalendarDays />}
                         title="Nothing scheduled"
                     />
                 ) : null}
-                <div className="ml-2 border-l-2 border-[#d7e5de] pl-6">
-                {tasks.map((task) => {
-                    const status = mapTaskStatus(task.status);
-                    const dotClasses =
-                        status === "completed"
-                            ? "bg-[#147465] text-white"
-                            : status === "active"
-                              ? "border-4 border-[#147465] bg-white"
-                              : status === "missed"
-                                ? "bg-[#d55b4d]"
-                                : "bg-[#d7e5de]";
+                {tasks.length > 0 ? (
+                    <div className="ml-2 border-l-2 border-[#d7e5de] pl-6">
+                        {tasks.map((task) => {
+                            const status = mapTaskStatus(task.status);
+                            const dotClasses =
+                                status === "completed"
+                                    ? "bg-[#147465] text-white"
+                                    : status === "active"
+                                      ? "border-4 border-[#147465] bg-white"
+                                      : status === "missed"
+                                        ? "bg-[#d55b4d]"
+                                        : "bg-[#d7e5de]";
 
-                    if (task.type === FeedTaskType.MEDICATION) {
-                        const medication = splitMedicationName(task.name);
-                        return (
-                            <div className="relative pb-6 last:pb-0" key={task.id}>
-                                <span className={`absolute -left-[34px] top-5 flex h-5 w-5 items-center justify-center rounded-full border-4 border-white ${dotClasses}`}>
-                                    {status === "completed" ? <HiOutlineCheck className="h-3.5 w-3.5" /> : null}
-                                </span>
-                                <p className={`mb-2 text-sm font-bold ${status === "active" ? "text-[#147465]" : "text-[#8090a5]"}`}>
-                                    {formatTimeLabel(
-                                        task.scheduledTime,
-                                        task.status,
-                                        task.requiresScheduleConfiguration,
-                                    )}
-                                </p>
-                                <MedicationCard
-                                    dosage={medication.dosage}
-                                    id={task.id}
-                                    instructions={task.description}
-                                    name={medication.name}
-                                    onMarkComplete={() => markComplete(task)}
-                                    prescriber={task.provider?.name}
-                                    status={status}
-                                    time={task.scheduledTime ?? ""}
-                                />
-                            </div>
-                        );
-                    }
+                            if (task.type === FeedTaskType.MEDICATION) {
+                                const medication = splitMedicationName(task.name);
+                                return (
+                                    <div className="relative pb-6 last:pb-0" key={task.id}>
+                                        <span className={`absolute -left-[34px] top-5 flex h-5 w-5 items-center justify-center rounded-full border-4 border-white ${dotClasses}`}>
+                                            {status === "completed" ? <HiOutlineCheck className="h-3.5 w-3.5" /> : null}
+                                        </span>
+                                        <p className={`mb-2 text-sm font-bold ${status === "active" ? "text-[#147465]" : "text-[#8090a5]"}`}>
+                                            {formatTimeLabel(
+                                                task.scheduledTime,
+                                                task.status,
+                                                task.requiresScheduleConfiguration,
+                                            )}
+                                        </p>
+                                        <MedicationCard
+                                            dosage={medication.dosage}
+                                            id={task.id}
+                                            instructions={task.description}
+                                            name={medication.name}
+                                            onMarkComplete={() => markComplete(task)}
+                                            prescriber={task.provider?.name}
+                                            status={status}
+                                            time={task.scheduledTime ?? ""}
+                                        />
+                                    </div>
+                                );
+                            }
 
-                    return (
-                        <div className="relative pb-6 last:pb-0" key={task.id}>
-                            <span className={`absolute -left-[34px] top-5 flex h-5 w-5 items-center justify-center rounded-full border-4 border-white ${dotClasses}`}>
-                                {status === "completed" ? <HiOutlineCheck className="h-3.5 w-3.5" /> : null}
-                            </span>
-                            <p className={`mb-2 text-sm font-bold ${status === "active" ? "text-[#147465]" : "text-[#8090a5]"}`}>
-                                {formatTimeLabel(
-                                    task.scheduledTime,
-                                    task.status,
-                                    task.requiresScheduleConfiguration,
-                                )}
-                            </p>
-                            <ObligationCard
-                                description={task.name}
-                                id={task.id}
-                                onMarkComplete={() => markComplete(task)}
-                                status={status}
-                                time={task.scheduledTime ?? ""}
-                                type={task.frequency.includes("walk") ? "exercise" : "custom"}
-                            />
-                        </div>
-                    );
-                })}
-                </div>
+                            return (
+                                <div className="relative pb-6 last:pb-0" key={task.id}>
+                                    <span className={`absolute -left-[34px] top-5 flex h-5 w-5 items-center justify-center rounded-full border-4 border-white ${dotClasses}`}>
+                                        {status === "completed" ? <HiOutlineCheck className="h-3.5 w-3.5" /> : null}
+                                    </span>
+                                    <p className={`mb-2 text-sm font-bold ${status === "active" ? "text-[#147465]" : "text-[#8090a5]"}`}>
+                                        {formatTimeLabel(
+                                            task.scheduledTime,
+                                            task.status,
+                                            task.requiresScheduleConfiguration,
+                                        )}
+                                    </p>
+                                    <ObligationCard
+                                        description={task.name}
+                                        id={task.id}
+                                        onMarkComplete={() => markComplete(task)}
+                                        status={status}
+                                        time={task.scheduledTime ?? ""}
+                                        type={task.frequency.includes("walk") ? "exercise" : "custom"}
+                                    />
+                                </div>
+                            );
+                        })}
+                    </div>
+                ) : null}
             </div>
 
             <div className="px-5 pt-2">

--- a/apps/patient-portal/src/hooks/use-feed-data.ts
+++ b/apps/patient-portal/src/hooks/use-feed-data.ts
@@ -1,87 +1,58 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { api } from "@/services/api";
 import {
     fetchTodayFeed,
-    loadMockFeed,
     markTaskComplete,
     setMissedTasks,
 } from "@/store/slices/feed-slice";
 import type { AppDispatch, RootState } from "@/store/store";
-import { FeedTaskStatus, FeedTaskType, type AdherenceStats, type FeedSummary, type FeedTask } from "@/types";
+import { FeedTaskStatus, FeedTaskType, type AdherenceStats, type FeedTask } from "@/types";
 
-const mockFeedTasks: FeedTask[] = [
-    {
-        completedAt: new Date().toISOString(),
-        description: "Take with breakfast.",
-        frequency: "daily",
-        id: "demo-1",
-        name: "Metformin 500mg",
-        provider: {
-            clinicName: "City Health",
-            id: "provider-1",
-            name: "Dr. Smith",
-            specialty: "Primary Care",
-        },
-        scheduledTime: "08:00:00",
-        status: FeedTaskStatus.COMPLETED,
-        targetId: "target-1",
-        type: FeedTaskType.MEDICATION,
-    },
-    {
-        description: "30 minutes of low-impact walking.",
-        frequency: "daily",
-        id: "demo-2",
-        name: "Daily walk",
-        provider: {
-            clinicName: "City Health",
-            id: "provider-2",
-            name: "Dr. Patel",
-            specialty: "Cardiology",
-        },
-        scheduledTime: "12:00:00",
-        status: FeedTaskStatus.PENDING,
-        targetId: "target-2",
-        type: FeedTaskType.OBLIGATION,
-    },
-    {
-        description: "Take with dinner.",
-        frequency: "daily",
-        id: "demo-3",
-        name: "Lisinopril 10mg",
-        provider: {
-            clinicName: "City Health",
-            id: "provider-2",
-            name: "Dr. Patel",
-            specialty: "Cardiology",
-        },
-        scheduledTime: "18:00:00",
-        status: FeedTaskStatus.PENDING,
-        targetId: "target-3",
-        type: FeedTaskType.MEDICATION,
-    },
-];
+interface ApiAdherenceStats {
+    current_streak_days?: number;
+    currentStreakDays?: number;
+    medication_score?: number;
+    medicationScore?: number;
+    obligation_score?: number;
+    obligationScore?: number;
+    overall_score?: number;
+    overallScore?: number;
+    patient_id?: string;
+    patientId?: string;
+    period_days?: number;
+    periodDays?: number;
+    total_completed?: number;
+    totalCompleted?: number;
+    total_expected?: number;
+    totalExpected?: number;
+}
 
-const mockFeedSummary: FeedSummary = {
-    completed: 1,
-    missed: 0,
-    pending: 2,
-    skipped: 0,
-    total: 3,
-};
-
-const mockAdherenceStats: AdherenceStats = {
-    currentStreakDays: 4,
-    medicationScore: 0.83,
-    obligationScore: 0.67,
-    overallScore: 0.75,
-    patientId: "demo-patient",
+const emptyAdherenceStats: AdherenceStats = {
+    currentStreakDays: 0,
+    medicationScore: 0,
+    obligationScore: 0,
+    overallScore: 0,
+    patientId: "",
     periodDays: 30,
-    totalCompleted: 18,
-    totalExpected: 24,
+    totalCompleted: 0,
+    totalExpected: 0,
 };
+
+function mapAdherenceStats(stats: ApiAdherenceStats): AdherenceStats {
+    return {
+        currentStreakDays: stats.currentStreakDays ?? stats.current_streak_days ?? 0,
+        medicationScore: stats.medicationScore ?? stats.medication_score ?? 0,
+        obligationScore: stats.obligationScore ?? stats.obligation_score ?? 0,
+        overallScore: stats.overallScore ?? stats.overall_score ?? 0,
+        patientId: stats.patientId ?? stats.patient_id ?? "",
+        periodDays: stats.periodDays ?? stats.period_days ?? 30,
+        totalCompleted: stats.totalCompleted ?? stats.total_completed ?? 0,
+        totalExpected: stats.totalExpected ?? stats.total_expected ?? 0,
+    };
+}
 
 function getMissedTaskIds(tasks: FeedTask[]) {
     const now = new Date();
@@ -100,20 +71,31 @@ export function useFeedData() {
     const dispatch = useDispatch<AppDispatch>();
     const feed = useSelector((state: RootState) => state.feed);
     const accessToken = useSelector((state: RootState) => state.auth.accessToken);
-    const [adherenceStats, setAdherenceStats] = useState<AdherenceStats>(mockAdherenceStats);
+    const [adherenceStats, setAdherenceStats] = useState<AdherenceStats>(emptyAdherenceStats);
+    const [documentImportError, setDocumentImportError] = useState<string | null>(null);
+    const [documentImporting, setDocumentImporting] = useState(false);
 
-    useEffect(() => {
-        dispatch(fetchTodayFeed({ token: accessToken }))
-            .unwrap()
-            .catch(() => {
-                dispatch(loadMockFeed({ summary: mockFeedSummary, tasks: mockFeedTasks }));
-            });
+    const refreshFeed = useCallback(() => {
+        if (!accessToken) {
+            return;
+        }
+
+        void dispatch(fetchTodayFeed({ token: accessToken }));
     }, [accessToken, dispatch]);
 
     useEffect(() => {
-        api.get<AdherenceStats>("/api/v1/adherence/stats", { token: accessToken ?? undefined })
-            .then((response) => setAdherenceStats(response))
-            .catch(() => setAdherenceStats(mockAdherenceStats));
+        refreshFeed();
+    }, [refreshFeed]);
+
+    useEffect(() => {
+        if (!accessToken) {
+            setAdherenceStats(emptyAdherenceStats);
+            return;
+        }
+
+        api.get<ApiAdherenceStats>("/api/v1/adherence/stats", { token: accessToken ?? undefined })
+            .then((response) => setAdherenceStats(mapAdherenceStats(response)))
+            .catch(() => setAdherenceStats(emptyAdherenceStats));
     }, [accessToken]);
 
     useEffect(() => {
@@ -147,13 +129,36 @@ export function useFeedData() {
         }
     }
 
+    async function importDemoDocument() {
+        if (!accessToken) {
+            setDocumentImportError("Please sign in again before importing a clinical document.");
+            return;
+        }
+
+        setDocumentImporting(true);
+        setDocumentImportError(null);
+        try {
+            await api.post("/api/v1/documents/extractions/import", undefined, {
+                token: accessToken,
+            });
+            await dispatch(fetchTodayFeed({ token: accessToken })).unwrap();
+        } catch (error) {
+            setDocumentImportError((error as Error).message || "Document import failed.");
+        } finally {
+            setDocumentImporting(false);
+        }
+    }
+
     return {
         adherenceStats,
+        documentImportError,
+        documentImporting,
         error: feed.error,
+        importDemoDocument,
         loading: feed.loading,
         markComplete,
+        refreshFeed,
         summary: feed.summary,
         tasks: feed.tasks,
-        usingMockData: feed.usingMockData,
     };
 }

--- a/apps/patient-portal/src/store/slices/feed-slice.ts
+++ b/apps/patient-portal/src/store/slices/feed-slice.ts
@@ -2,12 +2,46 @@ import { createAsyncThunk, createSlice, type PayloadAction } from "@reduxjs/tool
 import { api } from "@/services/api";
 import { FeedTaskStatus, type FeedSummary, type FeedTask, type TodayFeedResponse } from "@/types";
 
+interface ApiFeedProvider {
+    id: string;
+    name: string;
+    specialty: string;
+    clinic_name?: string;
+    clinicName?: string;
+}
+
+interface ApiFeedTask {
+    id: string;
+    type: FeedTask["type"];
+    target_id?: string;
+    targetId?: string;
+    name: string;
+    description?: string | null;
+    frequency: string;
+    scheduled_time?: string | null;
+    scheduledTime?: string | null;
+    scheduled_at?: string | null;
+    scheduledAt?: string | null;
+    status: FeedTask["status"];
+    completed_at?: string | null;
+    completedAt?: string | null;
+    requires_schedule_configuration?: boolean;
+    requiresScheduleConfiguration?: boolean;
+    provider?: ApiFeedProvider | null;
+}
+
+interface ApiTodayFeedResponse {
+    date: string;
+    timezone: string;
+    tasks: ApiFeedTask[];
+    summary: FeedSummary;
+}
+
 interface FeedState {
     tasks: FeedTask[];
     summary: FeedSummary;
     loading: boolean;
     error: string | null;
-    usingMockData: boolean;
 }
 
 export const defaultFeedSummary: FeedSummary = {
@@ -23,8 +57,51 @@ const initialState: FeedState = {
     summary: defaultFeedSummary,
     loading: false,
     error: null,
-    usingMockData: false,
 };
+
+function mapApiProvider(provider?: ApiFeedProvider | null): FeedTask["provider"] {
+    if (!provider) {
+        return undefined;
+    }
+
+    return {
+        clinicName: provider.clinicName ?? provider.clinic_name ?? "",
+        id: provider.id,
+        name: provider.name,
+        specialty: provider.specialty,
+    };
+}
+
+function mapApiTask(task: ApiFeedTask): FeedTask {
+    return {
+        completedAt: task.completedAt ?? task.completed_at ?? undefined,
+        description: task.description ?? undefined,
+        frequency: task.frequency,
+        id: task.id,
+        name: task.name,
+        provider: mapApiProvider(task.provider),
+        requiresScheduleConfiguration: Boolean(
+            task.requiresScheduleConfiguration ?? task.requires_schedule_configuration ?? false,
+        ),
+        scheduledAt: task.scheduledAt ?? task.scheduled_at ?? undefined,
+        scheduledTime: task.scheduledTime ?? task.scheduled_time ?? undefined,
+        status: task.status,
+        targetId: task.targetId ?? task.target_id ?? "",
+        type: task.type,
+    };
+}
+
+function mapTodayFeedResponse(response: ApiTodayFeedResponse): TodayFeedResponse {
+    return {
+        date: response.date,
+        summary: {
+            ...defaultFeedSummary,
+            ...response.summary,
+        },
+        tasks: response.tasks.map(mapApiTask),
+        timezone: response.timezone,
+    };
+}
 
 export const fetchTodayFeed = createAsyncThunk<
     TodayFeedResponse,
@@ -32,9 +109,10 @@ export const fetchTodayFeed = createAsyncThunk<
     { rejectValue: string }
 >("feed/fetchToday", async (payload, { rejectWithValue }) => {
     try {
-        return await api.get<TodayFeedResponse>("/api/v1/feed/today", {
+        const response = await api.get<ApiTodayFeedResponse>("/api/v1/feed/today", {
             token: payload?.token ?? undefined,
         });
+        return mapTodayFeedResponse(response);
     } catch (error) {
         return rejectWithValue((error as Error).message);
     }
@@ -44,16 +122,6 @@ export const feedSlice = createSlice({
     name: "feed",
     initialState,
     reducers: {
-        loadMockFeed: (
-            state,
-            action: PayloadAction<{ summary: FeedSummary; tasks: FeedTask[] }>,
-        ) => {
-            state.tasks = action.payload.tasks;
-            state.summary = action.payload.summary;
-            state.loading = false;
-            state.error = null;
-            state.usingMockData = true;
-        },
         markTaskComplete: (
             state,
             action: PayloadAction<{ completedAt: string; taskId: string }>,
@@ -94,7 +162,6 @@ export const feedSlice = createSlice({
                 state.summary = action.payload.summary;
                 state.loading = false;
                 state.error = null;
-                state.usingMockData = false;
             })
             .addCase(fetchTodayFeed.rejected, (state, action) => {
                 state.loading = false;
@@ -103,4 +170,4 @@ export const feedSlice = createSlice({
     },
 });
 
-export const { loadMockFeed, markTaskComplete, setMissedTasks } = feedSlice.actions;
+export const { markTaskComplete, setMissedTasks } = feedSlice.actions;

--- a/backend/src/app/models/document_extraction.py
+++ b/backend/src/app/models/document_extraction.py
@@ -1,0 +1,75 @@
+"""Project-owned document extraction schema.
+
+This is the normalized handoff between document parsing adapters and the app's
+relational clinical records. Inputs may come from PDF OCR, clinician entry, a
+future FHIR adapter, or local demo data, but persistence should flow through
+this shape.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import DocumentType, MedicationRoute, ObligationType
+
+
+class ExtractedDocumentMetadata(BaseModel):
+    """Metadata for the source document that produced extracted records."""
+
+    title: str = Field(default="Clinical Document", min_length=1, max_length=255)
+    document_type: DocumentType = DocumentType.OTHER
+    source_name: str | None = Field(default=None, max_length=255)
+    notes: str | None = None
+
+
+class ExtractedMedication(BaseModel):
+    """Medication record after document parsing and basic normalization."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+    dosage: str = Field(default="as directed", min_length=1)
+    frequency: str = Field(default="as directed", min_length=1)
+    route: MedicationRoute = MedicationRoute.OTHER
+    instructions: str | None = None
+    generic_name: str | None = None
+    rxcui: str | None = None
+
+
+class ExtractedCondition(BaseModel):
+    """Condition record after document parsing."""
+
+    name: str = Field(..., min_length=1)
+    status: str = Field(default="active", min_length=1)
+    notes: str | None = None
+
+
+class ExtractedAllergy(BaseModel):
+    """Allergy record after document parsing."""
+
+    allergen: str = Field(..., min_length=1)
+    reaction: str | None = None
+    severity: str = Field(default="moderate", pattern="^(mild|moderate|severe)$")
+
+
+class ExtractedObligation(BaseModel):
+    """Patient task or care-plan obligation extracted from a document."""
+
+    description: str = Field(..., min_length=1, max_length=500)
+    frequency: str = Field(default="as directed", min_length=1)
+    obligation_type: ObligationType = ObligationType.CUSTOM
+
+
+class DocumentExtractionResult(BaseModel):
+    """Normalized records produced from a clinical document."""
+
+    document: ExtractedDocumentMetadata = Field(default_factory=ExtractedDocumentMetadata)
+    summary: str | None = None
+    medications: list[ExtractedMedication] = Field(default_factory=list)
+    conditions: list[ExtractedCondition] = Field(default_factory=list)
+    allergies: list[ExtractedAllergy] = Field(default_factory=list)
+    obligations: list[ExtractedObligation] = Field(default_factory=list)
+
+
+class DocumentExtractionImportRequest(BaseModel):
+    """Optional extraction payload for local/demo import flows."""
+
+    extraction: DocumentExtractionResult | None = None

--- a/backend/src/app/routers/documents.py
+++ b/backend/src/app/routers/documents.py
@@ -22,7 +22,9 @@ from app.core.security import get_current_user
 from app.db.connection import get_db
 from app.models.auth import CurrentUser
 from app.models.document import DocumentRead
+from app.models.document_extraction import DocumentExtractionImportRequest
 from app.models.enums import DocumentType, Language, coerce_locale
+from app.services.document_extraction_import_service import DocumentExtractionImportService
 from app.services.document_service import DocumentService
 from app.services.explanation_service import ExplanationService
 from app.services.ingestion_service import IngestionService
@@ -129,6 +131,38 @@ async def list_documents(
     return await service.list_documents(user.id)
 
 
+@router.post(
+    "/extractions/import",
+    status_code=status.HTTP_201_CREATED,
+    summary="Import extracted document data",
+    description=(
+        "Imports a normalized document extraction result into document, medication, "
+        "allergy, condition, and feed-backed obligation records. If no extraction is "
+        "provided, a bundled demo discharge summary extraction is used."
+    ),
+)
+async def import_document_extraction(
+    body: DocumentExtractionImportRequest | None = None,
+    user: CurrentUser = Depends(get_current_user),
+    db: Client = Depends(get_db),
+) -> Any:
+    if user.role != "patient":
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only patients can import document extraction results",
+        )
+
+    service = DocumentExtractionImportService(db)
+    return await service.import_extraction(
+        patient_id=user.id,
+        uploaded_by=user.id,
+        uploaded_by_role=user.role,
+        extraction=body.extraction if body else None,
+    )
+
+
 @router.get(
     "/{document_id}",
     response_model=DocumentRead,
@@ -140,6 +174,19 @@ async def get_document(
     service: DocumentService = Depends(_get_service),
 ) -> Any:
     return await service.get_document(document_id, user.id)
+
+
+@router.delete(
+    "/{document_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a document",
+)
+async def delete_document(
+    document_id: UUID,
+    user: CurrentUser = Depends(get_current_user),
+    service: DocumentService = Depends(_get_service),
+) -> None:
+    await service.delete_document(document_id, user.id)
 
 
 @router.post(

--- a/backend/src/app/services/document_extraction_import_service.py
+++ b/backend/src/app/services/document_extraction_import_service.py
@@ -1,0 +1,282 @@
+"""Document extraction import service.
+
+Persists a project-owned extraction result into the same document, medication,
+condition, allergy, and obligation tables that power the Today feed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+from app.models.document_extraction import DocumentExtractionResult
+from app.models.enums import DocumentType, MedicationRoute, ObligationType
+from app.services.document_service import DocumentService
+from app.services.medication_service import MedicationService
+from app.services.obligation_service import ObligationService
+
+DEMO_DOCUMENT_EXTRACTION = DocumentExtractionResult.model_validate(
+    {
+        "document": {
+            "title": "Discharge Summary",
+            "document_type": DocumentType.DISCHARGE_SUMMARY.value,
+            "source_name": "Dr Adam Careful",
+            "notes": "Imported from a normalized document extraction demo.",
+        },
+        "summary": (
+            "Discharge Summary extracted from a clinical document. "
+            "Author: Dr Adam Careful. Reason for admission: Acute Asthmatic attack. "
+            "Was wheezing for days prior to admission. Discharge medications: "
+            "Theophylline 200mg, Ventolin Inhaler. Known allergies: Doxycycline (Hives)."
+        ),
+        "medications": [
+            {
+                "name": "Theophylline",
+                "dosage": "200mg",
+                "frequency": "twice daily",
+                "route": MedicationRoute.ORAL.value,
+                "instructions": "Take with Food",
+            },
+            {
+                "name": "Ventolin Inhaler",
+                "dosage": "as directed",
+                "frequency": "as directed",
+                "route": MedicationRoute.INHALED.value,
+                "instructions": "Management of Asthma",
+            },
+        ],
+        "conditions": [
+            {
+                "name": "Asthma exacerbation",
+                "status": "active",
+                "notes": "Acute Asthmatic attack. Was wheezing for days prior to admission.",
+            }
+        ],
+        "allergies": [
+            {
+                "allergen": "Doxycycline",
+                "reaction": "Hives",
+                "severity": "severe",
+            }
+        ],
+        "obligations": [
+            {
+                "description": "Review discharge instructions from Discharge Summary",
+                "frequency": "today",
+                "obligation_type": ObligationType.CUSTOM.value,
+            }
+        ],
+    }
+)
+
+
+class DocumentExtractionImportService:
+    """Imports normalized document extraction results into patient-scoped records."""
+
+    def __init__(self, db: Client) -> None:
+        self.db = db
+        self.document_service = DocumentService(db)
+        self.medication_service = MedicationService(db)
+        self.obligation_service = ObligationService(db)
+
+    async def import_extraction(
+        self,
+        *,
+        patient_id: UUID,
+        uploaded_by: UUID,
+        uploaded_by_role: str,
+        extraction: DocumentExtractionResult | None = None,
+    ) -> dict[str, Any]:
+        effective_extraction = extraction or DEMO_DOCUMENT_EXTRACTION
+        document_payload = effective_extraction.document
+        serialized_extraction = effective_extraction.model_dump(mode="json")
+        summary = effective_extraction.summary or self._summary(effective_extraction)
+
+        document = await self.document_service.create_document(
+            patient_id=patient_id,
+            uploaded_by=uploaded_by,
+            uploaded_by_role=uploaded_by_role,
+            file_name=self._file_name(document_payload.title),
+            file_path="",
+            file_size_bytes=len(json.dumps(serialized_extraction).encode("utf-8")),
+            mime_type="application/json",
+            document_type=document_payload.document_type.value,
+            source_clinic=document_payload.source_name or "Document extraction demo",
+            notes=document_payload.notes,
+            sign_file_url=False,
+        )
+        document_id = UUID(str(document["id"]))
+
+        medication_ids = await self._create_medications(
+            patient_id,
+            document_id,
+            effective_extraction,
+        )
+        condition_ids = self._create_conditions(patient_id, effective_extraction)
+        allergy_ids = self._create_allergies(patient_id, effective_extraction)
+        obligation_ids = await self._create_obligations(patient_id, effective_extraction)
+
+        self.document_service.update_parse_result(
+            document_id=document_id,
+            patient_id=patient_id,
+            ai_summary=summary,
+            parse_status="completed",
+            parsed=True,
+        )
+        document["ai_summary"] = summary
+        document["parsed"] = True
+        document["parse_status"] = "completed"
+        document["parse_error"] = None
+
+        return {
+            "document": document,
+            "medications_created": len(medication_ids),
+            "conditions_created": len(condition_ids),
+            "allergies_created": len(allergy_ids),
+            "obligations_created": len(obligation_ids),
+            "summary": summary,
+        }
+
+    async def _create_medications(
+        self,
+        patient_id: UUID,
+        document_id: UUID,
+        extraction: DocumentExtractionResult,
+    ) -> list[str]:
+        created_ids: list[str] = []
+        seen_names: set[str] = set()
+
+        for medication in extraction.medications:
+            dedupe_key = medication.name.strip().lower()
+            if dedupe_key in seen_names:
+                continue
+            seen_names.add(dedupe_key)
+            payload = {
+                "name": medication.name,
+                "generic_name": medication.generic_name,
+                "rxcui": medication.rxcui,
+                "dosage": medication.dosage,
+                "frequency": medication.frequency,
+                "route": medication.route.value,
+                "instructions": medication.instructions,
+                "source_document_id": str(document_id),
+            }
+            created = await self.medication_service.create_medication(patient_id, payload)
+            created_ids.append(str(created["id"]))
+
+        return created_ids
+
+    def _create_conditions(
+        self,
+        patient_id: UUID,
+        extraction: DocumentExtractionResult,
+    ) -> list[str]:
+        created_ids: list[str] = []
+
+        for condition in extraction.conditions:
+            result = (
+                self.db.table("conditions")
+                .insert(
+                    {
+                        "patient_id": str(patient_id),
+                        "name": condition.name,
+                        "status": condition.status,
+                        "notes": condition.notes,
+                    }
+                )
+                .execute()
+            )
+            data = cast(list[dict[str, Any]], result.data or [])
+            if data:
+                created_ids.append(str(data[0]["id"]))
+
+        return created_ids
+
+    def _create_allergies(
+        self,
+        patient_id: UUID,
+        extraction: DocumentExtractionResult,
+    ) -> list[str]:
+        created_ids: list[str] = []
+
+        for allergy in extraction.allergies:
+            result = (
+                self.db.table("allergies")
+                .insert(
+                    {
+                        "patient_id": str(patient_id),
+                        "allergen": allergy.allergen,
+                        "reaction": allergy.reaction,
+                        "severity": allergy.severity,
+                    }
+                )
+                .execute()
+            )
+            data = cast(list[dict[str, Any]], result.data or [])
+            if data:
+                created_ids.append(str(data[0]["id"]))
+
+        return created_ids
+
+    async def _create_obligations(
+        self,
+        patient_id: UUID,
+        extraction: DocumentExtractionResult,
+    ) -> list[str]:
+        created_ids: list[str] = []
+
+        for obligation in extraction.obligations:
+            payload = {
+                "obligation_type": obligation.obligation_type.value,
+                "description": obligation.description,
+                "frequency": obligation.frequency,
+            }
+            created = await self.obligation_service.create_obligation(patient_id, payload)
+            created_ids.append(str(created["id"]))
+
+        return created_ids
+
+    def _summary(self, extraction: DocumentExtractionResult) -> str:
+        title = extraction.document.title
+        parts = [f"{title} extracted from a clinical document."]
+        if extraction.document.source_name:
+            parts.append(f"Source: {extraction.document.source_name}.")
+        if extraction.conditions:
+            parts.append(
+                "Conditions: "
+                + ", ".join(condition.name for condition in extraction.conditions)
+                + "."
+            )
+        if extraction.medications:
+            parts.append(
+                "Medications: "
+                + ", ".join(
+                    " ".join(
+                        part
+                        for part in (medication.name, medication.dosage)
+                        if part and part != "as directed"
+                    )
+                    for medication in extraction.medications
+                )
+                + "."
+            )
+        if extraction.allergies:
+            parts.append(
+                "Allergies: "
+                + ", ".join(
+                    f"{allergy.allergen} ({allergy.reaction})"
+                    if allergy.reaction
+                    else allergy.allergen
+                    for allergy in extraction.allergies
+                )
+                + "."
+            )
+        return " ".join(parts)
+
+    def _file_name(self, title: str) -> str:
+        safe_title = re.sub(r"[^A-Za-z0-9._ -]+", "", title).strip()
+        return f"{safe_title or 'Clinical Document'}.json"

--- a/backend/src/app/services/document_service.py
+++ b/backend/src/app/services/document_service.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 ALLOWED_MIME_TYPES = frozenset(
     {
         "application/pdf",
+        "application/json",
         "image/jpeg",
         "image/png",
         "image/webp",
@@ -55,6 +56,7 @@ class DocumentService:
         document_type: str,
         source_clinic: str | None = None,
         notes: str | None = None,
+        sign_file_url: bool = True,
     ) -> Any:
         """Store document metadata after the frontend has uploaded the file.
 
@@ -63,7 +65,7 @@ class DocumentService:
         self._validate_file(mime_type, file_size_bytes)
 
         # Generate a signed URL for immediate access
-        file_url = self._generate_signed_url(file_path)
+        file_url = self._generate_signed_url(file_path) if sign_file_url else ""
 
         row: dict[str, Any] = {
             "patient_id": str(patient_id),
@@ -109,7 +111,7 @@ class DocumentService:
         # Refresh signed URLs for each document
         data = cast(list[dict[str, Any]], result.data or [])
         for doc in data:
-            if doc.get("file_path"):
+            if self._should_sign_url(doc):
                 doc["file_url"] = self._generate_signed_url(doc["file_path"])
         return data
 
@@ -117,6 +119,15 @@ class DocumentService:
 
     async def get_document(self, document_id: UUID, patient_id: UUID) -> Any:
         """Get a single document with a fresh signed URL."""
+        data = self._get_document_row(document_id, patient_id)
+
+        # Refresh the signed URL
+        if self._should_sign_url(data):
+            data["file_url"] = self._generate_signed_url(data["file_path"])
+        return data
+
+    def _get_document_row(self, document_id: UUID, patient_id: UUID) -> dict[str, Any]:
+        """Fetch a patient-owned document row without mutating signed URLs."""
         result = (
             self.db.table("documents")
             .select("*")
@@ -128,17 +139,54 @@ class DocumentService:
         if not result.data:
             raise NotFoundError("Document", str(document_id))
 
-        # Refresh the signed URL
-        data = cast(dict[str, Any], result.data)
-        if data.get("file_path"):
-            data["file_url"] = self._generate_signed_url(data["file_path"])
-        return data
+        return cast(dict[str, Any], result.data)
+
+    async def delete_document(self, document_id: UUID, patient_id: UUID) -> None:
+        """Delete a patient-owned document metadata row and its storage object."""
+        document = self._get_document_row(document_id, patient_id)
+        file_path = str(document.get("file_path") or "").strip()
+        if file_path:
+            self._delete_storage_file(file_path)
+
+        (
+            self.db.table("documents")
+            .delete()
+            .eq("id", str(document_id))
+            .eq("patient_id", str(patient_id))
+            .execute()
+        )
 
     async def update_summary(self, document_id: UUID, patient_id: UUID, summary: str) -> None:
         """Cache an AI summary on the document row."""
         (
             self.db.table("documents")
             .update({"ai_summary": summary, "parsed": True})
+            .eq("id", str(document_id))
+            .eq("patient_id", str(patient_id))
+            .execute()
+        )
+
+    def update_parse_result(
+        self,
+        document_id: UUID,
+        patient_id: UUID,
+        *,
+        ai_summary: str | None,
+        parse_status: str,
+        parsed: bool,
+        parse_error: str | None = None,
+    ) -> None:
+        """Persist a completed or failed parse result for a patient document."""
+        (
+            self.db.table("documents")
+            .update(
+                {
+                    "ai_summary": ai_summary,
+                    "parse_error": parse_error,
+                    "parse_status": parse_status,
+                    "parsed": parsed,
+                }
+            )
             .eq("id", str(document_id))
             .eq("patient_id", str(patient_id))
             .execute()
@@ -170,3 +218,14 @@ class DocumentService:
         except Exception as e:
             logger.warning("Failed to sign URL for %s: %s", file_path, e)
             return ""
+
+    def _delete_storage_file(self, file_path: str) -> None:
+        """Best-effort removal of a document object from Supabase Storage."""
+        try:
+            self.db.storage.from_("documents").remove([file_path])
+        except Exception as e:
+            logger.warning("Failed to delete storage object %s: %s", file_path, e)
+
+    def _should_sign_url(self, document: dict[str, Any]) -> bool:
+        """Only storage-backed documents have a path that should be signed."""
+        return bool(document.get("file_path"))

--- a/backend/tests/integration/routers/test_document_api.py
+++ b/backend/tests/integration/routers/test_document_api.py
@@ -32,13 +32,14 @@ def mock_supabase_db():
     db.table.return_value = table
 
     # Make all query methods chainable
-    for method in ["select", "eq", "single", "insert", "order"]:
+    for method in ["select", "eq", "single", "insert", "order", "delete"]:
         getattr(table, method).return_value = table
 
     # Mock storage
     storage = MagicMock()
     bucket = MagicMock()
     bucket.create_signed_url.return_value = {"signedURL": "https://storage.example.com/signed-url"}
+    bucket.remove.return_value = []
     storage.from_.return_value = bucket
     db.storage = storage
 
@@ -302,6 +303,56 @@ class TestGetDocument:
         response = client.get(f"/api/v1/documents/{document_id}")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestDeleteDocument:
+    """DELETE /api/v1/documents/{document_id} - Delete a document."""
+
+    def test_success_removes_document_and_storage_object(
+        self, client, override_auth, override_db, mock_supabase_db, patient_id
+    ):
+        document_id = uuid4()
+        file_path = f"{patient_id}/lab-results.pdf"
+        document_data = {
+            "id": str(document_id),
+            "patient_id": str(patient_id),
+            "uploaded_by": str(patient_id),
+            "uploaded_by_role": "patient",
+            "file_name": "lab-results.pdf",
+            "file_path": file_path,
+            "file_url": "https://storage.example.com/signed-url",
+            "file_size_bytes": 1024000,
+            "mime_type": "application/pdf",
+            "document_type": "lab_report",
+            "source_clinic": None,
+            "parsed": False,
+            "ai_summary": None,
+            "parse_status": "completed",
+            "parse_error": None,
+            "parse_attempts": 1,
+            "visibility": "all_providers",
+            "created_at": "2025-01-15T00:00:00Z",
+        }
+        mock_supabase_db.table().execute.side_effect = [
+            MagicMock(data=document_data),
+            MagicMock(data=[document_data]),
+        ]
+
+        response = client.delete(f"/api/v1/documents/{document_id}")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_supabase_db.storage.from_.assert_called_with("documents")
+        mock_supabase_db.storage.from_().remove.assert_called_once_with([file_path])
+        mock_supabase_db.table().delete.assert_called_once()
+
+    def test_not_found(self, client, override_auth, override_db, mock_supabase_db):
+        document_id = uuid4()
+        mock_supabase_db.table().execute.return_value = MagicMock(data=None)
+
+        response = client.delete(f"/api/v1/documents/{document_id}")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_supabase_db.table().delete.assert_not_called()
 
 
 class TestExplainDocument:

--- a/backend/tests/unit/services/test_document_extraction_import_service.py
+++ b/backend/tests/unit/services/test_document_extraction_import_service.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.document_extraction import DocumentExtractionResult
+from app.services.document_extraction_import_service import DocumentExtractionImportService
+
+PATIENT_ID = UUID("00000000-0000-0000-0000-000000000222")
+
+
+class FakeResult:
+    def __init__(self, data: Any) -> None:
+        self.data = data
+
+
+class FakeTable:
+    def __init__(self, name: str, store: dict[str, list[dict[str, Any]]]) -> None:
+        self.name = name
+        self.store = store
+        self.pending_insert: dict[str, Any] | None = None
+        self.pending_update: dict[str, Any] | None = None
+
+    def insert(self, payload: dict[str, Any]) -> FakeTable:
+        self.pending_insert = payload
+        return self
+
+    def update(self, payload: dict[str, Any]) -> FakeTable:
+        self.pending_update = payload
+        return self
+
+    def eq(self, *_args: Any) -> FakeTable:
+        return self
+
+    def execute(self) -> FakeResult:
+        if self.pending_insert is not None:
+            row = {
+                "id": str(uuid4()),
+                "created_at": "2026-05-01T00:00:00Z",
+                "visibility": "all_providers",
+                **self.pending_insert,
+            }
+            self.store.setdefault(self.name, []).append(row)
+            self.pending_insert = None
+            return FakeResult([row])
+
+        if self.pending_update is not None:
+            self.store.setdefault(f"{self.name}_updates", []).append(self.pending_update)
+            payload = self.pending_update
+            self.pending_update = None
+            return FakeResult([payload])
+
+        return FakeResult(self.store.get(self.name, []))
+
+
+class FakeStorageBucket:
+    def create_signed_url(self, _file_path: str, _expiry_seconds: int) -> dict[str, str]:
+        return {"signedURL": "https://storage.example.test/document.json"}
+
+
+class FakeStorage:
+    def from_(self, _bucket_name: str) -> FakeStorageBucket:
+        return FakeStorageBucket()
+
+
+class FakeSupabase:
+    def __init__(self) -> None:
+        self.store: dict[str, list[dict[str, Any]]] = {}
+        self.storage = FakeStorage()
+
+    def table(self, name: str) -> FakeTable:
+        return FakeTable(name, self.store)
+
+
+@pytest.mark.asyncio
+async def test_import_demo_extraction_creates_document_derived_feed_records() -> None:
+    db = FakeSupabase()
+    service = DocumentExtractionImportService(db)  # type: ignore[arg-type]
+
+    result = await service.import_extraction(
+        patient_id=PATIENT_ID,
+        uploaded_by=PATIENT_ID,
+        uploaded_by_role="patient",
+    )
+
+    assert result["document"]["document_type"] == "discharge_summary"
+    assert result["document"]["mime_type"] == "application/json"
+    assert result["document"]["parse_status"] == "completed"
+    assert result["medications_created"] == 2
+    assert result["obligations_created"] == 1
+    assert result["conditions_created"] == 1
+    assert result["allergies_created"] == 1
+
+    medication_names = {row["name"] for row in db.store["medications"]}
+    assert {"Theophylline", "Ventolin Inhaler"} == medication_names
+    assert all(
+        row["source_document_id"] == result["document"]["id"] for row in db.store["medications"]
+    )
+    assert (
+        db.store["obligations"][0]["description"]
+        == "Review discharge instructions from Discharge Summary"
+    )
+    assert db.store["documents_updates"][0]["parse_status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_import_custom_extraction_uses_project_owned_schema() -> None:
+    db = FakeSupabase()
+    service = DocumentExtractionImportService(db)  # type: ignore[arg-type]
+    extraction = DocumentExtractionResult.model_validate(
+        {
+            "document": {
+                "title": "Clinic Instructions",
+                "document_type": "other",
+                "source_name": "City Health",
+            },
+            "summary": "Patient should hydrate and check blood pressure daily.",
+            "medications": [],
+            "conditions": [],
+            "allergies": [],
+            "obligations": [
+                {
+                    "description": "Check blood pressure",
+                    "frequency": "daily",
+                    "obligation_type": "custom",
+                }
+            ],
+        }
+    )
+
+    result = await service.import_extraction(
+        patient_id=PATIENT_ID,
+        uploaded_by=PATIENT_ID,
+        uploaded_by_role="patient",
+        extraction=extraction,
+    )
+
+    assert result["document"]["file_name"] == "Clinic Instructions.json"
+    assert result["document"]["source_clinic"] == "City Health"
+    assert result["summary"] == "Patient should hydrate and check blood pressure daily."
+    assert db.store["obligations"][0]["frequency"] == "daily"

--- a/backend/tests/unit/services/test_feed_service.py
+++ b/backend/tests/unit/services/test_feed_service.py
@@ -1,6 +1,6 @@
 """Tests for Feed service."""
 
-from datetime import date
+from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, Mock
 from uuid import uuid4
 
@@ -416,7 +416,7 @@ async def test_get_today_empty_feed(feed_service, mock_supabase_client):
     patient_id = uuid4()
     result = await feed_service.get_today(patient_id)
 
-    assert result["date"] == date.today().isoformat()
+    assert result["date"] == datetime.now(UTC).date().isoformat()
     assert result["timezone"] == "UTC"
     assert result["tasks"] == []
     assert result["summary"]["total"] == 0

--- a/backend/tests/unit/test_document_service.py
+++ b/backend/tests/unit/test_document_service.py
@@ -24,6 +24,10 @@ class TestFileValidation:
         svc = self._make_service()
         svc._validate_file("image/jpeg", 1024)
 
+    def test_accepts_json_extraction_document(self):
+        svc = self._make_service()
+        svc._validate_file("application/json", 1024)
+
     def test_rejects_executable(self):
         from app.core.exceptions import ValidationError
 
@@ -53,5 +57,6 @@ class TestFileValidation:
         """Ensure we haven't accidentally emptied the allowed list."""
         assert len(ALLOWED_MIME_TYPES) >= 7
         assert "application/pdf" in ALLOWED_MIME_TYPES
+        assert "application/json" in ALLOWED_MIME_TYPES
         assert "image/jpeg" in ALLOWED_MIME_TYPES
         assert "text/plain" in ALLOWED_MIME_TYPES


### PR DESCRIPTION
## Summary

- Replaced the patient feed mock fallback with real API-backed feed/adherence mapping.
- Added a project-owned document extraction schema and demo import endpoint that persists normalized medications, conditions, allergies, obligations, and document summaries.
- Added patient Records deletion: backend `DELETE /documents/{id}` removes the document row and storage object, and the Records modal now has a confirmation flow.
- Added focused backend and patient portal tests for extraction import, feed mapping, Today page import, Records deletion, and document delete API behavior.

## Why

Issue #52 asks for the feed to be driven by the document-to-feed pipeline rather than hardcoded patient portal mock data. We also decided the app should use an internal normalized extraction format now, keeping FHIR as a future adapter rather than the patient-facing document format.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Validation

- Backend: `ruff check` on touched backend files
- Backend: `mypy` on touched backend modules
- Backend: `pytest tests/unit/test_document_service.py tests/integration/routers/test_document_api.py tests/unit/services/test_document_extraction_import_service.py tests/integration/test_ingestion_pipeline.py tests/unit/services/test_feed_service.py -q --no-cov`
- Patient portal: `eslint` on touched frontend files
- Patient portal: `tsc --noEmit`
- Patient portal: `vitest run --run src/__tests__/records-page.test.tsx src/__tests__/feed-slice.test.ts src/__tests__/today-page.test.tsx`

## Manual Verification

- Started the backend and patient portal locally.
- Verified the Today page renders real feed data and the clinical document demo import creates feed-backed tasks.
- Verified Records delete confirmation appears and deleting a document removes it from the list.
- Confirmed no `.env*`, key, token, or service-account files were staged or committed.
