### PR TITLE
[codex] Fold in patient portal audit fixes

### DIFF
--- a/apps/patient-portal/src/__tests__/records-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/records-page.test.tsx
@@ -3,11 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import RecordsPage from "@/app/(app)/records/page";
 import { DocumentParseStatus, DocumentType } from "@/types";
 
-const { deleteRequest, get, post, push } = vi.hoisted(() => ({
+const { deleteRequest, get, post, push, uploadDocumentToStorage } = vi.hoisted(() => ({
     deleteRequest: vi.fn(),
     get: vi.fn(),
     post: vi.fn(),
     push: vi.fn(),
+    uploadDocumentToStorage: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -29,7 +30,7 @@ vi.mock("@/services/api", () => ({
 }));
 
 vi.mock("@/services/storage", () => ({
-    uploadDocumentToStorage: vi.fn(),
+    uploadDocumentToStorage,
 }));
 
 describe("RecordsPage", () => {
@@ -38,6 +39,7 @@ describe("RecordsPage", () => {
         get.mockReset();
         post.mockReset();
         push.mockReset();
+        uploadDocumentToStorage.mockReset();
         window.sessionStorage.clear();
     });
 
@@ -116,5 +118,46 @@ describe("RecordsPage", () => {
             expect(screen.queryByText(/Discharge Summary\.txt/i)).not.toBeInTheDocument();
         });
         expect(screen.getByText(/No records yet/i)).toBeInTheDocument();
+    });
+
+    it("infers a discharge summary type from uploaded PDF filenames", async () => {
+        get.mockResolvedValue([]);
+        uploadDocumentToStorage.mockResolvedValue("patient-1/vatsal-discharge-summary.pdf");
+        post.mockResolvedValue({
+            ai_summary: null,
+            created_at: "2026-04-20T12:00:00Z",
+            document_type: DocumentType.DISCHARGE_SUMMARY,
+            file_name: "vatsal-discharge-summary.pdf",
+            file_size_bytes: 1400,
+            file_url: "https://example.test/discharge.pdf",
+            id: "doc-upload",
+            mime_type: "application/pdf",
+            parse_status: DocumentParseStatus.PENDING,
+            parsed: false,
+            patient_id: "patient-1",
+            source_clinic: null,
+            uploaded_by: "patient-1",
+            uploaded_by_role: "patient",
+            visibility: "shared",
+        });
+
+        const { container } = render(<RecordsPage />);
+        const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+        const file = new File(["test"], "vatsal-discharge-summary.pdf", {
+            type: "application/pdf",
+        });
+
+        fireEvent.change(input!, { target: { files: [file] } });
+
+        await waitFor(() => {
+            expect(post).toHaveBeenCalledWith(
+                "/api/v1/documents/",
+                expect.objectContaining({
+                    document_type: DocumentType.DISCHARGE_SUMMARY,
+                    file_name: "vatsal-discharge-summary.pdf",
+                }),
+                { token: "access-token" },
+            );
+        });
     });
 });

--- a/apps/patient-portal/src/__tests__/today-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/today-page.test.tsx
@@ -3,15 +3,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import TodayPage from "@/app/(app)/today/page";
 import { FeedTaskStatus, FeedTaskType, type FeedTask } from "@/types";
 
-const { importDemoDocument, markComplete, refreshFeed, useFeedData } = vi.hoisted(() => ({
+const { importDemoDocument, markComplete, refreshFeed, useFeedData, usePatientProfile } = vi.hoisted(() => ({
     importDemoDocument: vi.fn(),
     markComplete: vi.fn(),
     refreshFeed: vi.fn(),
     useFeedData: vi.fn(),
+    usePatientProfile: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-feed-data", () => ({
     useFeedData,
+}));
+
+vi.mock("@/hooks/use-patient-profile", () => ({
+    usePatientProfile,
 }));
 
 function mockFeedData(overrides: Partial<ReturnType<typeof baseFeedData>> = {}) {
@@ -45,6 +50,18 @@ describe("TodayPage", () => {
         markComplete.mockReset();
         refreshFeed.mockReset();
         useFeedData.mockReset();
+        usePatientProfile.mockReset();
+        usePatientProfile.mockReturnValue(null);
+    });
+
+    it("uses the logged-in patient profile for the greeting and avatar", () => {
+        usePatientProfile.mockReturnValue({ firstName: "Vatsal" });
+        mockFeedData({ tasks: [] });
+
+        render(<TodayPage />);
+
+        expect(screen.getByRole("heading", { name: "Hi, Vatsal" })).toBeInTheDocument();
+        expect(screen.getByText("V")).toBeInTheDocument();
     });
 
     it("renders a calm loading state while the first feed load is pending", () => {

--- a/apps/patient-portal/src/__tests__/visits-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/visits-page.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import VisitsPage from "@/app/(app)/visits/page";
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ back: vi.fn() }),
+}));
+
+describe("VisitsPage", () => {
+    it("shows an empty state instead of hardcoded visit data", () => {
+        render(<VisitsPage />);
+
+        expect(screen.getByText(/No visits scheduled yet/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Blood pressure follow-up/i)).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Message care team/i })).toBeInTheDocument();
+    });
+});

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -127,17 +127,39 @@ function inferDocumentType(file: File): DocumentType {
     const normalizedName = file.name.toLowerCase();
     const normalizedType = file.type.toLowerCase();
 
-    if (normalizedType.includes("pdf") || normalizedName.endsWith(".pdf")) {
-        return DocumentType.LAB_REPORT;
-    }
     if (normalizedType.startsWith("image/")) {
         return DocumentType.DIAGNOSTIC_REPORT;
     }
-    if (normalizedType === "text/csv" || normalizedName.endsWith(".csv")) {
+
+    if (normalizedName.includes("discharge") || normalizedName.includes("summary")) {
+        return DocumentType.DISCHARGE_SUMMARY;
+    }
+    if (normalizedName.includes("prescription") || normalizedName.includes("rx")) {
+        return DocumentType.PRESCRIPTION;
+    }
+    if (normalizedName.includes("referral")) {
+        return DocumentType.REFERRAL;
+    }
+    if (normalizedName.includes("insurance")) {
+        return DocumentType.INSURANCE;
+    }
+    if (
+        normalizedName.includes("lab")
+        || normalizedName.includes("blood")
+        || normalizedName.includes("result")
+        || normalizedType === "text/csv"
+        || normalizedName.endsWith(".csv")
+    ) {
         return DocumentType.LAB_REPORT;
     }
-    if (normalizedType === "text/plain" || normalizedName.endsWith(".txt")) {
-        return DocumentType.DISCHARGE_SUMMARY;
+    if (
+        normalizedName.includes("diagnostic")
+        || normalizedName.includes("xray")
+        || normalizedName.includes("mri")
+        || normalizedName.includes("ct")
+        || normalizedName.includes("scan")
+    ) {
+        return DocumentType.DIAGNOSTIC_REPORT;
     }
     return DocumentType.OTHER;
 }

--- a/apps/patient-portal/src/app/(app)/today/page.tsx
+++ b/apps/patient-portal/src/app/(app)/today/page.tsx
@@ -6,6 +6,7 @@ import { CircularProgress, MedicationCard, ObligationCard } from "@/components/f
 import type { TaskCardStatus } from "@/components/features/task-card.types";
 import { Button, Card, EmptyState, ErrorState, Skeleton } from "@/components/ui";
 import { useFeedData } from "@/hooks/use-feed-data";
+import { usePatientProfile } from "@/hooks/use-patient-profile";
 import { FeedTaskStatus, FeedTaskType, type FeedTask } from "@/types";
 
 function splitMedicationName(name: string) {
@@ -60,6 +61,9 @@ export default function TodayPage() {
         summary,
         tasks,
     } = useFeedData();
+    const profile = usePatientProfile();
+    const displayName = profile?.firstName ?? "";
+    const avatarInitial = displayName.charAt(0).toUpperCase() || "?";
     const completionPercent = Number.isFinite(adherenceStats.overallScore)
         ? Math.round(adherenceStats.overallScore * 100)
         : 0;
@@ -84,7 +88,9 @@ export default function TodayPage() {
                 <div className="relative flex items-start justify-between gap-4">
                     <div>
                         <p className="text-xs font-black uppercase tracking-[0.24em] text-white/68">Today</p>
-                        <h1 className="mt-2 text-[2.35rem] font-black leading-none tracking-[-0.04em]">Hi, Sarah</h1>
+                        <h1 className="mt-2 text-[2.35rem] font-black leading-none tracking-[-0.04em]">
+                            {displayName ? `Hi, ${displayName}` : "Hi there"}
+                        </h1>
                         <p className="mt-2 text-base text-white/82">
                             {new Date().toLocaleDateString(undefined, {
                                 day: "numeric",
@@ -94,7 +100,7 @@ export default function TodayPage() {
                         </p>
                     </div>
                     <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[24px] bg-white text-lg font-black text-[#147465] shadow-sm">
-                        S
+                        {avatarInitial}
                     </div>
                 </div>
 
@@ -221,7 +227,7 @@ export default function TodayPage() {
                                         onMarkComplete={() => markComplete(task)}
                                         status={status}
                                         time={task.scheduledTime ?? ""}
-                                        type={task.frequency.includes("walk") ? "exercise" : "custom"}
+                                        type={task.frequency?.includes("walk") ? "exercise" : "custom"}
                                     />
                                 </div>
                             );

--- a/apps/patient-portal/src/app/(app)/visits/page.tsx
+++ b/apps/patient-portal/src/app/(app)/visits/page.tsx
@@ -1,95 +1,57 @@
 "use client";
 
-import { useState } from "react";
 import { HiOutlineCalendarDays } from "react-icons/hi2";
 import { PageHeader } from "@/components/layouts";
-import { Badge, Button, Card, EmptyState, Modal } from "@/components/ui";
-import type { Appointment } from "@/types";
-
-const appointments: Appointment[] = [
-    {
-        appointmentType: "follow_up",
-        careTeamId: "care-team-1",
-        createdAt: "2026-03-20T00:00:00Z",
-        durationMinutes: 30,
-        id: "appt-1",
-        location: "City Health Primary Care",
-        patientId: "demo-patient",
-        reason: "Blood pressure follow-up and medication review.",
-        scheduledAt: "2026-04-15T10:30:00Z",
-        status: "scheduled",
-    },
-];
+import { Button, Card, EmptyState } from "@/components/ui";
 
 export default function VisitsPage() {
-    const [selected, setSelected] = useState<Appointment | null>(null);
-
     return (
         <div className="patient-page space-y-4 pb-8">
             <PageHeader
-                rightAction={<Button variant="secondary">Schedule visit</Button>}
                 subtitle="Upcoming appointments and preparation notes."
                 title="Visits"
             />
             <div className="patient-stack -mt-4 space-y-4 px-5">
-                {appointments[0] ? (
-                    <Card className="border-[#b9ded6] bg-gradient-to-br from-[#147465] to-[#285d8f] text-white shadow-[0_24px_55px_rgba(20,116,101,0.24)]">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#ccebe5]">Next visit</p>
-                        <h2 className="mt-2 text-xl font-semibold text-white">Care team follow-up</h2>
-                        <p className="mt-2 text-base leading-7 text-[#dcefeb]">
-                            {new Date(appointments[0].scheduledAt).toLocaleString(undefined, {
-                                dateStyle: "medium",
-                                timeStyle: "short",
-                            })}
-                        </p>
-                        <p className="mt-1 text-base text-[#dcefeb]">{appointments[0].location}</p>
-                    </Card>
-                ) : null}
-                {appointments.length === 0 ? (
-                    <EmptyState
-                        description="Your upcoming appointments will appear here."
-                        icon={<HiOutlineCalendarDays />}
-                        title="No visits scheduled"
-                    />
-                ) : null}
-                {appointments.map((appointment) => (
-                    <button className="w-full text-left" key={appointment.id} onClick={() => setSelected(appointment)} type="button">
-                        <Card className="space-y-4 transition hover:border-[#b9ded6] hover:shadow-[0_18px_44px_rgba(20,116,101,0.14)]">
-                            <div className="flex items-start justify-between gap-4">
-                                <div>
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Appointment</p>
-                                    <h2 className="mt-1 text-lg font-semibold text-[#17233a]">Care team visit</h2>
-                                    <p className="mt-1 text-base leading-7 text-[#5b6b83]">{appointment.reason}</p>
-                                </div>
-                                <Badge variant="info">Scheduled</Badge>
-                            </div>
-                            <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 text-base leading-7 text-[#48627c] ring-1 ring-[#eaded3]">
-                                <p>{new Date(appointment.scheduledAt).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })}</p>
-                                <p className="mt-1">{appointment.location}</p>
-                            </div>
-                        </Card>
-                    </button>
-                ))}
-            </div>
-            <Modal onClose={() => setSelected(null)} open={Boolean(selected)} title="Visit details">
-                <div className="space-y-4">
-                    <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Scheduled</p>
-                        <p className="mt-1 text-base font-semibold text-[#30415f]">
-                        {selected
-                            ? new Date(selected.scheduledAt).toLocaleString(undefined, {
-                                  dateStyle: "full",
-                                  timeStyle: "short",
-                              })
-                            : null}
-                        </p>
-                    </div>
-                    <p className="text-base leading-7 text-[#5b6b83]">{selected?.reason}</p>
-                    <Button fullWidth size="lg" variant="primary">
-                        Add to calendar
+                <Card className="border-[#b9ded6] bg-gradient-to-br from-[#147465] to-[#285d8f] text-white shadow-[0_24px_55px_rgba(20,116,101,0.24)]">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#ccebe5]">
+                        Coming soon
+                    </p>
+                    <h2 className="mt-2 text-xl font-semibold text-white">
+                        Appointment scheduling
+                    </h2>
+                    <p className="mt-2 text-base leading-7 text-[#dcefeb]">
+                        Your clinician will propose appointments based on your follow-up
+                        instructions. You&apos;ll be able to confirm and track them here.
+                    </p>
+                </Card>
+
+                <EmptyState
+                    description="Once your clinician schedules a visit, it will appear here with preparation notes and reminders."
+                    icon={<HiOutlineCalendarDays />}
+                    title="No visits scheduled yet"
+                />
+
+                <Card className="border-[#b9ded6] bg-[#e6f4f1]">
+                    <p className="text-base font-bold text-[#17233a]">
+                        Need to schedule a visit?
+                    </p>
+                    <p className="mt-1 text-base leading-7 text-[#5b6b83]">
+                        Message your care team directly through the chat to request an
+                        appointment or follow-up.
+                    </p>
+                    <Button
+                        className="mt-3"
+                        fullWidth
+                        onClick={() => {
+                            window.location.href = "/chat";
+                        }}
+                        size="lg"
+                        variant="secondary"
+                    >
+                        Message care team
                     </Button>
-                </div>
-            </Modal>
+                </Card>
+            </div>
         </div>
     );
 }

--- a/apps/patient-portal/src/hooks/use-patient-profile.ts
+++ b/apps/patient-portal/src/hooks/use-patient-profile.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { api } from "@/services/api";
+import type { RootState } from "@/store/store";
+import { normalizeLocale, type Locale } from "@/types";
+
+interface PatientProfileResponse {
+    date_of_birth: string;
+    email: string;
+    first_name: string;
+    id: string;
+    last_name: string;
+    preferred_language: Locale;
+    timezone?: string;
+}
+
+export interface PatientProfile {
+    dateOfBirth: string;
+    email: string;
+    firstName: string;
+    id: string;
+    lastName: string;
+    preferredLanguage: Locale;
+    timezone: string;
+}
+
+function mapProfile(raw: PatientProfileResponse): PatientProfile {
+    return {
+        dateOfBirth: raw.date_of_birth,
+        email: raw.email,
+        firstName: raw.first_name,
+        id: raw.id,
+        lastName: raw.last_name,
+        preferredLanguage: normalizeLocale(raw.preferred_language),
+        timezone: raw.timezone ?? "UTC",
+    };
+}
+
+export function usePatientProfile(): PatientProfile | null {
+    const accessToken = useSelector((state: RootState) => state.auth.accessToken);
+    const [profile, setProfile] = useState<PatientProfile | null>(null);
+
+    useEffect(() => {
+        if (!accessToken) {
+            return;
+        }
+
+        let isMounted = true;
+
+        api.get<PatientProfileResponse>("/api/v1/patients/me", { token: accessToken })
+            .then((raw) => {
+                if (isMounted) {
+                    setProfile(mapProfile(raw));
+                }
+            })
+            .catch(() => {
+                // The Today page still works with the generic greeting.
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [accessToken]);
+
+    return profile;
+}


### PR DESCRIPTION
## Summary

- Folded in the useful low-risk pieces from PR #57 without taking the conflicting mock feed fallback.
- Today now greets the logged-in patient from `/api/v1/patients/me` and keeps obligation frequency handling null-safe.
- Records upload type inference now uses filename/document hints instead of treating every PDF as a lab report.
- Visits no longer shows hardcoded demo appointment data and now uses an empty-state CTA.
- Fixed the Today Import button so it opens a file picker, uploads the selected clinical document, registers that document, and attaches the mocked extraction to the uploaded document id.
- Added focused patient portal and backend coverage for the greeting/avatar, document type inference, file-picker import path, Visits empty state, skipped ingestion, and document-id extraction import.

## Why

PR #57 has useful patient-portal polish, but it conflicts with the merged document extraction/feed/delete work and includes changes we should not carry forward. This follow-up keeps the useful pieces, avoids reintroducing mock data paths, and makes the Today import CTA behave like a real upload entry point while FHIR/document parsing remains mocked.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Validation

- Patient portal: `eslint` on touched frontend files
- Patient portal: `tsc --noEmit`
- Patient portal: `vitest run --run src/__tests__/records-page.test.tsx src/__tests__/feed-slice.test.ts src/__tests__/today-page.test.tsx src/__tests__/visits-page.test.tsx src/__tests__/documents-service.test.ts`
- Backend: `ruff check` on touched backend files and tests
- Backend: `ruff format --check` on touched backend files and tests
- Backend: `mypy src/app/models/document_extraction.py src/app/routers/documents.py src/app/services/document_extraction_import_service.py`
- Backend: `pytest tests/unit/services/test_document_extraction_import_service.py tests/integration/routers/test_document_api.py -q --no-cov`

## Manual Verification

- Confirmed the branch diff contains the selected patient portal audit fixes plus the Today import upload fix.
- Confirmed PR #57 remains conflicting and was not merged wholesale.
- Confirmed the Today import flow is now file-input driven; browser access to the local page was blocked by an expired session, so the interaction is covered by the focused component test.
- Confirmed no `.env*`, key, token, or service-account files were staged or committed.
