### PR TITLE
[codex] Delete document-derived feed tasks

### DIFF
--- a/apps/patient-portal/src/__tests__/documents-service.test.ts
+++ b/apps/patient-portal/src/__tests__/documents-service.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { inferDocumentType } from "@/services/documents";
+import { DocumentType } from "@/types";
+
+describe("documents service", () => {
+    it("infers clinical document types from uploaded filenames", () => {
+        expect(
+            inferDocumentType(new File(["test"], "vatsal-discharge-summary.pdf", {
+                type: "application/pdf",
+            })),
+        ).toBe(DocumentType.DISCHARGE_SUMMARY);
+        expect(
+            inferDocumentType(new File(["test"], "blood-results.csv", {
+                type: "text/csv",
+            })),
+        ).toBe(DocumentType.LAB_REPORT);
+        expect(
+            inferDocumentType(new File(["test"], "chest-xray.png", {
+                type: "image/png",
+            })),
+        ).toBe(DocumentType.DIAGNOSTIC_REPORT);
+    });
+});

--- a/apps/patient-portal/src/__tests__/today-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/today-page.test.tsx
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import TodayPage from "@/app/(app)/today/page";
 import { FeedTaskStatus, FeedTaskType, type FeedTask } from "@/types";
 
-const { importDemoDocument, markComplete, refreshFeed, useFeedData, usePatientProfile } = vi.hoisted(() => ({
-    importDemoDocument: vi.fn(),
+const { importDocumentFile, markComplete, refreshFeed, useFeedData, usePatientProfile } = vi.hoisted(() => ({
+    importDocumentFile: vi.fn(),
     markComplete: vi.fn(),
     refreshFeed: vi.fn(),
     useFeedData: vi.fn(),
@@ -32,7 +32,7 @@ function baseFeedData() {
         documentImportError: null,
         documentImporting: false,
         error: null,
-        importDemoDocument,
+        importDocumentFile,
         loading: false,
         markComplete,
         refreshFeed,
@@ -46,7 +46,7 @@ function baseFeedData() {
 
 describe("TodayPage", () => {
     beforeEach(() => {
-        importDemoDocument.mockReset();
+        importDocumentFile.mockReset();
         markComplete.mockReset();
         refreshFeed.mockReset();
         useFeedData.mockReset();
@@ -135,13 +135,31 @@ describe("TodayPage", () => {
         expect(screen.getByText(/^Set reminder time$/i)).toBeInTheDocument();
     });
 
-    it("lets patients import a demo clinical document extraction into the real feed pipeline", () => {
+    it("opens the file picker when patients import a clinical document", () => {
+        const inputClick = vi
+            .spyOn(HTMLInputElement.prototype, "click")
+            .mockImplementation(() => {});
         mockFeedData();
 
         render(<TodayPage />);
 
         fireEvent.click(screen.getByRole("button", { name: /^Import$/i }));
 
-        expect(importDemoDocument).toHaveBeenCalledOnce();
+        expect(inputClick).toHaveBeenCalledOnce();
+        inputClick.mockRestore();
+    });
+
+    it("imports the selected clinical document file", () => {
+        mockFeedData();
+
+        const { container } = render(<TodayPage />);
+        const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+        const file = new File(["test"], "vatsal-discharge-summary.pdf", {
+            type: "application/pdf",
+        });
+
+        fireEvent.change(input!, { target: { files: [file] } });
+
+        expect(importDocumentFile).toHaveBeenCalledWith(file);
     });
 });

--- a/apps/patient-portal/src/app/(app)/records/page.tsx
+++ b/apps/patient-portal/src/app/(app)/records/page.tsx
@@ -13,6 +13,7 @@ import {
     buildSuggestedDocumentQuestion,
     storePendingChatDocumentContext,
 } from "@/services/chat-bridge";
+import { inferDocumentType, type DocumentApiRecord } from "@/services/documents";
 import { uploadDocumentToStorage } from "@/services/storage";
 import type { RootState } from "@/store/store";
 import {
@@ -28,26 +29,6 @@ import {
 import { useSelector } from "react-redux";
 
 type PortalDocument = Document & { icon: ReactNode; provider: string };
-
-interface DocumentApiRecord {
-    id: string;
-    patient_id: string;
-    uploaded_by: string;
-    uploaded_by_role: Document["uploadedByRole"];
-    document_type: DocumentType;
-    file_name: string;
-    file_url: string;
-    mime_type: string;
-    file_size_bytes: number;
-    parsed: boolean;
-    ai_summary?: string | null;
-    parse_status?: Document["parseStatus"];
-    parse_error?: string | null;
-    parse_attempts?: number;
-    source_clinic?: string | null;
-    visibility: Document["visibility"];
-    created_at: string;
-}
 
 const EXPLANATION_UNAVAILABLE_MESSAGE =
     "Translation is currently unavailable. Please try again later.";
@@ -121,47 +102,6 @@ function getDocumentStatus(document: PortalDocument) {
         return { label: "AI Summary", variant: "info" as const };
     }
     return null;
-}
-
-function inferDocumentType(file: File): DocumentType {
-    const normalizedName = file.name.toLowerCase();
-    const normalizedType = file.type.toLowerCase();
-
-    if (normalizedType.startsWith("image/")) {
-        return DocumentType.DIAGNOSTIC_REPORT;
-    }
-
-    if (normalizedName.includes("discharge") || normalizedName.includes("summary")) {
-        return DocumentType.DISCHARGE_SUMMARY;
-    }
-    if (normalizedName.includes("prescription") || normalizedName.includes("rx")) {
-        return DocumentType.PRESCRIPTION;
-    }
-    if (normalizedName.includes("referral")) {
-        return DocumentType.REFERRAL;
-    }
-    if (normalizedName.includes("insurance")) {
-        return DocumentType.INSURANCE;
-    }
-    if (
-        normalizedName.includes("lab")
-        || normalizedName.includes("blood")
-        || normalizedName.includes("result")
-        || normalizedType === "text/csv"
-        || normalizedName.endsWith(".csv")
-    ) {
-        return DocumentType.LAB_REPORT;
-    }
-    if (
-        normalizedName.includes("diagnostic")
-        || normalizedName.includes("xray")
-        || normalizedName.includes("mri")
-        || normalizedName.includes("ct")
-        || normalizedName.includes("scan")
-    ) {
-        return DocumentType.DIAGNOSTIC_REPORT;
-    }
-    return DocumentType.OTHER;
 }
 
 export default function RecordsPage() {

--- a/apps/patient-portal/src/app/(app)/today/page.tsx
+++ b/apps/patient-portal/src/app/(app)/today/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef, type ChangeEvent } from "react";
 import Link from "next/link";
 import { HiOutlineCalendarDays, HiOutlineCheck } from "react-icons/hi2";
 import { CircularProgress, MedicationCard, ObligationCard } from "@/components/features";
@@ -54,13 +55,14 @@ export default function TodayPage() {
         documentImportError,
         documentImporting,
         error,
-        importDemoDocument,
+        importDocumentFile,
         loading,
         markComplete,
         refreshFeed,
         summary,
         tasks,
     } = useFeedData();
+    const documentInputRef = useRef<HTMLInputElement | null>(null);
     const profile = usePatientProfile();
     const displayName = profile?.firstName ?? "";
     const avatarInitial = displayName.charAt(0).toUpperCase() || "?";
@@ -69,6 +71,16 @@ export default function TodayPage() {
         : 0;
     const completedLabel = `${summary.completed} of ${summary.total || tasks.length} tasks completed`;
     const hasScheduleGaps = tasks.some((task) => task.requiresScheduleConfiguration);
+
+    function handleDocumentFileChange(event: ChangeEvent<HTMLInputElement>) {
+        const file = event.target.files?.[0];
+        if (!file) {
+            return;
+        }
+
+        void importDocumentFile(file);
+        event.target.value = "";
+    }
 
     if (loading && tasks.length === 0) {
         return (
@@ -136,17 +148,29 @@ export default function TodayPage() {
                     <div>
                         <p className="text-base font-black text-[#17233a]">Clinical document</p>
                         <p className="text-sm font-semibold text-[#48627c]">
-                            {documentImporting ? "Importing..." : "Demo extraction"}
+                            {documentImporting ? "Importing..." : "Upload PDF or image"}
                         </p>
                     </div>
-                    <Button disabled={documentImporting} onClick={importDemoDocument} size="sm" variant="secondary">
+                    <Button
+                        disabled={documentImporting}
+                        onClick={() => documentInputRef.current?.click()}
+                        size="sm"
+                        variant="secondary"
+                    >
                         {documentImporting ? "Importing" : "Import"}
                     </Button>
+                    <input
+                        accept="application/pdf,image/*,text/plain,text/csv,application/json"
+                        className="hidden"
+                        onChange={handleDocumentFileChange}
+                        ref={documentInputRef}
+                        type="file"
+                    />
                 </Card>
                 {documentImportError ? (
                     <ErrorState
                         description={documentImportError}
-                        onRetry={() => void importDemoDocument()}
+                        onRetry={() => documentInputRef.current?.click()}
                         title="Document import failed"
                     />
                 ) : null}

--- a/apps/patient-portal/src/hooks/use-feed-data.ts
+++ b/apps/patient-portal/src/hooks/use-feed-data.ts
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { api } from "@/services/api";
+import { inferDocumentType, type DocumentApiRecord } from "@/services/documents";
+import { uploadDocumentToStorage } from "@/services/storage";
 import {
     fetchTodayFeed,
     markTaskComplete,
@@ -70,7 +72,7 @@ function getMissedTaskIds(tasks: FeedTask[]) {
 export function useFeedData() {
     const dispatch = useDispatch<AppDispatch>();
     const feed = useSelector((state: RootState) => state.feed);
-    const accessToken = useSelector((state: RootState) => state.auth.accessToken);
+    const { accessToken, user } = useSelector((state: RootState) => state.auth);
     const [adherenceStats, setAdherenceStats] = useState<AdherenceStats>(emptyAdherenceStats);
     const [documentImportError, setDocumentImportError] = useState<string | null>(null);
     const [documentImporting, setDocumentImporting] = useState(false);
@@ -129,8 +131,8 @@ export function useFeedData() {
         }
     }
 
-    async function importDemoDocument() {
-        if (!accessToken) {
+    async function importDocumentFile(file: File) {
+        if (!accessToken || !user) {
             setDocumentImportError("Please sign in again before importing a clinical document.");
             return;
         }
@@ -138,7 +140,25 @@ export function useFeedData() {
         setDocumentImporting(true);
         setDocumentImportError(null);
         try {
-            await api.post("/api/v1/documents/extractions/import", undefined, {
+            const filePath = await uploadDocumentToStorage({
+                file,
+                patientId: user.id,
+                token: accessToken,
+            });
+            const document = await api.post<DocumentApiRecord>(
+                "/api/v1/documents/",
+                {
+                    document_type: inferDocumentType(file),
+                    file_name: file.name,
+                    file_path: filePath,
+                    file_size_bytes: file.size,
+                    mime_type: file.type || "application/octet-stream",
+                    source_clinic: "Patient uploaded document",
+                    start_ingestion: false,
+                },
+                { token: accessToken },
+            );
+            await api.post("/api/v1/documents/extractions/import", { document_id: document.id }, {
                 token: accessToken,
             });
             await dispatch(fetchTodayFeed({ token: accessToken })).unwrap();
@@ -154,7 +174,7 @@ export function useFeedData() {
         documentImportError,
         documentImporting,
         error: feed.error,
-        importDemoDocument,
+        importDocumentFile,
         loading: feed.loading,
         markComplete,
         refreshFeed,

--- a/apps/patient-portal/src/services/documents.ts
+++ b/apps/patient-portal/src/services/documents.ts
@@ -1,0 +1,62 @@
+import { DocumentType, type Document } from "@/types";
+
+export interface DocumentApiRecord {
+    id: string;
+    patient_id: string;
+    uploaded_by: string;
+    uploaded_by_role: Document["uploadedByRole"];
+    document_type: DocumentType;
+    file_name: string;
+    file_url: string;
+    mime_type: string;
+    file_size_bytes: number;
+    parsed: boolean;
+    ai_summary?: string | null;
+    parse_status?: Document["parseStatus"];
+    parse_error?: string | null;
+    parse_attempts?: number;
+    source_clinic?: string | null;
+    visibility: Document["visibility"];
+    created_at: string;
+}
+
+export function inferDocumentType(file: File): DocumentType {
+    const normalizedName = file.name.toLowerCase();
+    const normalizedType = file.type.toLowerCase();
+
+    if (normalizedType.startsWith("image/")) {
+        return DocumentType.DIAGNOSTIC_REPORT;
+    }
+
+    if (normalizedName.includes("discharge") || normalizedName.includes("summary")) {
+        return DocumentType.DISCHARGE_SUMMARY;
+    }
+    if (normalizedName.includes("prescription") || normalizedName.includes("rx")) {
+        return DocumentType.PRESCRIPTION;
+    }
+    if (normalizedName.includes("referral")) {
+        return DocumentType.REFERRAL;
+    }
+    if (normalizedName.includes("insurance")) {
+        return DocumentType.INSURANCE;
+    }
+    if (
+        normalizedName.includes("lab")
+        || normalizedName.includes("blood")
+        || normalizedName.includes("result")
+        || normalizedType === "text/csv"
+        || normalizedName.endsWith(".csv")
+    ) {
+        return DocumentType.LAB_REPORT;
+    }
+    if (
+        normalizedName.includes("diagnostic")
+        || normalizedName.includes("xray")
+        || normalizedName.includes("mri")
+        || normalizedName.includes("ct")
+        || normalizedName.includes("scan")
+    ) {
+        return DocumentType.DIAGNOSTIC_REPORT;
+    }
+    return DocumentType.OTHER;
+}

--- a/backend/src/app/db/migrations/016_obligation_source_document.sql
+++ b/backend/src/app/db/migrations/016_obligation_source_document.sql
@@ -1,0 +1,13 @@
+-- Track obligations that came from document extraction so deleting a document
+-- can remove derived Today-feed tasks without touching manual tasks.
+
+ALTER TABLE obligations
+  ADD COLUMN IF NOT EXISTS source_document_id uuid REFERENCES documents(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_medications_source_document
+  ON medications(source_document_id)
+  WHERE source_document_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_obligations_source_document
+  ON obligations(source_document_id)
+  WHERE source_document_id IS NOT NULL;

--- a/backend/src/app/models/document_extraction.py
+++ b/backend/src/app/models/document_extraction.py
@@ -8,6 +8,8 @@ this shape.
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from pydantic import BaseModel, Field
 
 from app.models.enums import DocumentType, MedicationRoute, ObligationType
@@ -72,4 +74,5 @@ class DocumentExtractionResult(BaseModel):
 class DocumentExtractionImportRequest(BaseModel):
     """Optional extraction payload for local/demo import flows."""
 
+    document_id: UUID | None = None
     extraction: DocumentExtractionResult | None = None

--- a/backend/src/app/models/obligation.py
+++ b/backend/src/app/models/obligation.py
@@ -13,6 +13,7 @@ class ObligationCreate(BaseModel):
     description: str = Field(..., min_length=1, max_length=500)
     frequency: str = Field(..., examples=["daily", "3x per week", "after meals"])
     set_by_care_team_id: UUID | None = None
+    source_document_id: UUID | None = None
     notes: str | None = None
 
 
@@ -30,6 +31,7 @@ class ObligationRead(BaseModel):
     description: str
     frequency: str
     set_by_care_team_id: UUID | None = None
+    source_document_id: UUID | None = None
     notes: str | None = None
     is_active: bool = True
     reminder_schedule: ReminderScheduleRead | None = None

--- a/backend/src/app/routers/documents.py
+++ b/backend/src/app/routers/documents.py
@@ -53,6 +53,7 @@ class DocumentCreateRequest(BaseModel):
     document_type: DocumentType
     source_clinic: str | None = None
     notes: str | None = None
+    start_ingestion: bool = True
 
 
 class ExplainRequest(BaseModel):
@@ -109,13 +110,14 @@ async def create_document(
         source_clinic=body.source_clinic,
         notes=body.notes,
     )
-    background_tasks.add_task(
-        _run_ingestion_safe,
-        document_id=str(document["id"]),
-        patient_id=user.id,
-        file_path=body.file_path,
-        document_type=body.document_type.value,
-    )
+    if body.start_ingestion:
+        background_tasks.add_task(
+            _run_ingestion_safe,
+            document_id=str(document["id"]),
+            patient_id=user.id,
+            file_path=body.file_path,
+            document_type=body.document_type.value,
+        )
     return document
 
 
@@ -159,6 +161,7 @@ async def import_document_extraction(
         patient_id=user.id,
         uploaded_by=user.id,
         uploaded_by_role=user.role,
+        document_id=body.document_id if body else None,
         extraction=body.extraction if body else None,
     )
 

--- a/backend/src/app/services/document_extraction_import_service.py
+++ b/backend/src/app/services/document_extraction_import_service.py
@@ -122,7 +122,11 @@ class DocumentExtractionImportService:
         )
         condition_ids = self._create_conditions(patient_id, effective_extraction)
         allergy_ids = self._create_allergies(patient_id, effective_extraction)
-        obligation_ids = await self._create_obligations(patient_id, effective_extraction)
+        obligation_ids = await self._create_obligations(
+            patient_id,
+            document_id,
+            effective_extraction,
+        )
 
         self.document_service.update_parse_result(
             document_id=document_id,
@@ -229,6 +233,7 @@ class DocumentExtractionImportService:
     async def _create_obligations(
         self,
         patient_id: UUID,
+        document_id: UUID,
         extraction: DocumentExtractionResult,
     ) -> list[str]:
         created_ids: list[str] = []

--- a/backend/src/app/services/document_extraction_import_service.py
+++ b/backend/src/app/services/document_extraction_import_service.py
@@ -89,6 +89,7 @@ class DocumentExtractionImportService:
         patient_id: UUID,
         uploaded_by: UUID,
         uploaded_by_role: str,
+        document_id: UUID | None = None,
         extraction: DocumentExtractionResult | None = None,
     ) -> dict[str, Any]:
         effective_extraction = extraction or DEMO_DOCUMENT_EXTRACTION
@@ -96,20 +97,23 @@ class DocumentExtractionImportService:
         serialized_extraction = effective_extraction.model_dump(mode="json")
         summary = effective_extraction.summary or self._summary(effective_extraction)
 
-        document = await self.document_service.create_document(
-            patient_id=patient_id,
-            uploaded_by=uploaded_by,
-            uploaded_by_role=uploaded_by_role,
-            file_name=self._file_name(document_payload.title),
-            file_path="",
-            file_size_bytes=len(json.dumps(serialized_extraction).encode("utf-8")),
-            mime_type="application/json",
-            document_type=document_payload.document_type.value,
-            source_clinic=document_payload.source_name or "Document extraction demo",
-            notes=document_payload.notes,
-            sign_file_url=False,
-        )
-        document_id = UUID(str(document["id"]))
+        if document_id is None:
+            document = await self.document_service.create_document(
+                patient_id=patient_id,
+                uploaded_by=uploaded_by,
+                uploaded_by_role=uploaded_by_role,
+                file_name=self._file_name(document_payload.title),
+                file_path="",
+                file_size_bytes=len(json.dumps(serialized_extraction).encode("utf-8")),
+                mime_type="application/json",
+                document_type=document_payload.document_type.value,
+                source_clinic=document_payload.source_name or "Document extraction demo",
+                notes=document_payload.notes,
+                sign_file_url=False,
+            )
+            document_id = UUID(str(document["id"]))
+        else:
+            document = await self.document_service.get_document(document_id, patient_id)
 
         medication_ids = await self._create_medications(
             patient_id,

--- a/backend/src/app/services/document_extraction_import_service.py
+++ b/backend/src/app/services/document_extraction_import_service.py
@@ -234,6 +234,7 @@ class DocumentExtractionImportService:
                 "obligation_type": obligation.obligation_type.value,
                 "description": obligation.description,
                 "frequency": obligation.frequency,
+                "source_document_id": str(document_id),
             }
             created = await self.obligation_service.create_obligation(patient_id, payload)
             created_ids.append(str(created["id"]))

--- a/backend/src/app/services/document_service.py
+++ b/backend/src/app/services/document_service.py
@@ -144,6 +144,8 @@ class DocumentService:
     async def delete_document(self, document_id: UUID, patient_id: UUID) -> None:
         """Delete a patient-owned document metadata row and its storage object."""
         document = self._get_document_row(document_id, patient_id)
+        self._delete_document_derived_records(document_id, patient_id)
+
         file_path = str(document.get("file_path") or "").strip()
         if file_path:
             self._delete_storage_file(file_path)
@@ -153,6 +155,86 @@ class DocumentService:
             .delete()
             .eq("id", str(document_id))
             .eq("patient_id", str(patient_id))
+            .execute()
+        )
+
+    def _delete_document_derived_records(self, document_id: UUID, patient_id: UUID) -> None:
+        """Delete Today-feed records that were created from this document."""
+        medication_ids = self._get_document_derived_record_ids(
+            "medications",
+            document_id,
+            patient_id,
+        )
+        obligation_ids = self._get_document_derived_record_ids(
+            "obligations",
+            document_id,
+            patient_id,
+        )
+
+        self._delete_feed_target_records("medication", medication_ids, patient_id)
+        self._delete_feed_target_records("obligation", obligation_ids, patient_id)
+        self._delete_document_derived_rows("medications", medication_ids, patient_id)
+        self._delete_document_derived_rows("obligations", obligation_ids, patient_id)
+
+    def _get_document_derived_record_ids(
+        self,
+        table_name: str,
+        document_id: UUID,
+        patient_id: UUID,
+    ) -> list[str]:
+        """Find patient-owned rows that were extracted from a document."""
+        result = (
+            self.db.table(table_name)
+            .select("id")
+            .eq("patient_id", str(patient_id))
+            .eq("source_document_id", str(document_id))
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], result.data or [])
+        return [str(row["id"]) for row in rows if row.get("id")]
+
+    def _delete_feed_target_records(
+        self,
+        target_type: str,
+        target_ids: list[str],
+        patient_id: UUID,
+    ) -> None:
+        """Delete logs and reminder schedules for removed feed targets."""
+        if not target_ids:
+            return
+
+        (
+            self.db.table("adherence_logs")
+            .delete()
+            .eq("patient_id", str(patient_id))
+            .eq("target_type", target_type)
+            .in_("target_id", target_ids)
+            .execute()
+        )
+        (
+            self.db.table("reminder_schedules")
+            .delete()
+            .eq("patient_id", str(patient_id))
+            .eq("target_type", target_type)
+            .in_("target_id", target_ids)
+            .execute()
+        )
+
+    def _delete_document_derived_rows(
+        self,
+        table_name: str,
+        row_ids: list[str],
+        patient_id: UUID,
+    ) -> None:
+        """Delete document-derived medication or obligation rows."""
+        if not row_ids:
+            return
+
+        (
+            self.db.table(table_name)
+            .delete()
+            .eq("patient_id", str(patient_id))
+            .in_("id", row_ids)
             .execute()
         )
 

--- a/backend/src/app/services/ingestion_service.py
+++ b/backend/src/app/services/ingestion_service.py
@@ -112,6 +112,7 @@ class IngestionService:
         )
         obligation_ids = await self._save_obligations(
             patient_id,
+            document_id,
             extracted_data.get("follow_up_instructions", []),
         )
 
@@ -208,6 +209,7 @@ class IngestionService:
     async def _save_obligations(
         self,
         patient_id: UUID,
+        document_id: UUID,
         follow_up_instructions: list[dict[str, Any]],
     ) -> list[str]:
         """Save follow-up instructions as obligations via ObligationService."""
@@ -222,6 +224,7 @@ class IngestionService:
                 "frequency": instruction.get("timing")
                 or instruction.get("frequency")
                 or "as directed",
+                "source_document_id": str(document_id),
             }
             created = await self._obligation_service.create_obligation(patient_id, payload)
             created_ids.append(str(created["id"]))

--- a/backend/tests/integration/routers/test_document_api.py
+++ b/backend/tests/integration/routers/test_document_api.py
@@ -32,7 +32,7 @@ def mock_supabase_db():
     db.table.return_value = table
 
     # Make all query methods chainable
-    for method in ["select", "eq", "single", "insert", "order", "delete"]:
+    for method in ["select", "eq", "single", "insert", "order", "delete", "in_"]:
         getattr(table, method).return_value = table
 
     # Mock storage
@@ -312,6 +312,8 @@ class TestDeleteDocument:
         self, client, override_auth, override_db, mock_supabase_db, patient_id
     ):
         document_id = uuid4()
+        medication_id = uuid4()
+        obligation_id = uuid4()
         file_path = f"{patient_id}/lab-results.pdf"
         document_data = {
             "id": str(document_id),
@@ -335,15 +337,27 @@ class TestDeleteDocument:
         }
         mock_supabase_db.table().execute.side_effect = [
             MagicMock(data=document_data),
+            MagicMock(data=[{"id": str(medication_id)}]),
+            MagicMock(data=[{"id": str(obligation_id)}]),
+            MagicMock(data=[]),
+            MagicMock(data=[]),
+            MagicMock(data=[]),
+            MagicMock(data=[]),
+            MagicMock(data=[]),
+            MagicMock(data=[]),
             MagicMock(data=[document_data]),
         ]
 
         response = client.delete(f"/api/v1/documents/{document_id}")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_supabase_db.table.assert_any_call("adherence_logs")
+        mock_supabase_db.table.assert_any_call("reminder_schedules")
+        mock_supabase_db.table.assert_any_call("medications")
+        mock_supabase_db.table.assert_any_call("obligations")
         mock_supabase_db.storage.from_.assert_called_with("documents")
         mock_supabase_db.storage.from_().remove.assert_called_once_with([file_path])
-        mock_supabase_db.table().delete.assert_called_once()
+        assert mock_supabase_db.table().delete.call_count == 7
 
     def test_not_found(self, client, override_auth, override_db, mock_supabase_db):
         document_id = uuid4()

--- a/backend/tests/integration/routers/test_document_api.py
+++ b/backend/tests/integration/routers/test_document_api.py
@@ -125,6 +125,56 @@ class TestCreateDocument:
         assert data["parse_status"] == "pending"
         mock_ingest.assert_awaited_once()
 
+    def test_can_skip_background_ingestion_for_mock_import(
+        self, client, override_auth, override_db, mock_supabase_db, patient_id
+    ):
+        """Create document metadata without starting parser when mock import will attach."""
+        document_id = uuid4()
+        document_data = {
+            "id": str(document_id),
+            "patient_id": str(patient_id),
+            "uploaded_by": str(patient_id),
+            "uploaded_by_role": "patient",
+            "file_name": "discharge-summary.pdf",
+            "file_url": "https://storage.example.com/signed-url",
+            "file_path": f"{patient_id}/discharge-summary.pdf",
+            "file_size_bytes": 1024000,
+            "mime_type": "application/pdf",
+            "document_type": "discharge_summary",
+            "source_clinic": "Patient uploaded document",
+            "notes": None,
+            "parsed": False,
+            "ai_summary": None,
+            "parse_status": "pending",
+            "parse_error": None,
+            "parse_attempts": 0,
+            "visibility": "all_providers",
+            "created_at": "2025-01-15T00:00:00Z",
+        }
+
+        mock_supabase_db.table().insert().execute.return_value = MagicMock(data=[document_data])
+
+        with patch(
+            "app.routers.documents._run_ingestion_safe",
+            new=AsyncMock(),
+        ) as mock_ingest:
+            response = client.post(
+                "/api/v1/documents/",
+                json={
+                    "document_type": "discharge_summary",
+                    "file_name": "discharge-summary.pdf",
+                    "file_path": f"{patient_id}/discharge-summary.pdf",
+                    "file_size_bytes": 1024000,
+                    "mime_type": "application/pdf",
+                    "source_clinic": "Patient uploaded document",
+                    "start_ingestion": False,
+                },
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["file_name"] == "discharge-summary.pdf"
+        mock_ingest.assert_not_awaited()
+
     def test_invalid_mime_type(self, client, override_auth, override_db):
         """Reject unsupported file type."""
         response = client.post(

--- a/backend/tests/integration/test_ingestion_pipeline.py
+++ b/backend/tests/integration/test_ingestion_pipeline.py
@@ -78,7 +78,15 @@ async def test_full_ingestion_pipeline():
     assert result["medications_created"] == 1
     assert result["obligations_created"] == 1
     service._med_service.create_medication.assert_awaited()
-    service._obligation_service.create_obligation.assert_awaited()
+    service._obligation_service.create_obligation.assert_awaited_once_with(
+        PATIENT_ID,
+        {
+            "description": "Walk daily",
+            "frequency": "daily",
+            "obligation_type": "exercise",
+            "source_document_id": str(DOCUMENT_ID),
+        },
+    )
     assert db.table("documents").update.call_count >= 2
 
 

--- a/backend/tests/unit/services/test_document_extraction_import_service.py
+++ b/backend/tests/unit/services/test_document_extraction_import_service.py
@@ -102,6 +102,7 @@ async def test_import_demo_extraction_creates_document_derived_feed_records() ->
         db.store["obligations"][0]["description"]
         == "Review discharge instructions from Discharge Summary"
     )
+    assert db.store["obligations"][0]["source_document_id"] == result["document"]["id"]
     assert db.store["documents_updates"][0]["parse_status"] == "completed"
 
 
@@ -141,3 +142,4 @@ async def test_import_custom_extraction_uses_project_owned_schema() -> None:
     assert result["document"]["source_clinic"] == "City Health"
     assert result["summary"] == "Patient should hydrate and check blood pressure daily."
     assert db.store["obligations"][0]["frequency"] == "daily"
+    assert db.store["obligations"][0]["source_document_id"] == result["document"]["id"]

--- a/backend/tests/unit/services/test_document_extraction_import_service.py
+++ b/backend/tests/unit/services/test_document_extraction_import_service.py
@@ -20,8 +20,10 @@ class FakeTable:
     def __init__(self, name: str, store: dict[str, list[dict[str, Any]]]) -> None:
         self.name = name
         self.store = store
+        self.filters: list[tuple[str, str]] = []
         self.pending_insert: dict[str, Any] | None = None
         self.pending_update: dict[str, Any] | None = None
+        self.return_single = False
 
     def insert(self, payload: dict[str, Any]) -> FakeTable:
         self.pending_insert = payload
@@ -31,7 +33,15 @@ class FakeTable:
         self.pending_update = payload
         return self
 
-    def eq(self, *_args: Any) -> FakeTable:
+    def select(self, *_args: Any) -> FakeTable:
+        return self
+
+    def single(self) -> FakeTable:
+        self.return_single = True
+        return self
+
+    def eq(self, column: str, value: Any) -> FakeTable:
+        self.filters.append((column, str(value)))
         return self
 
     def execute(self) -> FakeResult:
@@ -52,7 +62,13 @@ class FakeTable:
             self.pending_update = None
             return FakeResult([payload])
 
-        return FakeResult(self.store.get(self.name, []))
+        rows = self.store.get(self.name, [])
+        for column, value in self.filters:
+            rows = [row for row in rows if str(row.get(column)) == value]
+
+        if self.return_single:
+            return FakeResult(rows[0] if rows else None)
+        return FakeResult(rows)
 
 
 class FakeStorageBucket:
@@ -143,3 +159,46 @@ async def test_import_custom_extraction_uses_project_owned_schema() -> None:
     assert result["summary"] == "Patient should hydrate and check blood pressure daily."
     assert db.store["obligations"][0]["frequency"] == "daily"
     assert db.store["obligations"][0]["source_document_id"] == result["document"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_import_extraction_can_attach_to_existing_uploaded_document() -> None:
+    db = FakeSupabase()
+    document_id = uuid4()
+    db.store["documents"] = [
+        {
+            "id": str(document_id),
+            "patient_id": str(PATIENT_ID),
+            "uploaded_by": str(PATIENT_ID),
+            "uploaded_by_role": "patient",
+            "file_name": "vatsal-discharge-summary.pdf",
+            "file_url": "https://storage.example.test/document.pdf",
+            "file_path": f"{PATIENT_ID}/vatsal-discharge-summary.pdf",
+            "file_size_bytes": 1200,
+            "mime_type": "application/pdf",
+            "document_type": "discharge_summary",
+            "source_clinic": "Patient uploaded document",
+            "parsed": False,
+            "ai_summary": None,
+            "parse_status": "pending",
+            "parse_error": None,
+            "parse_attempts": 0,
+            "visibility": "all_providers",
+            "created_at": "2026-05-01T00:00:00Z",
+        }
+    ]
+    service = DocumentExtractionImportService(db)  # type: ignore[arg-type]
+
+    result = await service.import_extraction(
+        patient_id=PATIENT_ID,
+        uploaded_by=PATIENT_ID,
+        uploaded_by_role="patient",
+        document_id=document_id,
+    )
+
+    assert result["document"]["id"] == str(document_id)
+    assert result["document"]["file_name"] == "vatsal-discharge-summary.pdf"
+    assert len(db.store["documents"]) == 1
+    assert db.store["documents_updates"][0]["parse_status"] == "completed"
+    assert all(row["source_document_id"] == str(document_id) for row in db.store["medications"])
+    assert all(row["source_document_id"] == str(document_id) for row in db.store["obligations"])


### PR DESCRIPTION
## Summary

- Fixed the Today Import button flow so it opens a file picker, uploads the selected document, registers it, and attaches the mocked extraction to that uploaded document id.
- Added `source_document_id` tracking for extracted obligations so document-derived Today tasks can be identified reliably.
- Updated document deletion to remove related document-derived medications and obligations, plus their adherence logs and reminder schedules, before deleting the document row/storage object.
- Added focused backend and patient portal tests for file-picker import, document-id extraction import, source tracking, and delete cleanup behavior.

## Why

Document delete should not leave Today-feed tasks behind when those tasks came from the deleted document. The safe rule is to delete only rows explicitly linked to the document by `source_document_id` for the same patient; manual medications, manual obligations, and unrelated clinician-entered care-plan items remain untouched.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Validation

- Patient portal: `eslint` on touched frontend files
- Patient portal: `tsc --noEmit`
- Patient portal: `vitest run --run src/__tests__/records-page.test.tsx src/__tests__/feed-slice.test.ts src/__tests__/today-page.test.tsx src/__tests__/visits-page.test.tsx src/__tests__/documents-service.test.ts`
- Backend: `ruff check` on touched backend files and tests
- Backend: `ruff format --check` on touched backend files and tests
- Backend: `mypy src/app/models/document_extraction.py src/app/models/obligation.py src/app/routers/documents.py src/app/services/document_extraction_import_service.py src/app/services/document_service.py src/app/services/ingestion_service.py`
- Backend: `pytest tests/unit/services/test_document_extraction_import_service.py tests/integration/routers/test_document_api.py tests/integration/test_ingestion_pipeline.py -q --no-cov`

## Manual Verification

- Confirmed the branch carries forward the import-button upload fix that did not make it into merged PR #59.
- Confirmed delete cleanup is scoped to `source_document_id` and `patient_id`, so unrelated tasks are preserved.
- Confirmed no `.env*`, key, token, or service-account files were staged or committed.
