### PR TITLE
[codex] Fix document import load failure

### DIFF
--- a/apps/patient-portal/src/__tests__/auth-session.test.ts
+++ b/apps/patient-portal/src/__tests__/auth-session.test.ts
@@ -19,14 +19,28 @@ const session: PatientAuthSession = {
     },
 };
 
+function makeUnsignedJwt(expiresAt: number) {
+    const encode = (value: unknown) =>
+        Buffer.from(JSON.stringify(value)).toString("base64url");
+
+    return `${encode({ alg: "none", typ: "JWT" })}.${encode({ exp: expiresAt })}.`;
+}
+
 describe("patient auth session", () => {
     it("detects expiring sessions", () => {
-        expect(isSessionExpiring(Math.floor(Date.now() / 1000) + 30)).toBe(true);
-        expect(isSessionExpiring(Math.floor(Date.now() / 1000) + 600)).toBe(false);
+        expect(isSessionExpiring(Math.floor(Date.now() / 1000) + 30)).toBe(
+            true,
+        );
+        expect(isSessionExpiring(Math.floor(Date.now() / 1000) + 600)).toBe(
+            false,
+        );
     });
 
     it("refreshes and persists an expiring session", async () => {
-        writeStoredSession({ ...session, expiresAt: Math.floor(Date.now() / 1000) + 10 });
+        writeStoredSession({
+            ...session,
+            expiresAt: Math.floor(Date.now() / 1000) + 10,
+        });
         const refreshSession = vi.fn().mockResolvedValue({
             ...session,
             accessToken: "new-access-token",
@@ -37,23 +51,55 @@ describe("patient auth session", () => {
 
         expect(refreshSession).toHaveBeenCalledWith("refresh-token");
         expect(restored?.accessToken).toBe("new-access-token");
-        expect(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY)).toContain("new-access-token");
+        expect(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY)).toContain(
+            "new-access-token",
+        );
+    });
+
+    it("refreshes when the access token exp claim is stale even if stored expiry is later", async () => {
+        writeStoredSession({
+            ...session,
+            accessToken: makeUnsignedJwt(Math.floor(Date.now() / 1000) + 10),
+            expiresAt: Math.floor(Date.now() / 1000) + 900,
+        });
+        const refreshSession = vi.fn().mockResolvedValue({
+            ...session,
+            accessToken: "new-access-token",
+            expiresAt: Math.floor(Date.now() / 1000) + 900,
+        });
+
+        const restored = await restoreStoredSession({ refreshSession });
+
+        expect(refreshSession).toHaveBeenCalledWith("refresh-token");
+        expect(restored?.accessToken).toBe("new-access-token");
     });
 
     it("clears storage when refresh fails", async () => {
-        writeStoredSession({ ...session, expiresAt: Math.floor(Date.now() / 1000) + 10 });
+        writeStoredSession({
+            ...session,
+            expiresAt: Math.floor(Date.now() / 1000) + 10,
+        });
 
         const restored = await restoreStoredSession({
-            refreshSession: vi.fn().mockRejectedValue(new Error("refresh failed")),
+            refreshSession: vi
+                .fn()
+                .mockRejectedValue(new Error("refresh failed")),
         });
 
         expect(restored).toBeNull();
-        expect(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY)).toBeNull();
+        expect(
+            window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY),
+        ).toBeNull();
     });
 
     it("clears invalid sessions", () => {
-        window.localStorage.setItem(PATIENT_AUTH_STORAGE_KEY, JSON.stringify({ token: "bad" }));
+        window.localStorage.setItem(
+            PATIENT_AUTH_STORAGE_KEY,
+            JSON.stringify({ token: "bad" }),
+        );
         clearStoredSession();
-        expect(window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY)).toBeNull();
+        expect(
+            window.localStorage.getItem(PATIENT_AUTH_STORAGE_KEY),
+        ).toBeNull();
     });
 });

--- a/apps/patient-portal/src/hooks/use-auth-session-refresh.ts
+++ b/apps/patient-portal/src/hooks/use-auth-session-refresh.ts
@@ -8,25 +8,34 @@ import { hydrateSession, logout } from "@/store/slices/auth-slice";
 import { writeStoredSession } from "@/services/auth-session";
 import { refreshPatientSession } from "@/services/auth-refresh";
 import { redirectToLogin } from "@/services/auth-redirect";
+import { getEffectiveSessionExpiresAt } from "../../../../packages/shared/src/utils/jwt-expiry";
 
 const REFRESH_EARLY_WINDOW_SECONDS = 30 * 60;
 const REFRESH_CHECK_INTERVAL_MS = 60 * 1000;
 
-function shouldRefreshSoon(expiresAt: number, nowSeconds = Math.floor(Date.now() / 1000)) {
+function shouldRefreshSoon(
+    expiresAt: number,
+    nowSeconds = Math.floor(Date.now() / 1000),
+) {
     return expiresAt - nowSeconds <= REFRESH_EARLY_WINDOW_SECONDS;
 }
 
 export function useAuthSessionRefresh() {
     const dispatch = useDispatch<AppDispatch>();
-    const { expiresAt, refreshToken, isAuthenticated, loading } = useSelector(
-        (state: RootState) => state.auth,
-    );
+    const { accessToken, expiresAt, refreshToken, isAuthenticated, loading } =
+        useSelector((state: RootState) => state.auth);
 
     const refreshState = useRef({ inFlight: false });
 
     const refreshContext = useMemo(
-        () => ({ expiresAt, refreshToken, isAuthenticated, loading }),
-        [expiresAt, refreshToken, isAuthenticated, loading],
+        () => ({
+            accessToken,
+            expiresAt,
+            refreshToken,
+            isAuthenticated,
+            loading,
+        }),
+        [accessToken, expiresAt, refreshToken, isAuthenticated, loading],
     );
 
     useEffect(() => {
@@ -52,7 +61,12 @@ export function useAuthSessionRefresh() {
                 return;
             }
 
-            if (!shouldRefreshSoon(currentExpiresAt)) {
+            const effectiveExpiresAt = getEffectiveSessionExpiresAt(
+                currentExpiresAt,
+                refreshContext.accessToken,
+            );
+
+            if (effectiveExpiresAt && !shouldRefreshSoon(effectiveExpiresAt)) {
                 return;
             }
 
@@ -63,7 +77,8 @@ export function useAuthSessionRefresh() {
             refreshState.current.inFlight = true;
 
             try {
-                const session = await refreshPatientSession(currentRefreshToken);
+                const session =
+                    await refreshPatientSession(currentRefreshToken);
                 writeStoredSession(session);
                 dispatch(hydrateSession(session));
             } catch {

--- a/apps/patient-portal/src/hooks/use-feed-data.ts
+++ b/apps/patient-portal/src/hooks/use-feed-data.ts
@@ -3,15 +3,32 @@
 import { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { api } from "@/services/api";
-import { inferDocumentType, type DocumentApiRecord } from "@/services/documents";
+import { redirectToLogin } from "@/services/auth-redirect";
+import { refreshPatientSession } from "@/services/auth-refresh";
+import { writeStoredSession } from "@/services/auth-session";
+import {
+    inferDocumentType,
+    type DocumentApiRecord,
+} from "@/services/documents";
 import { uploadDocumentToStorage } from "@/services/storage";
+import {
+    hydrateSession,
+    logout,
+    type PatientAuthUser,
+} from "@/store/slices/auth-slice";
 import {
     fetchTodayFeed,
     markTaskComplete,
     setMissedTasks,
 } from "@/store/slices/feed-slice";
 import type { AppDispatch, RootState } from "@/store/store";
-import { FeedTaskStatus, FeedTaskType, type AdherenceStats, type FeedTask } from "@/types";
+import {
+    FeedTaskStatus,
+    FeedTaskType,
+    type AdherenceStats,
+    type FeedTask,
+} from "@/types";
+import { getEffectiveSessionExpiresAt } from "../../../../packages/shared/src/utils/jwt-expiry";
 
 interface ApiAdherenceStats {
     current_streak_days?: number;
@@ -43,9 +60,17 @@ const emptyAdherenceStats: AdherenceStats = {
     totalExpected: 0,
 };
 
+const DOCUMENT_IMPORT_REFRESH_WINDOW_SECONDS = 2 * 60;
+
+interface ActivePatientSession {
+    accessToken: string;
+    user: PatientAuthUser;
+}
+
 function mapAdherenceStats(stats: ApiAdherenceStats): AdherenceStats {
     return {
-        currentStreakDays: stats.currentStreakDays ?? stats.current_streak_days ?? 0,
+        currentStreakDays:
+            stats.currentStreakDays ?? stats.current_streak_days ?? 0,
         medicationScore: stats.medicationScore ?? stats.medication_score ?? 0,
         obligationScore: stats.obligationScore ?? stats.obligation_score ?? 0,
         overallScore: stats.overallScore ?? stats.overall_score ?? 0,
@@ -61,10 +86,20 @@ function getMissedTaskIds(tasks: FeedTask[]) {
     const currentMinutes = now.getHours() * 60 + now.getMinutes();
 
     return tasks
-        .filter((task) => task.status === FeedTaskStatus.PENDING && task.scheduledTime)
+        .filter(
+            (task) =>
+                task.status === FeedTaskStatus.PENDING && task.scheduledTime,
+        )
         .filter((task) => {
-            const [hours, minutes] = task.scheduledTime?.split(":").map((value) => Number.parseInt(value, 10)) ?? [];
-            return Number.isFinite(hours) && Number.isFinite(minutes) && hours * 60 + minutes < currentMinutes;
+            const [hours, minutes] =
+                task.scheduledTime
+                    ?.split(":")
+                    .map((value) => Number.parseInt(value, 10)) ?? [];
+            return (
+                Number.isFinite(hours) &&
+                Number.isFinite(minutes) &&
+                hours * 60 + minutes < currentMinutes
+            );
         })
         .map((task) => task.id);
 }
@@ -72,9 +107,14 @@ function getMissedTaskIds(tasks: FeedTask[]) {
 export function useFeedData() {
     const dispatch = useDispatch<AppDispatch>();
     const feed = useSelector((state: RootState) => state.feed);
-    const { accessToken, user } = useSelector((state: RootState) => state.auth);
-    const [adherenceStats, setAdherenceStats] = useState<AdherenceStats>(emptyAdherenceStats);
-    const [documentImportError, setDocumentImportError] = useState<string | null>(null);
+    const { accessToken, expiresAt, refreshToken, user } = useSelector(
+        (state: RootState) => state.auth,
+    );
+    const [adherenceStats, setAdherenceStats] =
+        useState<AdherenceStats>(emptyAdherenceStats);
+    const [documentImportError, setDocumentImportError] = useState<
+        string | null
+    >(null);
     const [documentImporting, setDocumentImporting] = useState(false);
 
     const refreshFeed = useCallback(() => {
@@ -95,7 +135,9 @@ export function useFeedData() {
             return;
         }
 
-        api.get<ApiAdherenceStats>("/api/v1/adherence/stats", { token: accessToken ?? undefined })
+        api.get<ApiAdherenceStats>("/api/v1/adherence/stats", {
+            token: accessToken ?? undefined,
+        })
             .then((response) => setAdherenceStats(mapAdherenceStats(response)))
             .catch(() => setAdherenceStats(emptyAdherenceStats));
     }, [accessToken]);
@@ -120,7 +162,10 @@ export function useFeedData() {
                 "/api/v1/adherence",
                 {
                     scheduled_time: task.scheduledAt,
-                    status: task.type === FeedTaskType.MEDICATION ? "taken" : "completed",
+                    status:
+                        task.type === FeedTaskType.MEDICATION
+                            ? "taken"
+                            : "completed",
                     target_id: task.targetId,
                     target_type: task.type,
                 },
@@ -131,19 +176,67 @@ export function useFeedData() {
         }
     }
 
-    async function importDocumentFile(file: File) {
+    async function getDocumentImportSession(): Promise<ActivePatientSession | null> {
         if (!accessToken || !user) {
-            setDocumentImportError("Please sign in again before importing a clinical document.");
-            return;
+            setDocumentImportError(
+                "Please sign in again before importing a clinical document.",
+            );
+            return null;
         }
 
+        const effectiveExpiresAt = getEffectiveSessionExpiresAt(
+            expiresAt,
+            accessToken,
+        );
+        const shouldRefresh =
+            !effectiveExpiresAt ||
+            effectiveExpiresAt - Math.floor(Date.now() / 1000) <=
+                DOCUMENT_IMPORT_REFRESH_WINDOW_SECONDS;
+
+        if (!shouldRefresh) {
+            return {
+                accessToken,
+                user,
+            };
+        }
+
+        if (!refreshToken) {
+            dispatch(logout());
+            redirectToLogin({ reason: "session_expired" });
+            setDocumentImportError(
+                "Your session expired. Please sign in again before importing a clinical document.",
+            );
+            return null;
+        }
+
+        try {
+            const session = await refreshPatientSession(refreshToken);
+            writeStoredSession(session);
+            dispatch(hydrateSession(session));
+            return session;
+        } catch {
+            dispatch(logout());
+            redirectToLogin({ reason: "session_expired" });
+            setDocumentImportError(
+                "Your session expired. Please sign in again before importing a clinical document.",
+            );
+            return null;
+        }
+    }
+
+    async function importDocumentFile(file: File) {
         setDocumentImporting(true);
         setDocumentImportError(null);
         try {
+            const session = await getDocumentImportSession();
+            if (!session) {
+                return;
+            }
+
             const filePath = await uploadDocumentToStorage({
                 file,
-                patientId: user.id,
-                token: accessToken,
+                patientId: session.user.id,
+                token: session.accessToken,
             });
             const document = await api.post<DocumentApiRecord>(
                 "/api/v1/documents/",
@@ -156,14 +249,22 @@ export function useFeedData() {
                     source_clinic: "Patient uploaded document",
                     start_ingestion: false,
                 },
-                { token: accessToken },
+                { token: session.accessToken },
             );
-            await api.post("/api/v1/documents/extractions/import", { document_id: document.id }, {
-                token: accessToken,
-            });
-            await dispatch(fetchTodayFeed({ token: accessToken })).unwrap();
+            await api.post(
+                "/api/v1/documents/extractions/import",
+                { document_id: document.id },
+                {
+                    token: session.accessToken,
+                },
+            );
+            await dispatch(
+                fetchTodayFeed({ token: session.accessToken }),
+            ).unwrap();
         } catch (error) {
-            setDocumentImportError((error as Error).message || "Document import failed.");
+            setDocumentImportError(
+                (error as Error).message || "Document import failed.",
+            );
         } finally {
             setDocumentImporting(false);
         }

--- a/apps/patient-portal/src/hooks/use-feed-data.ts
+++ b/apps/patient-portal/src/hooks/use-feed-data.ts
@@ -136,7 +136,7 @@ export function useFeedData() {
         }
 
         api.get<ApiAdherenceStats>("/api/v1/adherence/stats", {
-            token: accessToken ?? undefined,
+            token: accessToken,
         })
             .then((response) => setAdherenceStats(mapAdherenceStats(response)))
             .catch(() => setAdherenceStats(emptyAdherenceStats));

--- a/backend/src/app/services/document_extraction_import_service.py
+++ b/backend/src/app/services/document_extraction_import_service.py
@@ -7,10 +7,12 @@ condition, allergy, and obligation tables that power the Today feed.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import Any, cast
 from uuid import UUID
 
+from postgrest.exceptions import APIError
 from supabase import Client
 
 from app.models.document_extraction import DocumentExtractionResult
@@ -18,6 +20,17 @@ from app.models.enums import DocumentType, MedicationRoute, ObligationType
 from app.services.document_service import DocumentService
 from app.services.medication_service import MedicationService
 from app.services.obligation_service import ObligationService
+
+logger = logging.getLogger(__name__)
+
+
+def _is_missing_source_document_column_error(error: APIError, table_name: str) -> bool:
+    message = str(getattr(error, "message", error))
+    code = str(getattr(error, "code", ""))
+    return (
+        code in {"PGRST204", "42703"} and "source_document_id" in message and table_name in message
+    )
+
 
 DEMO_DOCUMENT_EXTRACTION = DocumentExtractionResult.model_validate(
     {
@@ -245,7 +258,16 @@ class DocumentExtractionImportService:
                 "frequency": obligation.frequency,
                 "source_document_id": str(document_id),
             }
-            created = await self.obligation_service.create_obligation(patient_id, payload)
+            try:
+                created = await self.obligation_service.create_obligation(patient_id, payload)
+            except APIError as exc:
+                if _is_missing_source_document_column_error(exc, "obligations"):
+                    logger.warning(
+                        "Skipping document-derived obligations because obligations.source_document_id "
+                        "is missing from the database schema"
+                    )
+                    return created_ids
+                raise
             created_ids.append(str(created["id"]))
 
         return created_ids

--- a/backend/src/app/services/document_service.py
+++ b/backend/src/app/services/document_service.py
@@ -11,12 +11,22 @@ import logging
 from typing import Any, cast
 from uuid import UUID
 
+from postgrest.exceptions import APIError
 from supabase import Client
 
 from app.core.exceptions import NotFoundError, ValidationError
 from app.models.enums import DocumentReviewStatus, UploaderRole
 
 logger = logging.getLogger(__name__)
+
+
+def _is_missing_source_document_column_error(error: APIError, table_name: str) -> bool:
+    message = str(getattr(error, "message", error))
+    code = str(getattr(error, "code", ""))
+    return (
+        code in {"PGRST204", "42703"} and "source_document_id" in message and table_name in message
+    )
+
 
 # File validation constants
 ALLOWED_MIME_TYPES = frozenset(
@@ -183,13 +193,24 @@ class DocumentService:
         patient_id: UUID,
     ) -> list[str]:
         """Find patient-owned rows that were extracted from a document."""
-        result = (
-            self.db.table(table_name)
-            .select("id")
-            .eq("patient_id", str(patient_id))
-            .eq("source_document_id", str(document_id))
-            .execute()
-        )
+        try:
+            result = (
+                self.db.table(table_name)
+                .select("id")
+                .eq("patient_id", str(patient_id))
+                .eq("source_document_id", str(document_id))
+                .execute()
+            )
+        except APIError as exc:
+            if _is_missing_source_document_column_error(exc, table_name):
+                logger.warning(
+                    "Skipping document-derived %s lookup because %s.source_document_id "
+                    "is missing from the database schema",
+                    table_name,
+                    table_name,
+                )
+                return []
+            raise
         rows = cast(list[dict[str, Any]], result.data or [])
         return [str(row["id"]) for row in rows if row.get("id")]
 

--- a/backend/tests/integration/routers/test_document_api.py
+++ b/backend/tests/integration/routers/test_document_api.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import status
+from postgrest.exceptions import APIError
 
 from app.core.security import get_current_user
 from app.db.connection import get_db
@@ -408,6 +409,56 @@ class TestDeleteDocument:
         mock_supabase_db.storage.from_.assert_called_with("documents")
         mock_supabase_db.storage.from_().remove.assert_called_once_with([file_path])
         assert mock_supabase_db.table().delete.call_count == 7
+
+    def test_delete_skips_obligation_lookup_when_source_document_column_is_missing(
+        self, client, override_auth, override_db, mock_supabase_db, patient_id
+    ):
+        document_id = uuid4()
+        medication_id = uuid4()
+        file_path = f"{patient_id}/lab-results.pdf"
+        document_data = {
+            "id": str(document_id),
+            "patient_id": str(patient_id),
+            "uploaded_by": str(patient_id),
+            "uploaded_by_role": "patient",
+            "file_name": "lab-results.pdf",
+            "file_path": file_path,
+            "file_url": "https://storage.example.com/signed-url",
+            "file_size_bytes": 1024000,
+            "mime_type": "application/pdf",
+            "document_type": "lab_report",
+            "source_clinic": None,
+            "parsed": True,
+            "ai_summary": "Summary",
+            "parse_status": "completed",
+            "parse_error": None,
+            "parse_attempts": 1,
+            "visibility": "all_providers",
+            "created_at": "2025-01-15T00:00:00Z",
+        }
+        missing_column_error = APIError(
+            {
+                "message": "column obligations.source_document_id does not exist",
+                "code": "42703",
+                "hint": None,
+                "details": None,
+            }
+        )
+        mock_supabase_db.table().execute.side_effect = [
+            MagicMock(data=document_data),
+            MagicMock(data=[{"id": str(medication_id)}]),
+            missing_column_error,
+            MagicMock(data=[]),
+            MagicMock(data=[]),
+            MagicMock(data=[]),
+            MagicMock(data=[document_data]),
+        ]
+
+        response = client.delete(f"/api/v1/documents/{document_id}")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_supabase_db.storage.from_().remove.assert_called_once_with([file_path])
+        assert mock_supabase_db.table().delete.call_count == 4
 
     def test_not_found(self, client, override_auth, override_db, mock_supabase_db):
         document_id = uuid4()

--- a/backend/tests/unit/services/test_document_extraction_import_service.py
+++ b/backend/tests/unit/services/test_document_extraction_import_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
 import pytest
+from postgrest.exceptions import APIError
 
 from app.models.document_extraction import DocumentExtractionResult
 from app.services.document_extraction_import_service import DocumentExtractionImportService
@@ -202,3 +204,32 @@ async def test_import_extraction_can_attach_to_existing_uploaded_document() -> N
     assert db.store["documents_updates"][0]["parse_status"] == "completed"
     assert all(row["source_document_id"] == str(document_id) for row in db.store["medications"])
     assert all(row["source_document_id"] == str(document_id) for row in db.store["obligations"])
+
+
+@pytest.mark.asyncio
+async def test_import_extraction_skips_obligations_when_source_document_column_is_missing() -> None:
+    db = FakeSupabase()
+    service = DocumentExtractionImportService(db)  # type: ignore[arg-type]
+    service.obligation_service.create_obligation = AsyncMock(  # type: ignore[method-assign]
+        side_effect=APIError(
+            {
+                "message": (
+                    "Could not find the 'source_document_id' column of 'obligations' "
+                    "in the schema cache"
+                ),
+                "code": "PGRST204",
+                "hint": None,
+                "details": None,
+            }
+        )
+    )
+
+    result = await service.import_extraction(
+        patient_id=PATIENT_ID,
+        uploaded_by=PATIENT_ID,
+        uploaded_by_role="patient",
+    )
+
+    assert result["medications_created"] == 2
+    assert result["obligations_created"] == 0
+    assert db.store["documents_updates"][0]["parse_status"] == "completed"

--- a/packages/shared/src/utils/auth-session.ts
+++ b/packages/shared/src/utils/auth-session.ts
@@ -1,3 +1,5 @@
+import { getEffectiveSessionExpiresAt } from "./jwt-expiry";
+
 export interface SharedAuthUser<Role extends string> {
     email: string;
     id: string;
@@ -14,7 +16,10 @@ export interface SharedAuthSession<
     user: User;
 }
 
-interface LegacyStoredSession<Role extends string, User extends SharedAuthUser<Role>> {
+interface LegacyStoredSession<
+    Role extends string,
+    User extends SharedAuthUser<Role>,
+> {
     token?: string | null;
     refreshToken?: string | null;
     expiresAt?: number | null;
@@ -37,22 +42,36 @@ export function createAuthSessionStorage<
     Role extends string,
     User extends SharedAuthUser<Role>,
     Session extends SharedAuthSession<Role, User>,
->({ refreshWindowSeconds = DEFAULT_REFRESH_WINDOW_SECONDS, role, storageKey }: CreateAuthSessionStorageConfig<Role>) {
+>({
+    refreshWindowSeconds = DEFAULT_REFRESH_WINDOW_SECONDS,
+    role,
+    storageKey,
+}: CreateAuthSessionStorageConfig<Role>) {
     function normalizeStoredSession(value: string | null): Session | null {
         if (!value) {
             return null;
         }
 
         try {
-            const parsed = JSON.parse(value) as Session | LegacyStoredSession<Role, User>;
+            const parsed = JSON.parse(value) as
+                | Session
+                | LegacyStoredSession<Role, User>;
             const user = parsed.user;
 
             if (!user || user.role !== role) {
                 return null;
             }
 
-            if ("accessToken" in parsed && "refreshToken" in parsed && "expiresAt" in parsed) {
-                if (!parsed.accessToken || !parsed.refreshToken || !parsed.expiresAt) {
+            if (
+                "accessToken" in parsed &&
+                "refreshToken" in parsed &&
+                "expiresAt" in parsed
+            ) {
+                if (
+                    !parsed.accessToken ||
+                    !parsed.refreshToken ||
+                    !parsed.expiresAt
+                ) {
                     return null;
                 }
 
@@ -79,7 +98,10 @@ export function createAuthSessionStorage<
         }
     }
 
-    function isSessionExpiring(expiresAt: number, nowSeconds = Math.floor(Date.now() / 1000)) {
+    function isSessionExpiring(
+        expiresAt: number,
+        nowSeconds = Math.floor(Date.now() / 1000),
+    ) {
         return expiresAt - nowSeconds <= refreshWindowSeconds;
     }
 
@@ -105,12 +127,19 @@ export function createAuthSessionStorage<
             return null;
         }
 
-        if (!isSessionExpiring(storedSession.expiresAt)) {
+        const effectiveExpiresAt = getEffectiveSessionExpiresAt(
+            storedSession.expiresAt,
+            storedSession.accessToken,
+        );
+
+        if (effectiveExpiresAt && !isSessionExpiring(effectiveExpiresAt)) {
             return storedSession;
         }
 
         try {
-            const refreshedSession = await refreshSession(storedSession.refreshToken);
+            const refreshedSession = await refreshSession(
+                storedSession.refreshToken,
+            );
 
             if (refreshedSession.user.role !== role) {
                 clearStoredSession();

--- a/packages/shared/src/utils/jwt-expiry.ts
+++ b/packages/shared/src/utils/jwt-expiry.ts
@@ -1,0 +1,67 @@
+interface JwtPayloadWithExpiry {
+    exp?: unknown;
+}
+
+function decodeBase64Url(value: string): string | null {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+        normalized.length + ((4 - (normalized.length % 4)) % 4),
+        "=",
+    );
+
+    try {
+        if (typeof globalThis.atob === "function") {
+            return globalThis.atob(padded);
+        }
+
+        if (typeof Buffer !== "undefined") {
+            return Buffer.from(padded, "base64").toString("utf8");
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+export function getJwtExpiresAt(
+    token: string | null | undefined,
+): number | null {
+    if (!token) {
+        return null;
+    }
+
+    const [, payload] = token.split(".");
+    if (!payload) {
+        return null;
+    }
+
+    const decoded = decodeBase64Url(payload);
+    if (!decoded) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(decoded) as JwtPayloadWithExpiry;
+        return typeof parsed.exp === "number" ? parsed.exp : null;
+    } catch {
+        return null;
+    }
+}
+
+export function getEffectiveSessionExpiresAt(
+    expiresAt: number | null | undefined,
+    accessToken: string | null | undefined,
+): number | null {
+    const tokenExpiresAt = getJwtExpiresAt(accessToken);
+
+    if (typeof expiresAt !== "number") {
+        return tokenExpiresAt;
+    }
+
+    if (typeof tokenExpiresAt !== "number") {
+        return expiresAt;
+    }
+
+    return Math.min(expiresAt, tokenExpiresAt);
+}


### PR DESCRIPTION
## Summary
- refresh patient sessions using the JWT `exp` claim before document imports so storage uploads do not reuse expired tokens
- keep shared stored-session restore logic from trusting stale `expiresAt` values when the access token itself is expiring
- tolerate remote databases that have not applied `obligations.source_document_id` yet by skipping undeletable document-derived obligations and allowing document delete to complete

## Validation
- `npx eslint src/hooks/use-feed-data.ts src/hooks/use-auth-session-refresh.ts src/__tests__/auth-session.test.ts`
- `npm run test -- src/__tests__/auth-session.test.ts src/__tests__/auth-session-refresh.test.tsx`
- `npx tsc --noEmit`
- `.venv/bin/ruff format src/app/services/document_extraction_import_service.py src/app/services/document_service.py tests/unit/services/test_document_extraction_import_service.py tests/integration/routers/test_document_api.py`
- `.venv/bin/ruff check src/app/services/document_extraction_import_service.py src/app/services/document_service.py tests/unit/services/test_document_extraction_import_service.py tests/integration/routers/test_document_api.py`
- `.venv/bin/mypy src/app/services/document_extraction_import_service.py src/app/services/document_service.py`
- `.venv/bin/pytest tests/unit/services/test_document_extraction_import_service.py tests/integration/routers/test_document_api.py -q --no-cov`

## Manual Verification
- Started backend at `http://127.0.0.1:8000` with `--reload-dir src` and patient portal at `http://127.0.0.1:3000`.
- Ran an API smoke test with a fresh patient JWT: storage upload returned 200, document create returned 201, mock import returned 201 with 2 medication tasks and 0 skipped-schema obligations, delete returned 204, Today feed returned to 0 tasks.
- Cleaned remote test rows after the smoke test; final counts for documents, medications, obligations, conditions, allergies, adherence logs, and reminder schedules were 0.

## Checklist
- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.
