### PR TITLE
fix(patient-portal): remove bottom gap in records document modal

### DIFF
--- a/apps/patient-portal/src/components/ui/modal.tsx
+++ b/apps/patient-portal/src/components/ui/modal.tsx
@@ -17,7 +17,7 @@ export function Modal({ children, onClose, open, title }: ModalProps) {
     return (
         <div className="fixed inset-0 z-50 flex flex-col justify-end bg-[#17233a]/45 backdrop-blur-sm" onClick={onClose}>
             <div
-                className="mx-auto max-h-[88vh] w-full max-w-[480px] overflow-y-auto rounded-t-[34px] border border-white/70 bg-[#fffaf4] p-6 shadow-[0_-24px_80px_rgba(23,35,58,0.20)] safe-bottom"
+                className="mx-auto max-h-[88vh] w-full max-w-[480px] overflow-y-auto rounded-t-[34px] border border-white/70 bg-[#fffaf4] p-6 pb-10 shadow-[0_-24px_80px_rgba(23,35,58,0.20)]"
                 onClick={(event) => event.stopPropagation()}
             >
                 <div className="mb-4 flex items-center justify-between">


### PR DESCRIPTION
## Description
- **Context:** When opening a document in My Records, the bottom sheet modal showed a large empty gap between the last action button (Delete document) and the bottom of the screen. This happened because the modal sheet only grows to fit its content — when content is shorter than `max-h-[88vh]`, the dimmed overlay extends below the sheet bottom edge, creating a visible void.
- **What changed:** Replaced the invalid `safe-bottom` class (not a real Tailwind utility — had no effect) with `pb-10` on the modal sheet div. This adds 40px of bottom padding so the sheet visually extends flush to the screen edge on all device sizes.
- **Risk/impact:** Minimal. One-line CSS change on a shared UI primitive. Affects all modals in the patient portal; all existing modals benefit from the fix.

## Related Tasks / Issues
- Resolves: UI polish — Records document modal bottom gap (observed 2026-05-08)

## Docs Impact
- [x] No docs update required.

## Required Verification Checklist
- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable. *(Single CSS class change — no logic change; existing modal render tests remain valid.)*
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Manual Verification
1. Open the Patient Portal and navigate to **My Records**.
2. Tap any document card to open the detail modal.
3. Confirm the modal sheet extends flush to the bottom of the screen with no empty gap below the **Delete document** button.
4. Verify on both short-content documents (no PDF viewer) and long-content documents (with PDF viewer + explanation text) that scroll still works correctly.

## UI Evidence (if applicable)
- **Before:** Large empty beige/gray gap visible below 'Delete document' button — bottom nav partially showing through the overlay.
- **After:** Modal sheet padding fills down to the screen edge; clean bottom presentation on all devices.