### PR TITLE
fix(patient-portal): reconcile profile and document flows

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -107,9 +107,9 @@ A task is done only when its implementation, authorization, error handling, audi
 - [x] Verify upload completes before extraction/import begins.
 - [x] Verify expired import sessions fail safely and visibly.
 - [x] Reimplement only behavior that is still missing on current `main`.
-- [ ] Delete `origin/codex/patient-portal-audit-followup` after verification.
-- [ ] Delete `origin/fix/patient-portal-audit` after verification.
-- [ ] Drop the stale April stash after verification.
+- [x] Delete `origin/codex/patient-portal-audit-followup` after verification.
+- [x] Delete `origin/fix/patient-portal-audit` after verification.
+- [x] Drop the stale April stash after verification.
 
 Verification evidence: the patient portal suite passed 79 tests, and the patient, document,
 feed, and extraction-import backend suites passed 59 tests on 2026-08-20. Current `main`
@@ -117,6 +117,7 @@ already covered greeting/avatar, visits, document-type inference, and backend pa
 The reconciliation restored the missing patient-profile edit flow and added regression coverage
 for non-finite adherence, missing obligation frequency, upload/import ordering, and expired
 upload-session recovery.
+The two obsolete audit branches and the April 29 stash were deleted on 2026-08-20.
 
 ### REV-003 — Make documentation truthful
 

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -98,18 +98,25 @@ A task is done only when its implementation, authorization, error handling, audi
 
 ### REV-002 — Reconcile preserved historical work
 
-- [ ] Add regression tests for real patient greeting and avatar identity.
-- [ ] Add regression test ensuring adherence percentages never render `NaN`.
-- [ ] Add regression test for missing obligation frequency.
-- [ ] Verify patient profile editing persists through the API.
-- [ ] Verify visits contain no hardcoded fake appointment.
-- [ ] Verify document types are inferred from content/metadata rather than mapping every PDF to a lab report.
-- [ ] Verify upload completes before extraction/import begins.
-- [ ] Verify expired import sessions fail safely and visibly.
-- [ ] Reimplement only behavior that is still missing on current `main`.
+- [x] Add regression tests for real patient greeting and avatar identity.
+- [x] Add regression test ensuring adherence percentages never render `NaN`.
+- [x] Add regression test for missing obligation frequency.
+- [x] Verify patient profile editing persists through the API.
+- [x] Verify visits contain no hardcoded fake appointment.
+- [x] Verify document types are inferred from content/metadata rather than mapping every PDF to a lab report.
+- [x] Verify upload completes before extraction/import begins.
+- [x] Verify expired import sessions fail safely and visibly.
+- [x] Reimplement only behavior that is still missing on current `main`.
 - [ ] Delete `origin/codex/patient-portal-audit-followup` after verification.
 - [ ] Delete `origin/fix/patient-portal-audit` after verification.
 - [ ] Drop the stale April stash after verification.
+
+Verification evidence: the patient portal suite passed 79 tests, and the patient, document,
+feed, and extraction-import backend suites passed 59 tests on 2026-08-20. Current `main`
+already covered greeting/avatar, visits, document-type inference, and backend patient updates.
+The reconciliation restored the missing patient-profile edit flow and added regression coverage
+for non-finite adherence, missing obligation frequency, upload/import ordering, and expired
+upload-session recovery.
 
 ### REV-003 — Make documentation truthful
 

--- a/apps/patient-portal/src/__tests__/profile-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/profile-page.test.tsx
@@ -55,7 +55,7 @@ describe("Patient profile page", () => {
                     first_name: "Sarah",
                     id: "patient-1",
                     last_name: "Johnson",
-                    preferred_language: "en",
+                    preferred_language: "en-US",
                 };
             }
 
@@ -92,7 +92,7 @@ describe("Patient profile page", () => {
                     first_name: "Sarah",
                     id: "patient-1",
                     last_name: "Johnson",
-                    preferred_language: "en",
+                    preferred_language: "en-US",
                 };
             }
 
@@ -148,7 +148,7 @@ describe("Patient profile page", () => {
                     first_name: "Sarah",
                     id: "patient-1",
                     last_name: "Johnson",
-                    preferred_language: "en",
+                    preferred_language: "en-US",
                 };
             }
 
@@ -203,7 +203,7 @@ describe("Patient profile page", () => {
                     first_name: "Sarah",
                     id: "patient-1",
                     last_name: "Johnson",
-                    preferred_language: "en",
+                    preferred_language: "en-US",
                 };
             }
 
@@ -235,7 +235,7 @@ describe("Patient profile page", () => {
                     first_name: "Sarah",
                     id: "patient-1",
                     last_name: "Johnson",
-                    preferred_language: "en",
+                    preferred_language: "en-US",
                 };
             }
 

--- a/apps/patient-portal/src/__tests__/profile-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/profile-page.test.tsx
@@ -2,11 +2,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ProfilePage from "@/app/(app)/profile/page";
 
-const { clearStoredSession, dispatch, get, post, replace, searchParamGet } = vi.hoisted(() => ({
+const { clearStoredSession, dispatch, get, post, put, replace, searchParamGet } = vi.hoisted(() => ({
     clearStoredSession: vi.fn(),
     dispatch: vi.fn(),
     get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
     replace: vi.fn(),
     searchParamGet: vi.fn(),
 }));
@@ -25,7 +26,7 @@ vi.mock("react-redux", () => ({
 }));
 
 vi.mock("@/services/api", () => ({
-    api: { get, post },
+    api: { get, post, put },
 }));
 
 vi.mock("@/services/auth-session", () => ({
@@ -38,6 +39,7 @@ describe("Patient profile page", () => {
         dispatch.mockReset();
         get.mockReset();
         post.mockReset();
+        put.mockReset();
         replace.mockReset();
         searchParamGet.mockReset();
         searchParamGet.mockReturnValue(null);
@@ -78,6 +80,61 @@ describe("Patient profile page", () => {
         expect(screen.getByText("sarah@example.com")).toBeInTheDocument();
         expect(screen.getByText("Dr. Emily Smith")).toBeInTheDocument();
         expect(screen.getByText("City Health")).toBeInTheDocument();
+    });
+
+    it("persists profile edits through the patient API", async () => {
+        get.mockImplementation(async (endpoint: string) => {
+            if (endpoint === "/api/v1/patients/me") {
+                return {
+                    created_at: "2026-01-10T00:00:00Z",
+                    date_of_birth: "1985-03-15",
+                    email: "sarah@example.com",
+                    first_name: "Sarah",
+                    id: "patient-1",
+                    last_name: "Johnson",
+                    preferred_language: "en",
+                };
+            }
+
+            return [];
+        });
+        put.mockResolvedValue({
+            created_at: "2026-01-10T00:00:00Z",
+            date_of_birth: "1985-03-15",
+            email: "sarah@example.com",
+            first_name: "Sara",
+            gender: "female",
+            id: "patient-1",
+            last_name: "Johnson",
+            preferred_language: "es-MX",
+        });
+
+        render(<ProfilePage />);
+
+        fireEvent.click(await screen.findByRole("button", { name: /edit profile/i }));
+        fireEvent.change(screen.getByLabelText(/^first name$/i), {
+            target: { value: "Sara" },
+        });
+        fireEvent.change(screen.getByLabelText(/^preferred language$/i), {
+            target: { value: "es-MX" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+        await waitFor(() => {
+            expect(put).toHaveBeenCalledWith(
+                "/api/v1/patients/me",
+                {
+                    first_name: "Sara",
+                    last_name: "Johnson",
+                    preferred_language: "es-MX",
+                },
+                { token: "access-token" },
+            );
+        });
+
+        expect(await screen.findByText(/profile updated successfully/i)).toBeInTheDocument();
+        expect(screen.getByText("Sara Johnson")).toBeInTheDocument();
+        expect(screen.getByText("Female")).toBeInTheDocument();
     });
 
     it("lets the patient join another clinic after onboarding", async () => {

--- a/apps/patient-portal/src/__tests__/records-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/records-page.test.tsx
@@ -3,15 +3,38 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import RecordsPage from "@/app/(app)/records/page";
 import { DocumentParseStatus, DocumentType } from "@/types";
 
-const { deleteRequest, dispatch, get, playAssistantVoiceResponse, post, push, uploadDocumentToStorage } =
+const {
+    authState,
+    deleteRequest,
+    dispatch,
+    get,
+    playAssistantVoiceResponse,
+    post,
+    push,
+    redirectToLogin,
+    refreshPatientSession,
+    uploadDocumentToStorage,
+    writeStoredSession,
+} =
     vi.hoisted(() => ({
+        authState: {
+            value: {
+                accessToken: "access-token",
+                expiresAt: Math.floor(Date.now() / 1000) + 3600,
+                refreshToken: "refresh-token",
+                user: { id: "patient-1" },
+            },
+        },
         deleteRequest: vi.fn(),
         dispatch: vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue(undefined) })),
         get: vi.fn(),
         playAssistantVoiceResponse: vi.fn(() => null),
         post: vi.fn(),
         push: vi.fn(),
+        redirectToLogin: vi.fn(),
+        refreshPatientSession: vi.fn(),
         uploadDocumentToStorage: vi.fn(),
+        writeStoredSession: vi.fn(),
     }));
 
 vi.mock("next/navigation", () => ({
@@ -22,12 +45,7 @@ vi.mock("react-redux", () => ({
     useDispatch: () => dispatch,
     useSelector: (selector: (state: unknown) => unknown) =>
         selector({
-            auth: {
-                accessToken: "access-token",
-                expiresAt: Math.floor(Date.now() / 1000) + 3600,
-                refreshToken: "refresh-token",
-                user: { id: "patient-1" },
-            },
+            auth: authState.value,
         }),
 }));
 
@@ -39,12 +57,30 @@ vi.mock("@/services/storage", () => ({
     uploadDocumentToStorage,
 }));
 
+vi.mock("@/services/auth-redirect", () => ({
+    redirectToLogin,
+}));
+
+vi.mock("@/services/auth-refresh", () => ({
+    refreshPatientSession,
+}));
+
+vi.mock("@/services/auth-session", () => ({
+    writeStoredSession,
+}));
+
 vi.mock("@/services/browser-voice", () => ({
     playAssistantVoiceResponse,
 }));
 
 describe("RecordsPage", () => {
     beforeEach(() => {
+        authState.value = {
+            accessToken: "access-token",
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            refreshToken: "refresh-token",
+            user: { id: "patient-1" },
+        };
         deleteRequest.mockReset();
         dispatch.mockReset();
         dispatch.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(undefined) });
@@ -53,7 +89,10 @@ describe("RecordsPage", () => {
         playAssistantVoiceResponse.mockReturnValue(null);
         post.mockReset();
         push.mockReset();
+        redirectToLogin.mockReset();
+        refreshPatientSession.mockReset();
         uploadDocumentToStorage.mockReset();
+        writeStoredSession.mockReset();
         window.sessionStorage.clear();
     });
 
@@ -173,6 +212,88 @@ describe("RecordsPage", () => {
                 { token: "access-token" },
             );
         });
+    });
+
+    it("uploads the file before starting its extraction import", async () => {
+        get.mockResolvedValue([]);
+        uploadDocumentToStorage.mockResolvedValue("patient-1/lab-results.pdf");
+        let resolveCreate: ((document: Record<string, unknown>) => void) | undefined;
+        const createdDocument = {
+            ai_summary: null,
+            created_at: "2026-04-20T12:00:00Z",
+            document_type: DocumentType.LAB_REPORT,
+            file_name: "lab-results.pdf",
+            file_size_bytes: 1400,
+            file_url: "https://example.test/lab-results.pdf",
+            id: "doc-upload-order",
+            mime_type: "application/pdf",
+            parse_status: DocumentParseStatus.PENDING,
+            parsed: false,
+            patient_id: "patient-1",
+            source_clinic: null,
+            uploaded_by: "patient-1",
+            uploaded_by_role: "patient",
+            visibility: "shared",
+        };
+        post.mockImplementationOnce(
+            () => new Promise((resolve) => {
+                resolveCreate = resolve;
+            }),
+        );
+        post.mockResolvedValueOnce({});
+
+        const { container } = render(<RecordsPage />);
+        const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+        fireEvent.change(input!, {
+            target: {
+                files: [new File(["test"], "lab-results.pdf", { type: "application/pdf" })],
+            },
+        });
+
+        await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+        expect(post).toHaveBeenLastCalledWith(
+            "/api/v1/documents/",
+            expect.objectContaining({
+                file_path: "patient-1/lab-results.pdf",
+                start_ingestion: false,
+            }),
+            { token: "access-token" },
+        );
+
+        resolveCreate!(createdDocument);
+
+        await waitFor(() => {
+            expect(post).toHaveBeenLastCalledWith(
+                "/api/v1/documents/extractions/import",
+                { document_id: "doc-upload-order" },
+                { token: "access-token" },
+            );
+        });
+    });
+
+    it("fails visibly and safely when an upload session cannot be refreshed", async () => {
+        authState.value = {
+            accessToken: "expired-access-token",
+            expiresAt: Math.floor(Date.now() / 1000) - 60,
+            refreshToken: "refresh-token",
+            user: { id: "patient-1" },
+        };
+        get.mockResolvedValue([]);
+        refreshPatientSession.mockRejectedValue(new Error("Refresh failed"));
+
+        const { container } = render(<RecordsPage />);
+        const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+        fireEvent.change(input!, {
+            target: {
+                files: [new File(["test"], "lab-results.pdf", { type: "application/pdf" })],
+            },
+        });
+
+        expect(await screen.findByText(/your session expired. please sign in again before uploading/i)).toBeInTheDocument();
+        expect(refreshPatientSession).toHaveBeenCalledWith("refresh-token");
+        expect(redirectToLogin).toHaveBeenCalledWith({ reason: "session_expired" });
+        expect(uploadDocumentToStorage).not.toHaveBeenCalled();
+        expect(post).not.toHaveBeenCalled();
     });
 
     it("reads the visible document summary aloud", async () => {

--- a/apps/patient-portal/src/__tests__/today-page.test.tsx
+++ b/apps/patient-portal/src/__tests__/today-page.test.tsx
@@ -59,6 +59,20 @@ describe("TodayPage", () => {
         expect(screen.getByText("V")).toBeInTheDocument();
     });
 
+    it("renders a safe zero percent when adherence is not finite", () => {
+        mockFeedData({
+            adherenceStats: {
+                currentStreakDays: 0,
+                overallScore: Number.NaN,
+            },
+        });
+
+        render(<TodayPage />);
+
+        expect(screen.getByText("0%")).toBeInTheDocument();
+        expect(screen.queryByText("NaN%")).not.toBeInTheDocument();
+    });
+
     it("renders a calm loading state while the first feed load is pending", () => {
         mockFeedData({ loading: true, tasks: [] });
 
@@ -128,6 +142,27 @@ describe("TodayPage", () => {
         const setupLink = screen.getByRole("link", { name: /set reminder times/i });
         expect(setupLink).toHaveAttribute("href", "/reminders");
         expect(screen.getByText(/^Set reminder time$/i)).toBeInTheDocument();
+    });
+
+    it("renders obligations without a frequency", () => {
+        const incompleteObligation = {
+            description: "Record a blood-pressure reading",
+            id: "task-3",
+            name: "Blood pressure check",
+            requiresScheduleConfiguration: false,
+            scheduledTime: undefined,
+            status: FeedTaskStatus.PENDING,
+            targetId: "obligation-2",
+            type: FeedTaskType.OBLIGATION,
+        } as unknown as FeedTask;
+        mockFeedData({
+            tasks: [incompleteObligation],
+        });
+
+        render(<TodayPage />);
+
+        expect(screen.getByText("Blood pressure check")).toBeInTheDocument();
+        expect(screen.getByText("Any time")).toBeInTheDocument();
     });
 
 });

--- a/apps/patient-portal/src/app/(app)/profile/page.tsx
+++ b/apps/patient-portal/src/app/(app)/profile/page.tsx
@@ -3,7 +3,12 @@
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { HiOutlineBuildingOffice2 } from "react-icons/hi2";
+import {
+    HiOutlineBuildingOffice2,
+    HiOutlineCheck,
+    HiOutlinePencilSquare,
+    HiOutlineXMark,
+} from "react-icons/hi2";
 import { useDispatch, useSelector } from "react-redux";
 import { PageHeader } from "@/components/layouts";
 import { api } from "@/services/api";
@@ -11,7 +16,13 @@ import { clearStoredSession } from "@/services/auth-session";
 import { Badge, Button, Card, EmptyState, ErrorState, Input, Skeleton } from "@/components/ui";
 import { logout } from "@/store/slices/auth-slice";
 import type { AppDispatch, RootState } from "@/store/store";
-import { getLocaleLabel, normalizeLocale, type Locale } from "@/types";
+import {
+    Gender,
+    getLocaleLabel,
+    normalizeLocale,
+    SUPPORTED_LOCALES,
+    type Locale,
+} from "@/types";
 import type { CareTeamMember, Patient } from "@/types";
 
 interface PatientProfileResponse {
@@ -37,6 +48,13 @@ interface CareTeamResponse {
     clinic_name?: string;
     status: CareTeamMember["status"];
     created_at: string;
+}
+
+interface EditDraft {
+    firstName: string;
+    gender: Patient["gender"] | "";
+    lastName: string;
+    preferredLanguage: Locale;
 }
 
 function mapPatient(profile: PatientProfileResponse): Patient {
@@ -70,6 +88,13 @@ function mapCareTeamMember(member: CareTeamResponse): CareTeamMember {
 
 const formatLanguage = getLocaleLabel;
 
+const GENDER_LABELS: Record<string, string> = {
+    [Gender.FEMALE]: "Female",
+    [Gender.MALE]: "Male",
+    [Gender.OTHER]: "Other",
+    [Gender.PREFER_NOT_TO_SAY]: "Prefer not to say",
+};
+
 function ProfilePageContent() {
     const dispatch = useDispatch<AppDispatch>();
     const { replace } = useRouter();
@@ -83,6 +108,11 @@ function ProfilePageContent() {
     const [loading, setLoading] = useState(true);
     const [pageError, setPageError] = useState("");
     const [joining, setJoining] = useState(false);
+    const [editing, setEditing] = useState(false);
+    const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [saveError, setSaveError] = useState("");
+    const [saveSuccess, setSaveSuccess] = useState("");
     const showJoinClinicPrompt = searchParams.get("joinClinic") === "1" && careTeam.length === 0;
 
     async function fetchCareTeam(token: string) {
@@ -140,6 +170,60 @@ function ProfilePageContent() {
         clearStoredSession();
         dispatch(logout());
         replace("/login");
+    }
+
+    function startEditing() {
+        if (!patientProfile) {
+            return;
+        }
+
+        setEditDraft({
+            firstName: patientProfile.firstName,
+            gender: patientProfile.gender ?? "",
+            lastName: patientProfile.lastName,
+            preferredLanguage: patientProfile.preferredLanguage,
+        });
+        setSaveError("");
+        setSaveSuccess("");
+        setEditing(true);
+    }
+
+    function cancelEditing() {
+        setEditing(false);
+        setEditDraft(null);
+        setSaveError("");
+    }
+
+    async function handleSaveProfile(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!accessToken || !editDraft) {
+            return;
+        }
+
+        setSaving(true);
+        setSaveError("");
+        setSaveSuccess("");
+
+        try {
+            const updated = await api.put<PatientProfileResponse>(
+                "/api/v1/patients/me",
+                {
+                    first_name: editDraft.firstName.trim(),
+                    last_name: editDraft.lastName.trim(),
+                    preferred_language: editDraft.preferredLanguage,
+                    ...(editDraft.gender ? { gender: editDraft.gender } : {}),
+                },
+                { token: accessToken },
+            );
+            setPatientProfile(mapPatient(updated));
+            setSaveSuccess("Profile updated successfully.");
+            setEditing(false);
+            setEditDraft(null);
+        } catch (error) {
+            setSaveError((error as Error).message || "Failed to save profile. Please try again.");
+        } finally {
+            setSaving(false);
+        }
     }
 
     async function handleJoinClinic(event: React.FormEvent<HTMLFormElement>) {
@@ -227,22 +311,110 @@ function ProfilePageContent() {
                                     <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Profile details</p>
                                     <h3 className="mt-1 text-xl font-semibold text-[#17233a]">Personal information</h3>
                                 </div>
-                                <Badge variant="info">Active</Badge>
+                                {editing ? (
+                                    <Badge variant="info">Editing</Badge>
+                                ) : (
+                                    <button
+                                        aria-label="Edit profile"
+                                        className="flex min-h-10 items-center gap-1.5 rounded-2xl border border-[#b9ded6] bg-[#e6f4f1] px-3 py-2 text-sm font-semibold text-[#147465] transition hover:bg-[#d0eceb]"
+                                        onClick={startEditing}
+                                        type="button"
+                                    >
+                                        <HiOutlinePencilSquare className="h-4 w-4" />
+                                        Edit
+                                    </button>
+                                )}
                             </div>
-                            <div className="grid gap-3 text-sm text-[#5b6b83]">
-                                <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Date of birth</p>
-                                    <p className="mt-1 font-semibold text-[#30415f]">{patientProfile.dateOfBirth}</p>
+                            {saveSuccess && !editing ? (
+                                <div className="flex items-center gap-2 rounded-2xl bg-[#ecf8ef] px-4 py-3 text-sm font-medium text-[#256047]">
+                                    <HiOutlineCheck className="h-4 w-4 shrink-0" />
+                                    {saveSuccess}
                                 </div>
-                                <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Preferred language</p>
-                                    <p className="mt-1 font-semibold text-[#30415f]">{formatLanguage(patientProfile.preferredLanguage)}</p>
+                            ) : null}
+                            {editing && editDraft ? (
+                                <form className="space-y-4" onSubmit={handleSaveProfile}>
+                                    <div className="grid gap-3 sm:grid-cols-2">
+                                        <Input
+                                            label="First name"
+                                            onChange={(event) => setEditDraft((draft) => draft ? { ...draft, firstName: event.target.value } : draft)}
+                                            required
+                                            value={editDraft.firstName}
+                                        />
+                                        <Input
+                                            label="Last name"
+                                            onChange={(event) => setEditDraft((draft) => draft ? { ...draft, lastName: event.target.value } : draft)}
+                                            required
+                                            value={editDraft.lastName}
+                                        />
+                                    </div>
+                                    <div className="space-y-1">
+                                        <label className="block text-[0.95rem] font-semibold text-[#30415f]" htmlFor="preferred-language">
+                                            Preferred language
+                                        </label>
+                                        <select
+                                            className="min-h-[3.25rem] w-full rounded-2xl border border-[#d9cbc0] bg-white/90 px-4 py-3 text-base text-[#17233a] outline-none focus:border-[#147465] focus:ring-4 focus:ring-[#147465]/15"
+                                            id="preferred-language"
+                                            onChange={(event) => setEditDraft((draft) => draft ? { ...draft, preferredLanguage: event.target.value as Locale } : draft)}
+                                            value={editDraft.preferredLanguage}
+                                        >
+                                            {SUPPORTED_LOCALES.map((locale) => (
+                                                <option key={locale} value={locale}>
+                                                    {getLocaleLabel(locale)}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                    <div className="space-y-1">
+                                        <label className="block text-[0.95rem] font-semibold text-[#30415f]" htmlFor="gender">
+                                            Gender <span className="font-normal text-[#8090a5]">(optional)</span>
+                                        </label>
+                                        <select
+                                            className="min-h-[3.25rem] w-full rounded-2xl border border-[#d9cbc0] bg-white/90 px-4 py-3 text-base text-[#17233a] outline-none focus:border-[#147465] focus:ring-4 focus:ring-[#147465]/15"
+                                            id="gender"
+                                            onChange={(event) => setEditDraft((draft) => draft ? { ...draft, gender: event.target.value as Patient["gender"] | "" } : draft)}
+                                            value={editDraft.gender}
+                                        >
+                                            <option value="">Prefer not to say</option>
+                                            {Object.entries(GENDER_LABELS).map(([value, label]) => (
+                                                <option key={value} value={value}>{label}</option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                    {saveError ? (
+                                        <div className="rounded-2xl bg-[#fff2ef] px-4 py-3 text-sm font-medium text-[#b94032]">{saveError}</div>
+                                    ) : null}
+                                    <div className="grid grid-cols-2 gap-3">
+                                        <Button disabled={saving} fullWidth size="lg" type="submit">
+                                            {saving ? "Saving..." : "Save changes"}
+                                        </Button>
+                                        <Button disabled={saving} fullWidth onClick={cancelEditing} size="lg" type="button" variant="secondary">
+                                            <HiOutlineXMark className="mr-1 h-4 w-4" />
+                                            Cancel
+                                        </Button>
+                                    </div>
+                                </form>
+                            ) : (
+                                <div className="grid gap-3 text-sm text-[#5b6b83]">
+                                    <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
+                                        <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Date of birth</p>
+                                        <p className="mt-1 font-semibold text-[#30415f]">{patientProfile.dateOfBirth}</p>
+                                    </div>
+                                    <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
+                                        <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Preferred language</p>
+                                        <p className="mt-1 font-semibold text-[#30415f]">{formatLanguage(patientProfile.preferredLanguage)}</p>
+                                    </div>
+                                    {patientProfile.gender ? (
+                                        <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
+                                            <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Gender</p>
+                                            <p className="mt-1 font-semibold text-[#30415f]">{GENDER_LABELS[patientProfile.gender] ?? patientProfile.gender}</p>
+                                        </div>
+                                    ) : null}
+                                    <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
+                                        <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Timezone</p>
+                                        <p className="mt-1 font-semibold text-[#30415f]">{patientProfile.timezone ?? "UTC"}</p>
+                                    </div>
                                 </div>
-                                <div className="rounded-2xl bg-[#fff7ed] px-4 py-3 ring-1 ring-[#eaded3]">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-[#7b8798]">Timezone</p>
-                                    <p className="mt-1 font-semibold text-[#30415f]">{patientProfile.timezone ?? "UTC"}</p>
-                                </div>
-                            </div>
+                            )}
                         </Card>
 
                         <Card className="space-y-4">


### PR DESCRIPTION
## Description

- Restores patient profile editing through the canonical API and locale contract.
- Adds regression coverage for patient identity, adherence display, document upload ordering, and expired-session recovery.
- Reconciles the verified historical fixes and records the result in the task tracker.

## Related Tasks / Issues

- Completes REV-002 in `.agent/TASKS.md`.

## Docs Impact

- [x] Updated `.agent/TASKS.md`.

## Required Verification Checklist

- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Manual Verification

1. Edit a patient profile and confirm the change persists through `PUT /api/v1/patients/me`.
2. Upload a document and confirm the record exists before extraction/import begins.
3. Simulate an expired import session and confirm a visible recovery error is shown without starting upload/import.

## UI Evidence

- Not applicable; coverage is automated component and integration validation.