### PR TITLE
docs: add contributor workflow guidance

### DIFF
--- a/.acquit.toml
+++ b/.acquit.toml
@@ -2,12 +2,13 @@
 # uses a nested src layout, so declare its import roots explicitly.
 roots = ["backend/src", "backend"]
 
-# Backend pytest never reads these frontend/project-management trees. Changes
-# here cannot alter Python test behavior; frontend CI remains responsible for
-# apps and shared TypeScript packages.
+# Backend pytest never reads these frontend, editor-configuration, and
+# project-management trees. Changes here cannot alter Python test behavior;
+# frontend CI remains responsible for apps and shared TypeScript packages.
 assume_inert = [
   ".agent/**",
   "apps/**",
+  ".cursor/**",
   "*.md",
   "docs/**",
   "meetings/**",

--- a/.cursor/rules/mediagent-workflow.mdc
+++ b/.cursor/rules/mediagent-workflow.mdc
@@ -1,0 +1,12 @@
+---
+description: MediAgent project workflow and task routing
+alwaysApply: true
+---
+
+Read and follow the repository-root `AGENTS.md` before planning, editing, or
+running commands. It is the canonical project instruction source. Use its
+routing table to load only the task-specific product, safety, and verification
+documents that apply to the files you touch.
+
+Do not duplicate or override `AGENTS.md` here. Repository-wide changes to this
+workflow belong in `AGENTS.md` and `docs/contributor-agent-workflow.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,89 @@
-# Contribution naming
+# MediAgent contributor contract
 
-Use product- and work-focused names for branches and commits (for example,
-`fix/appointment-validation` or `docs/release-checklist`). Do not include
-author, tool, provider, assistant, or platform identifiers in public branch
-names, commit messages, source comments, or documentation.
+This is the repository's canonical instruction source for coding assistants and
+human contributors. Keep it concise, durable, and version controlled. Put
+feature-specific detail in the linked source documents rather than duplicating
+it here.
+
+## Start every task this way
+
+1. Inspect the branch and working tree. Preserve unrelated user changes.
+2. Read [`.agent/TASKS.md`](.agent/TASKS.md), then the active plan named at its
+   top. Select an existing task or create a scoped task entry before expanding
+   the product surface.
+3. Read the relevant routing documents below and inspect adjacent code and
+   tests before editing.
+4. State the acceptance path, assumptions, and any missing decision. Implement
+   and verify the smallest coherent change that satisfies that path.
+5. Update the task tracker and affected product or operational documentation
+   whenever behavior, contracts, rollout, or evidence changes.
+
+## Product boundaries that are not optional
+
+- MediAgent is supervised clinical decision support for California outpatient
+  chronic-care and polypharmacy workflows. It is not an autonomous clinician.
+- Use only synthetic or rigorously de-identified data. Do not claim HIPAA or
+  production readiness without the required agreements and review.
+- Supported patient-facing locales are American English (`en-US`) and Mexican
+  Spanish (`es-MX`).
+- Imported clinical data is a candidate with resource-level provenance. It
+  cannot overwrite approved local clinical truth without the established
+  review and approval path.
+- Never expose private chain-of-thought, credentials, service-role keys, or
+  real patient data in code, logs, fixtures, commits, pull requests, or docs.
+
+## Route work to the right sources
+
+| Change surface | Read before editing | Verify before review |
+| --- | --- | --- |
+| Any task | `.agent/TASKS.md`, `.agent/PROJECT.md`, `.agent/TEAM.md` | Scope, acceptance criteria, and tracker state are current |
+| Backend/API | `backend/README.md`, `.agent/CODING_STANDARDS.md`, adjacent router/service/tests | Focused tests; Ruff and mypy for changed Python |
+| Patient or clinician portal | Relevant app `README.md`, `.agent/DESIGN_SYSTEM.md`, adjacent UI/tests | Lint, typecheck, focused tests, and build when practical |
+| Database, Auth, storage, or Supabase | `docs/supabase_setup_guide.md`, migrations, relevant RLS tests | Migration validation and the least-privilege/RLS path; never improvise remote SQL |
+| Synthetic demo data | `docs/demo-environment.md`, `docs/synthetic-data-catalog.md`, fixture README | Fixture checksum, dry run, idempotency, and documented synthetic-only boundary |
+| Clinical provenance, approvals, FHIR, or SMART | `docs/clinical-facts-provenance.md`, `.agent/specs/int-002-003-interoperability-plan.md` | Provenance, authorization, error, and review behavior—not only a happy path |
+| Architecture or cross-cutting behavior | `.agent/ARCHITECTURE.md`, active specification | Update the decision record and integration tests as needed |
+| CI or dependencies | `.github/workflows/ci.yml`, lockfiles, `.agent/TASKS.md` | Reproducible install and all relevant required checks |
+
+## Safe delivery rules
+
+- Do not edit, print, commit, or upload `.env`, `.env.local`, credentials,
+  tokens, database dumps, or production-like data. Use `.env.example` for
+  documented configuration changes.
+- Do not discard, overwrite, or reformat unrelated work. Avoid destructive
+  Git commands and never force-push shared history without explicit approval.
+- Do not apply remote migrations, reset or seed a remote environment, deploy,
+  merge a pull request, or change external service configuration without the
+  requester explicitly authorizing that exact action.
+- Keep routers thin; put business rules in services; validate at boundaries;
+  add tests at the level where the behavior is owned.
+- Prefer existing shared types, services, fixtures, and patterns over parallel
+  implementations. Do not add schema solely to make a demo look richer.
+
+## Branches, commits, reviews, and evidence
+
+- Start short-lived branches from current `main`. Use product- and work-focused
+  names such as `feature/import-review` or `fix/appointment-validation`.
+- Branch names, commit messages, source comments, and product documentation
+  must not identify an authoring tool, provider, or assistant. The compatibility
+  files named below are the sole documentation exception.
+- Use conventional, human-readable commit messages. Keep one coherent concern
+  per pull request whenever possible.
+- Before requesting review, run the relevant checks from `CONTRIBUTING.md`,
+  record exact commands and outcomes, identify manual verification, and call
+  out follow-up work honestly.
+- Never describe a task as complete merely because a route, mock, or UI exists.
+  Completion needs the agreed behavior, authorization, error handling, audit
+  behavior where applicable, tests, and user-visible acceptance path.
+
+## Supported coding environments
+
+- **Codex:** reads this root `AGENTS.md` directly.
+- **Claude Code:** reads root `CLAUDE.md`, which imports this file.
+- **Cursor:** reads this file and `.cursor/rules/mediagent-workflow.mdc`, whose
+  only job is to route work back here.
+
+Maintain shared instructions in this file. Do not create `.cursorrules`, copy
+the guidance into multiple files, or commit personal preferences. See
+[`docs/contributor-agent-workflow.md`](docs/contributor-agent-workflow.md) for
+the maintainer guide and first-task checklist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,12 @@ Developer guide for setup, architecture orientation, verification, and pull requ
 
 Before writing code, read in this order:
 
-1. [PROJECT.md](.agent/PROJECT.md) — product context and decisions  
-2. [ARCHITECTURE.md](.agent/ARCHITECTURE.md) — system design and data model  
-3. [CODING_STANDARDS.md](.agent/CODING_STANDARDS.md) — how we write code  
-4. [TASKS.md](.agent/TASKS.md) — phase status and backlog  
-5. [TEAM.md](.agent/TEAM.md) — Git workflow and PR norms  
+1. [AGENTS.md](AGENTS.md) — shared task routing, safety, and delivery contract
+2. [TASKS.md](.agent/TASKS.md) — phase status and backlog
+3. [PROJECT.md](.agent/PROJECT.md) — product context and decisions
+4. [ARCHITECTURE.md](.agent/ARCHITECTURE.md) — system design and data model
+5. [CODING_STANDARDS.md](.agent/CODING_STANDARDS.md) — how we write code
+6. [TEAM.md](.agent/TEAM.md) — Git workflow and PR norms
 
 For UI work, also use [DESIGN_SYSTEM.md](.agent/DESIGN_SYSTEM.md).
 
@@ -131,7 +132,7 @@ See [TEAM.md](.agent/TEAM.md) for sprint and review expectations.
 6. Run checks below.  
 7. Open a PR using the repo template.
 
-### Adding an AI agent
+### Adding a product worker
 
 Follow [.agent/workflows/new-agent.md](.agent/workflows/new-agent.md). Typical layout under `backend/src/app/agents/<name>/`:
 
@@ -185,7 +186,7 @@ npm run build
 npm run test             # when tests cover your change
 ```
 
-### AI-assisted / agent-generated code
+### Automated-code safeguards
 
 - Routers stay thin; business logic lives in `services/`.  
 - No secrets, API keys, or real `.env` contents in commits.  
@@ -321,6 +322,8 @@ Before requesting review, walk through [.agent/workflows/ai-code-review.md](.age
 
 | Question | Doc |
 |----------|-----|
+| Shared task routing and safety rules | [AGENTS.md](AGENTS.md) |
+| Supported coding-environment setup | [Contributor agent workflow](docs/contributor-agent-workflow.md) |
 | System design | [ARCHITECTURE.md](.agent/ARCHITECTURE.md) |
 | Code style | [CODING_STANDARDS.md](.agent/CODING_STANDARDS.md) |
 | What to build next | [TASKS.md](.agent/TASKS.md) |

--- a/docs/contributor-agent-workflow.md
+++ b/docs/contributor-agent-workflow.md
@@ -1,0 +1,80 @@
+# Contributor agent workflow
+
+This guide gives every supported coding environment the same repository context
+without maintaining three competing instruction sets. It is for contributors
+who use Codex, Claude Code, or Cursor while working in MediAgent.
+
+## One canonical source
+
+`AGENTS.md` at the repository root is the shared contributor contract. It
+contains the start-of-task sequence, product boundaries, task-routing table,
+safety rules, and pull-request expectations.
+
+| Environment | Repository file | How shared instructions arrive |
+| --- | --- | --- |
+| Codex | `AGENTS.md` | Root project instructions are loaded directly. |
+| Claude Code | `CLAUDE.md` | The tracked file imports `AGENTS.md`. |
+| Cursor | `AGENTS.md` and `.cursor/rules/mediagent-workflow.mdc` | The project rule directs every task to the canonical file. |
+
+The compatibility files deliberately contain no copy of the instructions. When
+the team changes a shared rule, edit `AGENTS.md` once and review the resulting
+diff as an ordinary documentation change. Do not add the deprecated
+`.cursorrules` file.
+
+## First task checklist
+
+Before asking an assistant to implement anything, make the task concrete:
+
+1. Name the existing `.agent/TASKS.md` item or create a small, testable task.
+2. State the user outcome and acceptance checks, not merely an implementation
+   idea.
+3. Point to the relevant screen, API, migration, or specification if one is
+   known.
+4. Say whether a remote action is authorized. Remote migrations, deployment,
+   resets, seeds, merges, and service configuration changes require explicit
+   confirmation.
+5. Ask for a focused branch, tests, documentation updates, and a review-ready
+   summary with exact verification results.
+
+For example:
+
+```text
+Implement INT-002 mapping for <resource>. Preserve pending-review provenance.
+Read the INT plan and adjacent tests first. Do not change the remote database.
+Add focused tests, update TASKS.md and the relevant design doc, then prepare a
+single focused PR with the verification commands and results.
+```
+
+## Maintaining useful instructions
+
+Keep `AGENTS.md` under roughly 200 lines and include only stable facts that
+apply to most tasks: hard product boundaries, required safety behavior, task
+routing, and delivery rules. Put detail where it belongs:
+
+| Need | Location |
+| --- | --- |
+| Current priority, owner, and acceptance evidence | `.agent/TASKS.md` |
+| Product thesis and clinical boundaries | `.agent/PROJECT.md` |
+| Architecture and cross-cutting decisions | `.agent/ARCHITECTURE.md` |
+| Code conventions | `.agent/CODING_STANDARDS.md` |
+| Team branching and review process | `.agent/TEAM.md` |
+| Database, Auth, RLS, and environment recreation | `docs/supabase_setup_guide.md` |
+| Fixture and staging-demo rules | `docs/demo-environment.md`, `docs/synthetic-data-catalog.md` |
+| FHIR/SMART import boundary | `.agent/specs/int-002-003-interoperability-plan.md` |
+
+Keep personal workflow preferences out of the repository. Use each product's
+local, ignored settings mechanism for those instead.
+
+## Review the workflow itself
+
+Review these instructions when a repeated correction, a review finding, a
+security incident, or a new mandatory delivery step exposes missing context.
+Prefer a specific, testable instruction over a broad request to “be careful.”
+Remove stale or conflicting rules rather than accumulating them.
+
+The approach follows the current project-instruction patterns documented by
+[Claude Code](https://code.claude.com/docs/en/memory),
+[Cursor](https://cursor.com/docs/context/rules), and
+[OpenAI](https://developers.openai.com/api/docs/guides/latest-model): maintain
+concise shared instructions, scope detailed rules to the work that needs them,
+and avoid repeating prompt material.


### PR DESCRIPTION
## Description
- Context: Contributors need one durable project context across the supported coding environments without maintaining divergent instruction files.
- What changed:
  - makes root `AGENTS.md` the canonical task-routing, safety, product-boundary, and delivery contract;
  - adds a minimal `CLAUDE.md` import and a Cursor project rule that both route back to that source;
  - adds a maintainer guide and updates the contributor onboarding sequence and safeguards.
- Risk/impact: Documentation and repository configuration only. No runtime, database, or deployment behavior changes.

## Related Tasks / Issues
- Resolves: contributor workflow and onboarding documentation maintenance.

## Docs Impact
- [ ] No docs update required.
- [ ] Updated `.agent/TASKS.md`.
- [ ] Updated `.agent/specs/*` docs.
- [x] Updated `README.md` and/or `CONTRIBUTING.md`.

## Required Verification Checklist
- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Manual Verification
1. Start each supported coding environment from the repository root and verify that it loads the root contract directly or through its tracked compatibility file.
2. Follow the first-task checklist for a backend, portal, database, and documentation task; each should route to the correct source material and verification path.
3. Confirm no personal configuration, credentials, or duplicate instruction source is committed.

## Verification evidence
- `git diff --check` passed.
- The canonical contract is 89 lines; its two compatibility files are deliberately minimal.