### PR TITLE
feat: export clinical fact provenance

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -207,10 +207,10 @@ records as pending candidates; `list_approved` is the clinical-display query. Se
 ### INT-002 — FHIR R4 validation and mapping
 
 - [x] Establish an R4-compatible validation boundary; the maintained dependency provides R4B while emitted payloads remain R4-compatible.
-- [/] Map Patient; Practitioner, Organization, and CareTeam remain deferred because the local clinician/care-team model is authoritative.
+- [x] Map Patient. Practitioner, Organization, and CareTeam are intentionally not mapped because the local clinician/care-team model remains authoritative.
 - [x] Map Condition, AllergyIntolerance, MedicationRequest, and MedicationStatement.
-- [/] Map Observation, DocumentReference, and CarePlan; Appointment and Communication remain deferred.
-- [ ] Generate Provenance and AuditEvent resources.
+- [x] Map Observation, DocumentReference, and CarePlan; Appointment and Communication are intentionally outside the committed import set.
+- [x] Generate validated, read-only Provenance and AuditEvent representations from local clinical-fact lineage and immutable audit records without external FHIR writes or private-reasoning disclosure.
 - [/] Validate supported resource shape before persistence; identifier-quality and export validation remain deferred.
 - [x] Handle missing, partial, duplicate, and unsupported resources safely.
 - [/] Add import fixture tests; FHIR export and round-trip fixtures remain deferred.

--- a/backend/src/app/routers/smart.py
+++ b/backend/src/app/routers/smart.py
@@ -22,6 +22,7 @@ from app.models.fhir_import import (
     SmartLaunchResponse,
 )
 from app.services.clinical_fact_service import ClinicalFactService
+from app.services.fhir_audit_export_service import FhirAuditExportService
 from app.services.smart_launch_service import SmartLaunchService
 
 router = APIRouter()
@@ -30,6 +31,10 @@ _clinician_dep = require_role("clinician")
 
 def _service(db: Client = Depends(get_db)) -> SmartLaunchService:
     return SmartLaunchService(db)
+
+
+def _fhir_audit_export_service(db: Client = Depends(get_db)) -> FhirAuditExportService:
+    return FhirAuditExportService(db)
 
 
 @router.post(
@@ -110,6 +115,19 @@ async def fact_lineage(
 ) -> Any:
     service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
     return ClinicalFactService(db).get_lineage(fact_id, patient_id)
+
+
+@router.get("/patients/{patient_id}/facts/{fact_id}/fhir-audit")
+async def fact_fhir_audit(
+    patient_id: UUID,
+    fact_id: UUID,
+    user: CurrentUser = Depends(_clinician_dep),
+    service: SmartLaunchService = Depends(_service),
+    export_service: FhirAuditExportService = Depends(_fhir_audit_export_service),
+) -> Any:
+    """Generate validated FHIR provenance/audit resources without external writes."""
+    service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
+    return export_service.export_for_fact(fact_id=fact_id, patient_id=patient_id)
 
 
 @router.post("/patients/{patient_id}/facts/{fact_id}/approve")

--- a/backend/src/app/services/fhir_audit_export_service.py
+++ b/backend/src/app/services/fhir_audit_export_service.py
@@ -1,0 +1,154 @@
+"""FHIR R4B representations of local clinical-fact provenance and audit history.
+
+These resources are generated on demand from the immutable local lineage and
+audit records. They are not written back to an external FHIR server and never
+carry private reasoning, clinical-fact values, or reviewer notes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, cast
+from uuid import UUID
+
+from fhir.resources.R4B.auditevent import AuditEvent
+from fhir.resources.R4B.provenance import Provenance
+from supabase import Client
+
+from app.services.clinical_fact_service import ClinicalFactService
+
+_FACT_IDENTIFIER_SYSTEM = "urn:mediagent:clinical-fact"
+_AUDIT_SUBTYPE_SYSTEM = "urn:mediagent:clinical-fact-audit"
+_AUDIT_EVENT_TYPE_SYSTEM = "http://terminology.hl7.org/CodeSystem/audit-event-type"
+_AUDIT_EVENT_TYPE_CODE = "110110"
+_OBSERVER_REFERENCE = "Device/mediagent-backend"
+_AUDIT_ACTIONS = {
+    "created": "C",
+    "corrected": "U",
+    "approved": "U",
+    "rejected": "U",
+    "deleted": "D",
+}
+
+
+class FhirAuditExportService:
+    """Expose the existing review trail as validated, read-only FHIR resources."""
+
+    def __init__(self, db: Client) -> None:
+        self.db = db
+        self.facts = ClinicalFactService(db)
+
+    def export_for_fact(self, *, fact_id: UUID, patient_id: UUID) -> dict[str, Any]:
+        """Build one Provenance and ordered AuditEvents for a local candidate fact."""
+        lineage = self.facts.get_lineage(fact_id, patient_id)
+        fact = cast(dict[str, Any], lineage["fact"])
+        provenances = cast(list[dict[str, Any]], lineage["provenances"])
+        target = self._fact_reference(fact_id)
+
+        provenance = Provenance.model_validate(
+            {
+                "resourceType": "Provenance",
+                "target": [target],
+                "recorded": self._instant(fact["created_at"]),
+                "agent": [{"who": {"reference": _OBSERVER_REFERENCE}}],
+                "entity": [self._source_entity(source) for source in provenances],
+            }
+        ).model_dump(mode="json", exclude_none=True)
+
+        audit_rows = self._audit_rows(fact_id)
+        audit_events = [
+            AuditEvent.model_validate(self._audit_payload(event, target)).model_dump(
+                mode="json", exclude_none=True
+            )
+            for event in audit_rows
+        ]
+        return {"provenance": provenance, "audit_events": audit_events}
+
+    def _audit_rows(self, fact_id: UUID) -> list[dict[str, Any]]:
+        result = (
+            self.db.table("clinical_fact_audit_events")
+            .select("*")
+            .eq("fact_id", str(fact_id))
+            .order("created_at")
+            .execute()
+        )
+        return cast(list[dict[str, Any]], result.data or [])
+
+    @staticmethod
+    def _fact_reference(fact_id: UUID) -> dict[str, Any]:
+        return {"identifier": {"system": _FACT_IDENTIFIER_SYSTEM, "value": str(fact_id)}}
+
+    def _source_entity(self, source: dict[str, Any]) -> dict[str, Any]:
+        imported_reference = self._imported_fhir_reference(source)
+        if imported_reference:
+            return {"role": "source", "what": imported_reference}
+        if source.get("document_id"):
+            source_reference: dict[str, Any] = {
+                "reference": f"DocumentReference/{source['document_id']}"
+            }
+        else:
+            identifier: dict[str, Any] = {"value": str(source["source_reference"])}
+            source_system = str(source.get("source_system") or "")
+            if source_system.startswith(("https://", "http://", "urn:")):
+                identifier["system"] = source_system
+            source_reference = {"identifier": identifier}
+        return {"role": "source", "what": source_reference}
+
+    def _imported_fhir_reference(self, source: dict[str, Any]) -> dict[str, Any] | None:
+        """Prefer the original versioned FHIR resource over an internal envelope id."""
+        if source.get("artifact_type") != "fhir_resource":
+            return None
+        prefix = "fhir_import_resources/"
+        source_reference = str(source.get("source_reference") or "")
+        if not source_reference.startswith(prefix):
+            return None
+        resource_id = source_reference.removeprefix(prefix)
+        result = (
+            self.db.table("fhir_import_resources")
+            .select("resource_type, external_resource_id, version_id, issuer, content_hash")
+            .eq("id", resource_id)
+            .single()
+            .execute()
+        )
+        imported = cast(dict[str, Any] | None, result.data)
+        if not imported:
+            return None
+        resource_type = str(imported.get("resource_type") or "")
+        external_id = str(imported.get("external_resource_id") or "")
+        if resource_type and external_id:
+            reference = f"{resource_type}/{external_id}"
+            version_id = str(imported.get("version_id") or "")
+            if version_id:
+                reference = f"{reference}/_history/{version_id}"
+            return {"reference": reference}
+        identifier: dict[str, Any] = {"value": str(imported.get("content_hash") or resource_id)}
+        issuer = str(imported.get("issuer") or "")
+        if issuer.startswith(("https://", "http://", "urn:")):
+            identifier["system"] = issuer
+        return {"identifier": identifier}
+
+    @staticmethod
+    def _audit_payload(event: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+        event_type = str(event["event_type"])
+        return {
+            "resourceType": "AuditEvent",
+            "type": {"system": _AUDIT_EVENT_TYPE_SYSTEM, "code": _AUDIT_EVENT_TYPE_CODE},
+            "subtype": [{"system": _AUDIT_SUBTYPE_SYSTEM, "code": event_type}],
+            "action": _AUDIT_ACTIONS[event_type],
+            "recorded": FhirAuditExportService._instant(event["created_at"]),
+            "outcome": "0",
+            "agent": [
+                {
+                    "who": {"reference": f"Practitioner/{event['actor_id']}"},
+                    "requestor": True,
+                }
+            ],
+            "source": {"observer": {"reference": _OBSERVER_REFERENCE}},
+            "entity": [{"what": target}],
+        }
+
+    @staticmethod
+    def _instant(value: Any) -> str:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)

--- a/backend/tests/integration/routers/test_smart_api.py
+++ b/backend/tests/integration/routers/test_smart_api.py
@@ -11,7 +11,7 @@ import pytest
 
 from app.main import app
 from app.models.auth import CurrentUser
-from app.routers.smart import _clinician_dep, _service
+from app.routers.smart import _clinician_dep, _fhir_audit_export_service, _service
 
 
 @pytest.fixture
@@ -27,6 +27,14 @@ def clinician() -> CurrentUser:
     user = CurrentUser(id=uuid4(), email="clinician@example.test", role="clinician", aal="aal2")
     app.dependency_overrides[_clinician_dep] = lambda: user
     yield user
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def fhir_audit_export_service() -> MagicMock:
+    service = MagicMock()
+    app.dependency_overrides[_fhir_audit_export_service] = lambda: service
+    yield service
     app.dependency_overrides.clear()
 
 
@@ -66,3 +74,25 @@ def test_callback_redirects_with_one_time_handoff_only(client, smart_service) ->
     assert response.status_code == 303
     assert "ticket=" + "x" * 48 in response.headers["location"]
     assert "authorization-code" not in response.headers["location"]
+
+
+def test_fact_fhir_audit_requires_assignment_and_returns_generated_resources(
+    client, smart_service, fhir_audit_export_service, clinician
+) -> None:
+    patient_id = uuid4()
+    fact_id = uuid4()
+    fhir_audit_export_service.export_for_fact.return_value = {
+        "provenance": {"resourceType": "Provenance"},
+        "audit_events": [{"resourceType": "AuditEvent"}],
+    }
+
+    response = client.get(f"/api/v1/smart/patients/{patient_id}/facts/{fact_id}/fhir-audit")
+
+    assert response.status_code == 200
+    assert response.json()["provenance"]["resourceType"] == "Provenance"
+    smart_service.ensure_assignment.assert_called_once_with(
+        clinician_id=clinician.id, patient_id=patient_id
+    )
+    fhir_audit_export_service.export_for_fact.assert_called_once_with(
+        fact_id=fact_id, patient_id=patient_id
+    )

--- a/backend/tests/unit/services/test_clinical_fact_service.py
+++ b/backend/tests/unit/services/test_clinical_fact_service.py
@@ -10,6 +10,7 @@ import pytest
 from app.core.exceptions import ValidationError
 from app.models.clinical_fact import ClinicalFactCreate
 from app.services.clinical_fact_service import ClinicalFactService
+from app.services.fhir_audit_export_service import FhirAuditExportService
 
 PATIENT_ID = UUID("00000000-0000-0000-0000-000000000111")
 ACTOR_ID = UUID("00000000-0000-0000-0000-000000000222")
@@ -198,3 +199,59 @@ def test_lineage_returns_the_source_artifact_and_evidence_excerpt() -> None:
     assert lineage["fact"]["id"] == fact["id"]
     assert lineage["provenances"][0]["document_location"]["page"] == 2
     assert lineage["citations"][0]["excerpt"] == "Continue metformin 500 mg."
+
+
+def test_fhir_provenance_and_audit_export_are_valid_and_minimally_disclose_lineage() -> None:
+    db = FakeDatabase()
+    facts = ClinicalFactService(db)  # type: ignore[arg-type]
+    fact = facts.create_candidate(candidate(), actor_id=ACTOR_ID)
+    facts.approve(UUID(fact["id"]), PATIENT_ID, reviewer_id=REVIEWER_ID, note="Reviewed")
+
+    exported = FhirAuditExportService(db).export_for_fact(  # type: ignore[arg-type]
+        fact_id=UUID(fact["id"]), patient_id=PATIENT_ID
+    )
+
+    provenance = exported["provenance"]
+    assert provenance["resourceType"] == "Provenance"
+    assert provenance["target"][0]["identifier"]["value"] == fact["id"]
+    assert provenance["entity"][0]["what"]["reference"] == f"DocumentReference/{DOCUMENT_ID}"
+    assert [event["subtype"][0]["code"] for event in exported["audit_events"]] == [
+        "created",
+        "approved",
+    ]
+    assert [event["action"] for event in exported["audit_events"]] == ["C", "U"]
+    assert all(
+        "event_data" not in event and "review_note" not in event
+        for event in exported["audit_events"]
+    )
+
+
+def test_fhir_provenance_prefers_the_versioned_imported_resource_reference() -> None:
+    db = FakeDatabase()
+    facts = ClinicalFactService(db)  # type: ignore[arg-type]
+    envelope_id = uuid4()
+    payload = candidate().model_dump(mode="json")
+    payload["provenance"] = {
+        "artifact_type": "fhir_resource",
+        "source_system": "https://sandbox.example/fhir",
+        "source_reference": f"fhir_import_resources/{envelope_id}",
+    }
+    db.store["fhir_import_resources"] = [
+        {
+            "id": str(envelope_id),
+            "resource_type": "MedicationRequest",
+            "external_resource_id": "med-123",
+            "version_id": "7",
+            "issuer": "https://sandbox.example/fhir",
+            "content_hash": "content-hash",
+        }
+    ]
+    fact = facts.create_candidate(ClinicalFactCreate.model_validate(payload), actor_id=ACTOR_ID)
+
+    exported = FhirAuditExportService(db).export_for_fact(  # type: ignore[arg-type]
+        fact_id=UUID(fact["id"]), patient_id=PATIENT_ID
+    )
+
+    assert exported["provenance"]["entity"][0]["what"]["reference"] == (
+        "MedicationRequest/med-123/_history/7"
+    )

--- a/docs/clinical-facts-provenance.md
+++ b/docs/clinical-facts-provenance.md
@@ -41,3 +41,16 @@ Row-level policies allow a patient to read only their approved facts and related
 evidence. An assigned clinician may read candidates and their audit trail for review.
 Direct client mutations are not granted; lifecycle changes go through the backend
 service so each transition is audited.
+
+## FHIR provenance and audit representation
+
+Assigned clinicians can request `GET /api/v1/smart/patients/{patient_id}/facts/{fact_id}/fhir-audit`.
+It generates, but does not persist or transmit, one validated FHIR R4B `Provenance`
+resource and ordered `AuditEvent` resources from the existing local lineage and audit
+trail. The response identifies the local fact with a stable identifier, preserves source
+artifact references, and represents lifecycle action and timestamp only. It deliberately
+excludes clinical-fact values, evidence excerpts, reviewer notes, and private reasoning.
+
+The route first verifies the requesting clinician's existing care-team assignment. It
+does not create a FHIR server endpoint, change local review state, or grant authority to
+an external SMART identity.


### PR DESCRIPTION
## Summary

- Export validated, read-only FHIR R4B Provenance and AuditEvent resources for a clinical fact's lineage and review trail.
- Require assigned-clinician access at the endpoint.
- Retain versioned imported-resource references while excluding fact values, reviewer notes, and private reasoning.

## Verification

- `backend/.venv/bin/pytest backend/tests/unit/services/test_clinical_fact_service.py backend/tests/integration/routers/test_smart_api.py --no-cov` — 10 passed.
- Ruff check and format check — passed.
- Mypy for the changed router and service — passed.

## Manual verification

- The endpoint returns a valid Provenance resource and ordered AuditEvent resources only for an assigned clinician.
- The exported payload excludes clinical values, reviewer notes, and private reasoning.

## Required checklist

- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.
