### PR TITLE
fix: remove legacy fixture email accounts

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -145,6 +145,7 @@ The two obsolete audit branches and the April 29 stash were deleted on 2026-08-2
 - [x] Map supported source content into two clinics, sixteen synthetic accounts, care teams, conditions, allergies, medications, metadata-only documents, appointments, five reviewed portal messages, and in-portal notifications.
 - [x] Keep unsupported preferences, proxies, accessibility data, non-portal concerns, adherence events, and care-team scopes unpersisted and documented rather than inventing schema or false records.
 - [x] Make seed/reset idempotent and guarded by environment, explicit confirmation, exact fixture-account deletion, and a migration-checksum preflight.
+- [x] Remove the six verified pre-canonical staging identities through the exact reset allowlist, then verify that only the sixteen current fixture accounts remain.
 - [x] Document deterministic fixture accounts without embedding secrets in the repository.
 - [x] Run the approved staging seed and verify table counts, source-specific mappings, ledger checksums, and idempotency.
 - [/] Verify RLS isolation and clinician/patient login journeys against the seeded staging environment. Patient password login, role-claim validation, live feed, and live adherence statistics passed on 2026-08-27 after the guarded reset/reseed; clinician and RLS-isolation journeys remain.
@@ -179,6 +180,12 @@ The two obsolete audit branches and the April 29 stash were deleted on 2026-08-2
   `SELECT` on all three required tables while `anon` and `authenticated` do not gain
   access to `reminder_schedules`. A new patient login then returned `200` from both
   live endpoints, and Cloud Run had no fresh error log in the following five minutes.
+- On 2026-08-27, a follow-up staging audit found six older named fixture identities
+  under the invalid `.local` namespace. The reset allowlist now includes only those
+  six verified addresses (not a broad domain match). The authorized reset/reseed
+  completed successfully; Auth, patients, and clinicians now contain exactly 16,
+  8, and 8 project-controlled `accounts.mediagent.live` addresses respectively,
+  with no legacy address remaining.
 
 **R0 exit gate**
 

--- a/apps/clinician-portal/src/__tests__/sidebar.test.tsx
+++ b/apps/clinician-portal/src/__tests__/sidebar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "@/components/layouts/sidebar";
-import { hydrateSession } from "@/store/slices/auth-slice";
+import { hydrateSession, logout } from "@/store/slices/auth-slice";
 import { store } from "@/store/store";
 
 const replaceMock = vi.fn();
@@ -70,5 +70,18 @@ describe("Sidebar", () => {
         expect(screen.getByText("Clinic Admin")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: /logout/i })).toBeInTheDocument();
         expect(screen.getByRole("link", { name: /risk radar/i }).className).toContain("bg-blue-600");
+    });
+
+    it("does not invent an invalid fallback email when the session is unavailable", () => {
+        store.dispatch(logout());
+
+        render(
+            <Provider store={store}>
+                <Sidebar />
+            </Provider>,
+        );
+
+        expect(screen.getByText("Email unavailable")).toBeInTheDocument();
+        expect(screen.queryByText("clinician@mediagent.local")).not.toBeInTheDocument();
     });
 });

--- a/apps/clinician-portal/src/components/layouts/sidebar.tsx
+++ b/apps/clinician-portal/src/components/layouts/sidebar.tsx
@@ -76,7 +76,7 @@ export function Sidebar() {
         };
     }, [token]);
 
-    const email = user?.email ?? "clinician@mediagent.local";
+    const email = user?.email ?? "Email unavailable";
     const displayName = profile ? `${profile.first_name} ${profile.last_name}` : "Clinician";
     const roleMeta = getRoleMeta(profile?.role ?? user?.role ?? PortalUserRole.CLINICIAN);
     const initials = displayName

--- a/backend/scripts/seed_demo_environment.py
+++ b/backend/scripts/seed_demo_environment.py
@@ -100,6 +100,24 @@ FIXTURE_EMAIL_LOCAL_PARTS = {
     "SYN-ADMIN-001": "carmen.ortiz",
     "SYN-ADMIN-002": "jordan.lee",
 }
+# These six names were used by the pre-canonical staging fixture. They are
+# exact, verified historical aliases rather than a domain-wide deletion rule.
+# Keep patients separate so reset continues to remove dependent patient records
+# before the clinicians that uploaded or managed them.
+HISTORICAL_FIXTURE_PATIENT_EMAILS = frozenset(
+    {
+        "maria.garcia@demo.mediagent.local",
+        "jose.martinez@demo.mediagent.local",
+    }
+)
+HISTORICAL_FIXTURE_STAFF_EMAILS = frozenset(
+    {
+        "dr.avery@demo.mediagent.local",
+        "dr.rivera@demo.mediagent.local",
+        "nurse.taylor@demo.mediagent.local",
+        "staff.chen@demo.mediagent.local",
+    }
+)
 
 
 def _rows(result: Any) -> list[dict[str, Any]]:
@@ -467,11 +485,14 @@ def seed(client: Any, password: str) -> None:
         )
 
 
-def _reserved_demo_user_ids(client: Any, source_ids: Iterable[str]) -> list[str]:
+def _reserved_demo_user_ids(
+    client: Any, source_ids: Iterable[str], *, historical_emails: Iterable[str] = ()
+) -> list[str]:
     """Return exact fixture Auth IDs for one profile type, never a broad domain match."""
     expected_emails = {
         email for source_id in source_ids for email in fixture_email_aliases(source_id)
     }
+    expected_emails.update(email.lower() for email in historical_emails)
     user_ids: list[str] = []
     page = 1
     while True:
@@ -496,9 +517,15 @@ def reset(client: Any) -> None:
     # their patient. Remove fixture patients first so their dependent records
     # disappear before the fixture clinicians are deleted.
     patient_user_ids = _reserved_demo_user_ids(
-        client, (patient.source_id for patient in fixture.patients)
+        client,
+        (patient.source_id for patient in fixture.patients),
+        historical_emails=HISTORICAL_FIXTURE_PATIENT_EMAILS,
     )
-    staff_user_ids = _reserved_demo_user_ids(client, (staff.source_id for staff in fixture.staff))
+    staff_user_ids = _reserved_demo_user_ids(
+        client,
+        (staff.source_id for staff in fixture.staff),
+        historical_emails=HISTORICAL_FIXTURE_STAFF_EMAILS,
+    )
     for user_id in [*patient_user_ids, *staff_user_ids]:
         client.auth.admin.delete_user(user_id)
     client.table("clinics").delete().in_(

--- a/backend/tests/integration/test_demo_seed_adapter.py
+++ b/backend/tests/integration/test_demo_seed_adapter.py
@@ -239,12 +239,26 @@ def test_reset_deletes_only_exact_canonical_fixture_users(monkeypatch: pytest.Mo
             id="legacy-fixture",
             email=f"{fixture.patients[1].source_id.lower()}@demo.mediagent.local",
         ),
+        SimpleNamespace(
+            id="historical-patient",
+            email="maria.garcia@demo.mediagent.local",
+        ),
+        SimpleNamespace(
+            id="historical-staff",
+            email="dr.avery@demo.mediagent.local",
+        ),
         SimpleNamespace(id="unrelated", email="other@demo.mediagent.local"),
     ]
 
     seed_adapter.reset(client)
 
     assert [user.id for user in client.auth.admin.users] == ["unrelated"]
+    assert client.auth.admin.deleted_user_ids == [
+        "fixture",
+        "historical-patient",
+        "legacy-fixture",
+        "historical-staff",
+    ]
 
 
 def test_reset_deletes_fixture_patients_before_fixture_staff(

--- a/docs/demo-environment.md
+++ b/docs/demo-environment.md
@@ -42,7 +42,11 @@ The adapter uses named fictional accounts in the project-controlled
 `accounts.mediagent.live` namespace. The source IDs remain internal provenance
 identifiers; the account emails and persisted display labels are coherent fictional
 names. The reset recognizes the two prior source-ID email namespaces only so it can
-remove the exact old fixture accounts safely.
+remove the exact old fixture accounts safely. It also recognizes the six verified
+named accounts from the pre-canonical fixture; this remains an explicit allowlist,
+not a domain-wide deletion rule. After a reset, verify that the Auth user inventory
+and the `patients` and `clinicians` profiles contain only the sixteen current
+`accounts.mediagent.live` fixture addresses.
 
 ## Reset
 


### PR DESCRIPTION
## Summary

- Remove six verified pre-canonical fixture accounts through an exact reset allowlist.
- Retain protection against broad reserved-domain deletion.
- Replace the clinician sidebar's invalid fallback email with a neutral unavailable state.

## Staging verification

- Authorized reset/reseed completed.
- Auth: 16 accounts, all under `accounts.mediagent.live`.
- Profiles: 8 patients and 8 clinicians, with no legacy address remaining.

## Local verification

- `backend/.venv/bin/pytest backend/tests/unit/db/test_demo_data.py backend/tests/integration/test_demo_seed_adapter.py --no-cov` — 12 passed.
- Ruff, format check, and mypy — passed.
- Clinician sidebar test, lint, and type check — passed.

## Manual verification

- After the guarded staging reset/reseed, Auth, `patients`, and `clinicians` contain only the expected project-controlled fixture addresses.
- The sidebar renders a neutral label rather than an invented email when no session profile is available.

## Required checklist

- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.
