### PR TITLE
feat: support SMART EHR launch context

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -231,7 +231,7 @@ uses the compatible R4B model.
 
 - [x] Implement `/api/v1/smart/launch` and `/api/v1/smart/callback`.
 - [/] Validate PKCE, OAuth state, issuer, and expiry; token audience/scope conformance awaits a live sandbox registration.
-- [x] Consume patient and encounter launch context.
+- [/] Bind EHR `iss` and opaque `launch` context to a locally authenticated, care-team-authorized clinician/patient selection; standalone patient/encounter context handling is implemented, while live sandbox verification remains.
 - [/] Import the supported patient bundle; live public-sandbox verification awaits the replacement Supabase project and Cloud Run callback.
 - [/] Show import status, raw-resource warnings, and review handoff in the clinician portal; lineage inspection is exposed by API.
 - [x] Document sandbox setup and reproducible conformance test.

--- a/.agent/specs/int-002-003-interoperability-plan.md
+++ b/.agent/specs/int-002-003-interoperability-plan.md
@@ -87,10 +87,13 @@ are present. Do not reuse Supabase JWT configuration for SMART validation.
 
 ### Backend flow
 
-1. `GET /api/v1/smart/launch` accepts an EHR-launch `iss` and `launch` handle, or a
-   documented standalone sandbox mode. It validates the issuer, retrieves SMART
-   configuration, creates a short-lived launch session, generates PKCE values and state,
-   then redirects to the authorization endpoint.
+1. The clinician portal launch route accepts the EHR's `iss` and opaque `launch` handle.
+   It requires an existing local clinician session and a selected, locally assigned patient,
+   then sends them to protected `POST /api/v1/smart/launch`. The backend validates the
+   issuer, retrieves SMART configuration, creates a short-lived launch session, generates
+   PKCE values and state, encrypts the opaque handle at rest, and redirects to the
+   authorization endpoint. In standalone mode, the same protected endpoint omits the
+   opaque handle and requests patient/encounter launch context instead.
 2. `GET /api/v1/smart/callback` rejects provider errors, missing or mismatched state,
    expired/replayed sessions, an unexpected issuer/audience, and insufficient scopes.
    It exchanges the code server-side and captures patient and encounter context.

--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,9 @@ SMART_REDIRECT_URI=http://localhost:8000/api/v1/smart/callback
 SMART_STATE_ENCRYPTION_KEY=
 # Comma-separated HTTPS FHIR base URLs permitted in this environment.
 SMART_ALLOWED_ISSUERS=https://launch.smarthealthit.org/v/r4/fhir
-SMART_SCOPES="launch/patient launch/encounter patient/Patient.read patient/Encounter.read patient/Condition.read patient/AllergyIntolerance.read patient/MedicationRequest.read patient/MedicationStatement.read patient/Observation.read patient/DiagnosticReport.read patient/Procedure.read patient/CarePlan.read patient/DocumentReference.read"
+# Launch-context scopes are selected by the backend: launch for EHR launch;
+# launch/patient and launch/encounter for standalone sandbox launch.
+SMART_SCOPES="patient/Patient.read patient/Encounter.read patient/Condition.read patient/AllergyIntolerance.read patient/MedicationRequest.read patient/MedicationStatement.read patient/Observation.read patient/DiagnosticReport.read patient/Procedure.read patient/CarePlan.read patient/DocumentReference.read"
 SMART_LAUNCH_TTL_SECONDS=600
 SMART_HANDOFF_TTL_SECONDS=300
 

--- a/apps/clinician-portal/src/__tests__/smart-import-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/smart-import-page.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { get, post, replace, setSearchParams, getSearchParams, assign, replaceState } = vi.hoisted(() => {
+    let searchParamsString = "";
+    return {
+        get: vi.fn(),
+        post: vi.fn(),
+        replace: vi.fn(),
+        setSearchParams: (value: string) => {
+            searchParamsString = value;
+        },
+        getSearchParams: () => new URLSearchParams(searchParamsString),
+        assign: vi.fn(),
+        replaceState: vi.fn(),
+    };
+});
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace, push: vi.fn() }),
+    useSearchParams: () => getSearchParams(),
+}));
+
+vi.mock("react-redux", () => ({
+    useSelector: () => "local-clinician-token",
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { get, post },
+}));
+
+import SmartImportPage from "@/app/(dashboard)/smart-import/page";
+
+describe("SMART import page", () => {
+    beforeEach(() => {
+        get.mockReset();
+        post.mockReset();
+        replace.mockReset();
+        assign.mockReset();
+        replaceState.mockReset();
+        setSearchParams("");
+        Object.defineProperty(window, "location", {
+            configurable: true,
+            value: { ...window.location, assign },
+        });
+        Object.defineProperty(window.history, "replaceState", {
+            configurable: true,
+            value: replaceState,
+        });
+        get.mockResolvedValue([
+            { id: "patient-1", first_name: "Maria", last_name: "Garcia", email: "maria@accounts.mediagent.live" },
+        ]);
+    });
+
+    it("binds an EHR launch handle to the locally selected patient without displaying it", async () => {
+        setSearchParams("iss=https%3A%2F%2Flaunch.smarthealthit.org%2Fv%2Fr4%2Ffhir&launch=opaque-ehr-handle");
+        post.mockResolvedValue({ authorization_url: "https://sandbox.example/authorize" });
+
+        render(<SmartImportPage />);
+
+        await screen.findByRole("button", { name: /launch sandbox import/i });
+        expect(screen.getByText(/ehr launch context received/i)).toBeInTheDocument();
+        expect(screen.queryByText("opaque-ehr-handle")).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/smart issuer/i)).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /launch sandbox import/i }));
+
+        await waitFor(() => {
+            expect(post).toHaveBeenCalledWith(
+                "/api/v1/smart/launch",
+                {
+                    patient_id: "patient-1",
+                    issuer: "https://launch.smarthealthit.org/v/r4/fhir",
+                    launch_context: "opaque-ehr-handle",
+                },
+                { token: "local-clinician-token" },
+            );
+        });
+        expect(replaceState).toHaveBeenCalledWith({}, "", "/smart-import");
+        expect(assign).toHaveBeenCalledWith("https://sandbox.example/authorize");
+    });
+
+    it("refuses an incomplete EHR context before posting", async () => {
+        setSearchParams("iss=https%3A%2F%2Flaunch.smarthealthit.org%2Fv%2Fr4%2Ffhir");
+
+        render(<SmartImportPage />);
+
+        await screen.findByRole("button", { name: /launch sandbox import/i });
+        fireEvent.click(screen.getByRole("button", { name: /launch sandbox import/i }));
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(/launch context is incomplete/i);
+        expect(post).not.toHaveBeenCalled();
+    });
+});

--- a/apps/clinician-portal/src/app/(dashboard)/smart-import/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/smart-import/page.tsx
@@ -49,6 +49,10 @@ export default function SmartImportPage() {
     const [starting, setStarting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [handoff, setHandoff] = useState<HandoffResponse | null>(null);
+    const ehrIssuer = searchParams?.get("iss") ?? null;
+    const ehrLaunchContext = searchParams?.get("launch") ?? null;
+    const hasEhrLaunch = Boolean(ehrIssuer && ehrLaunchContext);
+    const hasIncompleteEhrLaunch = Boolean(ehrIssuer || ehrLaunchContext) && !hasEhrLaunch;
 
     const selectedPatient = useMemo(
         () => patients.find((patient) => patient.id === patientId),
@@ -73,6 +77,12 @@ export default function SmartImportPage() {
     }, [loadPatients]);
 
     useEffect(() => {
+        if (ehrIssuer) {
+            setIssuer(ehrIssuer);
+        }
+    }, [ehrIssuer]);
+
+    useEffect(() => {
         const ticket = searchParams?.get("ticket");
         if (!ticket || !token) return;
         void (async () => {
@@ -89,14 +99,26 @@ export default function SmartImportPage() {
 
     const startLaunch = async () => {
         if (!token || !patientId) return;
+        if (hasIncompleteEhrLaunch) {
+            setError("The EHR launch context is incomplete. Return to the EHR and launch again.");
+            return;
+        }
         setStarting(true);
         setError(null);
         try {
             const result = await api.post<{ authorization_url: string }>(
                 "/api/v1/smart/launch",
-                { patient_id: patientId, issuer },
+                {
+                    patient_id: patientId,
+                    issuer,
+                    ...(hasEhrLaunch ? { launch_context: ehrLaunchContext } : {}),
+                },
                 { token },
             );
+            if (hasEhrLaunch) {
+                // Do not retain the opaque EHR launch handle in local history.
+                window.history.replaceState({}, "", "/smart-import");
+            }
             window.location.assign(result.authorization_url);
         } catch (launchError) {
             setError(launchError instanceof Error ? launchError.message : "Unable to start SMART launch.");
@@ -137,13 +159,20 @@ export default function SmartImportPage() {
                         ))}
                     </select>
                 </div>
-                <Input
-                    id="smart-issuer"
-                    label="SMART issuer"
-                    value={issuer}
-                    onChange={(event) => setIssuer(event.target.value)}
-                    autoComplete="off"
-                />
+                {hasEhrLaunch ? (
+                    <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+                        EHR launch context received. Your local clinician session and selected patient still
+                        control whether this sandbox import can begin.
+                    </div>
+                ) : (
+                    <Input
+                        id="smart-issuer"
+                        label="SMART issuer"
+                        value={issuer}
+                        onChange={(event) => setIssuer(event.target.value)}
+                        autoComplete="off"
+                    />
+                )}
                 {error && <p role="alert" className="text-sm text-red-700">{error}</p>}
                 <Button onClick={() => void startLaunch()} disabled={starting || !selectedPatient}>
                     {starting ? "Opening SMART launch…" : "Launch sandbox import"}

--- a/backend/src/app/config.py
+++ b/backend/src/app/config.py
@@ -84,8 +84,8 @@ class Settings(BaseSettings):
     smart_state_encryption_key: str = ""
     smart_allowed_issuers: str = "https://launch.smarthealthit.org/v/r4/fhir"
     smart_scopes: str = (
-        "launch/patient launch/encounter patient/Patient.read patient/Encounter.read "
-        "patient/Condition.read patient/AllergyIntolerance.read patient/MedicationRequest.read "
+        "patient/Patient.read patient/Encounter.read patient/Condition.read "
+        "patient/AllergyIntolerance.read patient/MedicationRequest.read "
         "patient/MedicationStatement.read patient/Observation.read patient/DiagnosticReport.read "
         "patient/Procedure.read patient/CarePlan.read patient/DocumentReference.read"
     )

--- a/backend/src/app/models/fhir_import.py
+++ b/backend/src/app/models/fhir_import.py
@@ -19,10 +19,16 @@ class FhirImportStatus(StrEnum):
 
 
 class SmartLaunchRequest(BaseModel):
-    """A locally authorized request to start a SMART launch for one patient."""
+    """A locally authorized request to start a SMART launch for one patient.
+
+    ``launch_context`` is the opaque EHR-launch handle.  It is accepted only
+    after local clinician and care-team authorization, and is never returned to
+    the browser by this API.
+    """
 
     patient_id: UUID
     issuer: HttpUrl
+    launch_context: str | None = Field(default=None, min_length=1, max_length=2048)
 
     @field_validator("issuer")
     @classmethod

--- a/backend/src/app/routers/smart.py
+++ b/backend/src/app/routers/smart.py
@@ -49,6 +49,7 @@ async def start_launch(
         clinician_id=user.id,
         patient_id=request.patient_id,
         issuer=str(request.issuer),
+        launch_context=request.launch_context,
     )
 
 

--- a/backend/src/app/services/smart_launch_service.py
+++ b/backend/src/app/services/smart_launch_service.py
@@ -27,8 +27,20 @@ class SmartLaunchService:
         self.http = http_client or httpx.Client(timeout=15.0, follow_redirects=False)
         self.imports = FhirImportService(db)
 
-    def start_launch(self, *, clinician_id: UUID, patient_id: UUID, issuer: str) -> dict[str, Any]:
-        """Create a PKCE-bound session after confirming local care-team authority."""
+    def start_launch(
+        self,
+        *,
+        clinician_id: UUID,
+        patient_id: UUID,
+        issuer: str,
+        launch_context: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a PKCE-bound session after confirming local care-team authority.
+
+        An EHR may supply an opaque ``launch`` handle alongside ``iss``.  It is
+        echoed only to the authorization endpoint and stored encrypted for the
+        short lifetime of the session; it never substitutes for local authority.
+        """
         self._require_config()
         self._require_assignment(clinician_id, patient_id)
         issuer = self._validate_issuer(issuer)
@@ -37,15 +49,20 @@ class SmartLaunchService:
         verifier = secrets.token_urlsafe(64)
         nonce = secrets.token_urlsafe(24)
         expires_at = datetime.now(UTC) + timedelta(seconds=settings.smart_launch_ttl_seconds)
+        cipher = self._cipher()
+        requested_scopes = self._requested_scopes(launch_context)
         payload = {
             "state_hash": self._digest(state),
-            "pkce_verifier_ciphertext": self._cipher().encrypt(verifier.encode()).decode(),
+            "pkce_verifier_ciphertext": cipher.encrypt(verifier.encode()).decode(),
             "issuer": issuer,
             "authorization_endpoint": configuration["authorization_endpoint"],
             "token_endpoint": configuration["token_endpoint"],
+            "launch_context": (
+                cipher.encrypt(launch_context.encode()).decode() if launch_context else None
+            ),
             "clinician_id": str(clinician_id),
             "patient_id": str(patient_id),
-            "requested_scopes": settings.smart_scopes,
+            "requested_scopes": requested_scopes,
             "nonce": nonce,
             "expires_at": expires_at.isoformat(),
         }
@@ -56,13 +73,15 @@ class SmartLaunchService:
             "response_type": "code",
             "client_id": settings.smart_client_id,
             "redirect_uri": self._redirect_uri(),
-            "scope": settings.smart_scopes,
+            "scope": requested_scopes,
             "aud": issuer,
             "state": state,
             "nonce": nonce,
             "code_challenge": self._code_challenge(verifier),
             "code_challenge_method": "S256",
         }
+        if launch_context:
+            params["launch"] = launch_context
         return {
             "authorization_url": f"{configuration['authorization_endpoint']}?{urlencode(params)}",
             "expires_at": expires_at,
@@ -366,6 +385,23 @@ class SmartLaunchService:
             .rstrip(b"=")
             .decode()
         )
+
+    @staticmethod
+    def _requested_scopes(launch_context: str | None) -> str:
+        """Use the SMART scope appropriate to standalone or EHR launch.
+
+        ``launch/patient`` and ``launch/encounter`` request context for a
+        standalone launch.  An EHR launch instead requires the generic
+        ``launch`` scope and the opaque launch handle in the authorization
+        request.  Resource-read scopes remain configuration-owned.
+        """
+        configured = [
+            scope
+            for scope in settings.smart_scopes.split()
+            if scope not in {"launch", "launch/patient", "launch/encounter"}
+        ]
+        context_scopes = ["launch"] if launch_context else ["launch/patient", "launch/encounter"]
+        return " ".join([*context_scopes, *configured])
 
     @staticmethod
     def _expired(value: Any) -> bool:

--- a/backend/tests/integration/routers/test_smart_api.py
+++ b/backend/tests/integration/routers/test_smart_api.py
@@ -58,7 +58,37 @@ def test_start_launch_requires_local_clinician_and_returns_redirect_url(
     assert authorization_url.netloc == "sandbox.example"
     assert authorization_url.path == "/authorize"
     smart_service.start_launch.assert_called_once_with(
-        clinician_id=clinician.id, patient_id=patient_id, issuer="https://sandbox.example/fhir"
+        clinician_id=clinician.id,
+        patient_id=patient_id,
+        issuer="https://sandbox.example/fhir",
+        launch_context=None,
+    )
+
+
+def test_start_launch_binds_ehr_launch_context_to_local_clinician_and_patient(
+    client, smart_service, clinician
+) -> None:
+    patient_id = uuid4()
+    smart_service.start_launch.return_value = {
+        "authorization_url": "https://sandbox.example/authorize?state=opaque",
+        "expires_at": datetime.now(UTC) + timedelta(minutes=10),
+    }
+
+    response = client.post(
+        "/api/v1/smart/launch",
+        json={
+            "patient_id": str(patient_id),
+            "issuer": "https://sandbox.example/fhir",
+            "launch_context": "opaque-ehr-handle",
+        },
+    )
+
+    assert response.status_code == 200
+    smart_service.start_launch.assert_called_once_with(
+        clinician_id=clinician.id,
+        patient_id=patient_id,
+        issuer="https://sandbox.example/fhir",
+        launch_context="opaque-ehr-handle",
     )
 
 

--- a/backend/tests/unit/services/test_smart_launch_service.py
+++ b/backend/tests/unit/services/test_smart_launch_service.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
 
 import pytest
+from cryptography.fernet import Fernet
 
+from app.config import settings
 from app.core.exceptions import ExternalServiceError, ValidationError
 from app.services.smart_launch_service import SmartLaunchService
 
 
 def test_code_challenge_is_s256_and_state_digest_is_not_reversible() -> None:
-    assert SmartLaunchService._code_challenge("verifier") == "iMnq5o6zALKXGivsnlom_0F5_WYda32GHkxlV7mq7hQ"
+    assert (
+        SmartLaunchService._code_challenge("verifier")
+        == "iMnq5o6zALKXGivsnlom_0F5_WYda32GHkxlV7mq7hQ"
+    )
     assert SmartLaunchService._digest("state") != "state"
     assert len(SmartLaunchService._digest("state")) == 64
 
@@ -46,7 +55,9 @@ def test_expiry_handles_past_and_future_timestamps() -> None:
 
 def test_token_response_rejects_invalid_expiry_scope_and_audience() -> None:
     with pytest.raises(ExternalServiceError, match="expiry"):
-        SmartLaunchService._validate_token_response({"access_token": "token"}, issuer="https://sandbox.example")
+        SmartLaunchService._validate_token_response(
+            {"access_token": "token"}, issuer="https://sandbox.example"
+        )
     with pytest.raises(ExternalServiceError, match="scope"):
         SmartLaunchService._validate_token_response(
             {"access_token": "token", "expires_in": 300, "scope": "patient/Observation.read"},
@@ -57,3 +68,52 @@ def test_token_response_rejects_invalid_expiry_scope_and_audience() -> None:
             {"access_token": "token", "expires_in": 300, "aud": "https://other.example"},
             issuer="https://sandbox.example",
         )
+
+
+def test_ehr_launch_encrypts_opaque_context_and_uses_ehr_scope(monkeypatch) -> None:
+    key = Fernet.generate_key().decode()
+    db = MagicMock()
+    insert = db.table.return_value.insert.return_value
+    insert.execute.return_value = SimpleNamespace(data=[{"id": str(uuid4())}])
+    service = SmartLaunchService(db)
+    monkeypatch.setattr(settings, "smart_client_id", "sandbox-client")
+    monkeypatch.setattr(settings, "smart_state_encryption_key", key)
+    monkeypatch.setattr(settings, "smart_redirect_uri", "https://api.example/smart/callback")
+    monkeypatch.setattr(settings, "smart_allowed_issuers", "https://sandbox.example/fhir")
+    monkeypatch.setattr(settings, "smart_scopes", "patient/Patient.read patient/Condition.read")
+    monkeypatch.setattr(service, "_require_assignment", lambda *_: None)
+    monkeypatch.setattr(
+        service,
+        "_discover",
+        lambda _: {
+            "authorization_endpoint": "https://sandbox.example/authorize",
+            "token_endpoint": "https://sandbox.example/token",
+        },
+    )
+
+    result = service.start_launch(
+        clinician_id=uuid4(),
+        patient_id=uuid4(),
+        issuer="https://sandbox.example/fhir",
+        launch_context="opaque-ehr-launch-handle",
+    )
+
+    payload = db.table.return_value.insert.call_args.args[0]
+    assert payload["launch_context"] != "opaque-ehr-launch-handle"
+    assert (
+        Fernet(key.encode()).decrypt(payload["launch_context"].encode()).decode()
+        == "opaque-ehr-launch-handle"
+    )
+    assert payload["requested_scopes"] == "launch patient/Patient.read patient/Condition.read"
+    query = parse_qs(urlparse(result["authorization_url"]).query)
+    assert query["launch"] == ["opaque-ehr-launch-handle"]
+    assert query["scope"] == ["launch patient/Patient.read patient/Condition.read"]
+    assert "launch/patient" not in query["scope"][0]
+
+
+def test_standalone_launch_uses_patient_and_encounter_context_scopes(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "smart_scopes", "patient/Patient.read patient/Condition.read")
+
+    assert SmartLaunchService._requested_scopes(None) == (
+        "launch/patient launch/encounter patient/Patient.read patient/Condition.read"
+    )

--- a/docs/supabase_setup_guide.md
+++ b/docs/supabase_setup_guide.md
@@ -35,10 +35,17 @@ SMART_CLIENT_SECRET=<only if the sandbox registration requires one>
 SMART_REDIRECT_URI=https://YOUR_BACKEND/api/v1/smart/callback
 SMART_STATE_ENCRYPTION_KEY=<a Fernet-compatible key generated in the secret store>
 SMART_ALLOWED_ISSUERS=https://launch.smarthealthit.org/v/r4/fhir
-SMART_SCOPES="launch/patient launch/encounter patient/Patient.read patient/Encounter.read patient/Condition.read patient/AllergyIntolerance.read patient/MedicationRequest.read patient/MedicationStatement.read patient/Observation.read patient/DiagnosticReport.read patient/Procedure.read patient/CarePlan.read patient/DocumentReference.read"
+# The backend adds `launch` for EHR launch or `launch/patient launch/encounter`
+# for standalone launch. Keep this value to least-privilege resource reads.
+SMART_SCOPES="patient/Patient.read patient/Encounter.read patient/Condition.read patient/AllergyIntolerance.read patient/MedicationRequest.read patient/MedicationStatement.read patient/Observation.read patient/DiagnosticReport.read patient/Procedure.read patient/CarePlan.read patient/DocumentReference.read"
 ```
 
-Register the exact `SMART_REDIRECT_URI` with the sandbox. Tokens and authorization codes remain server-side; the browser receives only a short-lived, single-use review handoff.
+Register the exact `SMART_REDIRECT_URI` with the sandbox. For an EHR launch, separately
+register the clinician portal's launch route (for example,
+`https://clinician.mediagent.live/smart-import`) as the app launch URL. The portal receives
+the EHR's `iss` and opaque `launch` handle, then requires local clinician sign-in and local
+care-team/patient selection before the backend begins authorization. Tokens and authorization
+codes remain server-side; the browser receives only a short-lived, single-use review handoff.
 
 ## Verification checklist
 


### PR DESCRIPTION
## Summary

- Accept the EHR issuer and opaque launch context only after local clinician authentication and assigned-patient selection.
- Encrypt the short-lived launch handle at rest, echo it only to the SMART authorization endpoint, and remove it from portal history.
- Derive the correct least-privilege launch scope for EHR versus standalone sandbox launches.
- Document the separate EHR App Launch URL and OAuth callback URI.

## Safety boundary

SMART identity never grants local clinical authority. The protected backend launch route still enforces the existing local clinician and care-team assignment before an import can start. Tokens, authorization codes, and opaque launch handles are not returned to the portal.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Verification

- 11 backend SMART unit and route tests passed.
- Ruff, formatting, and mypy passed for the changed backend surfaces.
- Two clinician-portal page tests, lint, and typecheck passed.
- The clinician portal production build passed with Next webpack.

## Manual verification

After merge and deployment, configure the server-side SMART values, register https://clinician.mediagent.live/smart-import as the EHR App Launch URL, register https://api.mediagent.live/api/v1/smart/callback as the OAuth redirect URI, then complete an R4 sandbox launch as a locally signed-in assigned clinician. Confirm the resulting import remains pending review.

## Follow-up

No remote configuration or sandbox registration is included in this PR.