### PR TITLE
fix: grant backend SMART import access

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -230,6 +230,7 @@ uses the compatible R4B model.
 ### INT-003 — SMART-on-FHIR sandbox launch
 
 - [x] Implement `/api/v1/smart/launch` and `/api/v1/smart/callback`.
+- [/] Grant the trusted backend only the SMART session, import, provenance, and handoff operations it needs; apply and verify the migration in staging.
 - [/] Validate PKCE, OAuth state, issuer, and expiry; token audience/scope conformance awaits a live sandbox registration.
 - [/] Bind EHR `iss` and opaque `launch` context to a locally authenticated, care-team-authorized clinician/patient selection; standalone patient/encounter context handling is implemented, while live sandbox verification remains.
 - [/] Import the supported patient bundle; live public-sandbox verification awaits the replacement Supabase project and Cloud Run callback.

--- a/backend/src/app/db/migrations/026_grant_service_role_smart_import_access.sql
+++ b/backend/src/app/db/migrations/026_grant_service_role_smart_import_access.sql
@@ -1,0 +1,17 @@
+-- SMART launch and import processing runs only in the trusted backend after
+-- local clinician and care-team authorization. Browser roles receive no new
+-- privileges, and the backend has no delete capability for these records.
+
+GRANT SELECT, INSERT, UPDATE ON TABLE
+  public.smart_launch_sessions,
+  public.fhir_imports,
+  public.smart_portal_handoffs,
+  public.clinical_facts
+TO service_role;
+
+GRANT SELECT, INSERT ON TABLE
+  public.fhir_import_resources,
+  public.source_provenances,
+  public.evidence_citations,
+  public.clinical_fact_audit_events
+TO service_role;

--- a/backend/tests/unit/db/test_smart_import_service_role_grants.py
+++ b/backend/tests/unit/db/test_smart_import_service_role_grants.py
@@ -1,0 +1,31 @@
+"""Guard the least-privilege grant contract for the SMART import backend."""
+
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "app"
+    / "db"
+    / "migrations"
+    / "026_grant_service_role_smart_import_access.sql"
+)
+
+
+def test_smart_import_service_role_grants_are_minimal_and_server_only() -> None:
+    migration = MIGRATION_PATH.read_text()
+
+    assert "GRANT SELECT, INSERT, UPDATE ON TABLE" in migration
+    assert "public.smart_launch_sessions" in migration
+    assert "public.fhir_imports" in migration
+    assert "public.smart_portal_handoffs" in migration
+    assert "public.clinical_facts" in migration
+    assert "GRANT SELECT, INSERT ON TABLE" in migration
+    assert "public.fhir_import_resources" in migration
+    assert "public.source_provenances" in migration
+    assert "public.evidence_citations" in migration
+    assert "public.clinical_fact_audit_events" in migration
+    assert "TO service_role" in migration
+    assert "DELETE" not in migration
+    assert "anon" not in migration
+    assert "authenticated" not in migration


### PR DESCRIPTION
## Summary
- grant the trusted backend role only the SMART session, import, provenance, clinical-fact, and handoff operations it uses
- preserve RLS and grant no browser-role or delete access
- add a regression guard for the permission contract

## Verification
- `pytest tests/unit/db/test_smart_import_service_role_grants.py tests/unit/services/test_smart_launch_service.py tests/unit/services/test_fhir_import_service.py --no-cov`
- `ruff check src/app/db/migrations tests/unit/db/test_smart_import_service_role_grants.py`
- `ruff format --check tests/unit/db/test_smart_import_service_role_grants.py`
- `python scripts/validate_migrations.py`
- `mypy src/app/services/smart_launch_service.py src/app/services/fhir_import_service.py`

## Required checklist
- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Manual verification and rollout
After merge, apply migration `026_grant_service_role_smart_import_access.sql` to staging. Sign in as an assigned clinician, complete a SMART EHR launch, select an assigned local patient, launch the sandbox import, then verify the import status, pending clinical facts, and provenance are available only through the clinician review path.