### PR TITLE
Fix SMART import feedback and patient review access

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -234,7 +234,8 @@ uses the compatible R4B model.
 - [/] Validate PKCE, OAuth state, issuer, and expiry; token audience/scope conformance awaits a live sandbox registration.
 - [/] Bind EHR `iss` and opaque `launch` context to a locally authenticated, care-team-authorized clinician/patient selection; standalone patient/encounter context handling is implemented, while live sandbox verification remains.
 - [/] Import the supported patient bundle; live public-sandbox verification awaits the replacement Supabase project and Cloud Run callback.
-- [/] Show import status, raw-resource warnings, and review handoff in the clinician portal; lineage inspection is exposed by API.
+- [/] Show import status, raw-resource warnings, and review handoff in the clinician portal; make idempotent no-new-resource outcomes and in-progress authorization status explicit. Lineage inspection is exposed by API.
+- [/] Repair the least-privilege backend read grant discovered by the live patient-review path; apply and verify it in staging.
 - [x] Document sandbox setup and reproducible conformance test.
 
 **Plan:** Build SMART authorization-code + PKCE handling after the INT-002 import

--- a/apps/clinician-portal/src/__tests__/smart-import-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/smart-import-page.test.tsx
@@ -91,4 +91,25 @@ describe("SMART import page", () => {
         expect(await screen.findByRole("alert")).toHaveTextContent(/launch context is incomplete/i);
         expect(post).not.toHaveBeenCalled();
     });
+
+    it("makes an idempotent import outcome explicit", async () => {
+        setSearchParams("ticket=single-use-ticket-value-that-is-long-enough");
+        post.mockResolvedValue({
+            import_record: {
+                id: "import-1",
+                patient_id: "patient-1",
+                status: "completed_with_warnings",
+                resource_count: 0,
+                candidate_fact_count: 0,
+                warnings: ["No new source resources were imported because this sandbox record was already imported."],
+            },
+            resources: [],
+        });
+
+        render(<SmartImportPage />);
+
+        expect(await screen.findByText(/no new smart records to review/i)).toBeInTheDocument();
+        expect(screen.getByText(/repeat of a previously imported sandbox record/i)).toBeInTheDocument();
+        expect(screen.getByText(/already imported/i)).toBeInTheDocument();
+    });
 });

--- a/apps/clinician-portal/src/app/(dashboard)/smart-import/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/smart-import/page.tsx
@@ -47,6 +47,7 @@ export default function SmartImportPage() {
     const [issuer, setIssuer] = useState(DEFAULT_ISSUER);
     const [loading, setLoading] = useState(true);
     const [starting, setStarting] = useState(false);
+    const [launchStatus, setLaunchStatus] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [handoff, setHandoff] = useState<HandoffResponse | null>(null);
     const ehrIssuer = searchParams?.get("iss") ?? null;
@@ -104,6 +105,7 @@ export default function SmartImportPage() {
             return;
         }
         setStarting(true);
+        setLaunchStatus("Preparing the secure SMART authorization session…");
         setError(null);
         try {
             const result = await api.post<{ authorization_url: string }>(
@@ -115,6 +117,10 @@ export default function SmartImportPage() {
                 },
                 { token },
             );
+            if (!result.authorization_url) {
+                throw new Error("The SMART sandbox did not provide an authorization address.");
+            }
+            setLaunchStatus("Redirecting to the SMART sandbox. Do not refresh this page.");
             if (hasEhrLaunch) {
                 // Do not retain the opaque EHR launch handle in local history.
                 window.history.replaceState({}, "", "/smart-import");
@@ -122,6 +128,7 @@ export default function SmartImportPage() {
             window.location.assign(result.authorization_url);
         } catch (launchError) {
             setError(launchError instanceof Error ? launchError.message : "Unable to start SMART launch.");
+            setLaunchStatus(null);
             setStarting(false);
         }
     };
@@ -174,6 +181,7 @@ export default function SmartImportPage() {
                     />
                 )}
                 {error && <p role="alert" className="text-sm text-red-700">{error}</p>}
+                {launchStatus && <p role="status" className="text-sm text-slate-600">{launchStatus}</p>}
                 <Button onClick={() => void startLaunch()} disabled={starting || !selectedPatient}>
                     {starting ? "Opening SMART launch…" : "Launch sandbox import"}
                 </Button>
@@ -182,10 +190,21 @@ export default function SmartImportPage() {
             {handoff && (
                 <Card className="space-y-4 p-5">
                     <div>
-                        <h2 className="text-lg font-semibold text-slate-900">Import ready for review</h2>
-                        <p className="text-sm text-slate-600">
-                            {handoff.import_record.resource_count} source resources created {handoff.import_record.candidate_fact_count} pending facts.
-                        </p>
+                        <h2 className="text-lg font-semibold text-slate-900">
+                            {handoff.import_record.resource_count === 0
+                                ? "No new SMART records to review"
+                                : "Import ready for review"}
+                        </h2>
+                        {handoff.import_record.resource_count === 0 ? (
+                            <p className="text-sm text-slate-600">
+                                This may be a repeat of a previously imported sandbox record, or the selected
+                                sandbox patient has no supported records. No local clinical truth was changed.
+                            </p>
+                        ) : (
+                            <p className="text-sm text-slate-600">
+                                {handoff.import_record.resource_count} source resources created {handoff.import_record.candidate_fact_count} pending facts.
+                            </p>
+                        )}
                     </div>
                     {handoff.import_record.warnings.length > 0 && (
                         <ul className="list-disc space-y-1 pl-5 text-sm text-amber-800">

--- a/backend/src/app/db/migrations/027_grant_service_role_symptom_report_read.sql
+++ b/backend/src/app/db/migrations/027_grant_service_role_symptom_report_read.sql
@@ -1,0 +1,3 @@
+-- The trusted backend aggregates symptom reports for a locally authorized
+-- clinician's patient deep-dive view. Browser roles receive no new privilege.
+GRANT SELECT ON TABLE public.symptom_reports TO service_role;

--- a/backend/src/app/services/fhir_import_service.py
+++ b/backend/src/app/services/fhir_import_service.py
@@ -73,6 +73,7 @@ class FhirImportService:
         warnings: list[str] = []
         persisted_count = 0
         candidate_count = 0
+        duplicate_count = 0
         for resource in self.expand_bundles(resources):
             resource_type = str(resource.get("resourceType", ""))
             validation_errors = self.validate_resource(resource)
@@ -96,6 +97,7 @@ class FhirImportService:
                 mapping_warnings=mapping_warnings,
             )
             if not is_new:
+                duplicate_count += 1
                 continue
             persisted_count += 1
             if validation_errors or mapping_warnings:
@@ -108,6 +110,11 @@ class FhirImportService:
             ):
                 self.facts.create_candidate(candidate, actor_id=actor_id)
                 candidate_count += 1
+
+        if resources and persisted_count == 0 and duplicate_count:
+            warnings.append(
+                "No new source resources were imported because this sandbox record was already imported."
+            )
 
         return {
             "resources_persisted": persisted_count,

--- a/backend/tests/unit/db/test_patient_deep_dive_service_role_grants.py
+++ b/backend/tests/unit/db/test_patient_deep_dive_service_role_grants.py
@@ -1,0 +1,23 @@
+"""Guard the minimal backend grant required by the patient deep-dive route."""
+
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "app"
+    / "db"
+    / "migrations"
+    / "027_grant_service_role_symptom_report_read.sql"
+)
+
+
+def test_patient_deep_dive_symptom_report_grant_is_server_only() -> None:
+    migration = MIGRATION_PATH.read_text()
+
+    assert "GRANT SELECT ON TABLE public.symptom_reports TO service_role" in migration
+    assert "INSERT" not in migration
+    assert "UPDATE" not in migration
+    assert "DELETE" not in migration
+    assert "anon" not in migration
+    assert "authenticated" not in migration

--- a/backend/tests/unit/services/test_fhir_import_service.py
+++ b/backend/tests/unit/services/test_fhir_import_service.py
@@ -41,9 +41,13 @@ class Table:
             row = {"id": str(uuid4()), "created_at": "2026-08-20T00:00:00Z", **self.payload}
             rows.append(row)
             return Result([row])
-        return Result([
-            row for row in rows if all(str(row.get(column)) == value for column, value in self.filters)
-        ])
+        return Result(
+            [
+                row
+                for row in rows
+                if all(str(row.get(column)) == value for column, value in self.filters)
+            ]
+        )
 
 
 class Database:
@@ -110,6 +114,9 @@ def test_duplicate_resource_does_not_create_duplicate_candidate_facts() -> None:
 
     assert second["resources_persisted"] == 0
     assert second["candidate_facts_created"] == 0
+    assert second["warnings"] == [
+        "No new source resources were imported because this sandbox record was already imported."
+    ]
     assert len(db.store["clinical_facts"]) == 1
 
 

--- a/scripts/apply-supabase-migrations.sh
+++ b/scripts/apply-supabase-migrations.sh
@@ -29,8 +29,12 @@ for migration_path in "$MIGRATIONS_DIR"/*.sql; do
   filename="$(basename "$migration_path")"
   checksum="$(shasum -a 256 "$migration_path" | awk '{print $1}')"
   recorded_checksum="$(psql "$MEDIAGENT_DB_URL" -At -v ON_ERROR_STOP=1 \
-    -v filename="$filename" \
-    -c "SELECT checksum FROM public.schema_migrations WHERE filename = :'filename';")"
+    -v filename="$filename" <<'SQL'
+SELECT checksum
+FROM public.schema_migrations
+WHERE filename = :'filename';
+SQL
+  )"
 
   if [[ -n "$recorded_checksum" ]]; then
     if [[ "$recorded_checksum" != "$checksum" ]]; then


### PR DESCRIPTION
## Summary
- make SMART authorization progress and failures visible in the clinician portal
- explain idempotent no-new-record outcomes and retain duplicate-resource warnings
- grant the backend only the symptom-report read access required by the authorized patient deep-dive
- repair the migration runner checksum lookup with psql variable binding

## Related Tasks / Issues
- Resolves: INT-002 SMART import acceptance follow-up

## Docs Impact
- [ ] No docs update required.
- [x] Updated `.agent/TASKS.md`.
- [ ] Updated `.agent/specs/*` docs.
- [ ] Updated `README.md` and/or `CONTRIBUTING.md`.

## Required Verification Checklist
- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Manual Verification
1. Apply migration 027 after merge and confirm the ledger is synchronized.
2. Sign in to the clinician portal and open an assigned patient detail; the deep-dive view loads without a symptom_reports permission error.
3. Start a SMART sandbox import; authorization progress is visible, and repeat imports explain that no new records were created.

## Validation
- `backend/.venv/bin/pytest backend/tests --no-cov` — 725 passed
- `npm run test`, `npm run lint`, `npm run typecheck` — clinician portal passed
- `npx next build --webpack` — clinician portal passed
- `backend/.venv/bin/python backend/scripts/validate_migrations.py` — 28 migrations
- `bash -n scripts/apply-supabase-migrations.sh`

## Follow-up
- Apply migration 027 to staging only after merge. Browser roles receive no new database privilege.