### PR TITLE
feat: add SMART import review

### DIFF
--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -234,7 +234,7 @@ uses the compatible R4B model.
 - [/] Validate PKCE, OAuth state, issuer, and expiry; token audience/scope conformance awaits a live sandbox registration.
 - [/] Bind EHR `iss` and opaque `launch` context to a locally authenticated, care-team-authorized clinician/patient selection; standalone patient/encounter context handling is implemented, while live sandbox verification remains.
 - [/] Import the supported patient bundle; live public-sandbox verification awaits the replacement Supabase project and Cloud Run callback.
-- [/] Show import status, raw-resource warnings, and review handoff in the clinician portal; make idempotent no-new-resource outcomes and in-progress authorization status explicit. Lineage inspection is exposed by API.
+- [/] Show import status, raw-resource warnings, and review handoff in the clinician portal; make idempotent no-new-resource outcomes and in-progress authorization status explicit. The patient-level SMART imports tab now exposes mapped candidate fields, explicit original-resource inspection, and review actions; live acceptance remains.
 - [/] Repair and verify the least-privilege backend read set for live clinician dashboard and patient-review routes; staging application remains required.
 - [/] Replace the clinician portal's mock roster with live care-team-authorized dashboard data and make SMART authorization progress explicit.
 - [x] Document sandbox setup and reproducible conformance test.

--- a/apps/clinician-portal/src/__tests__/smart-import-page.test.tsx
+++ b/apps/clinician-portal/src/__tests__/smart-import-page.test.tsx
@@ -109,6 +109,13 @@ describe("SMART import page", () => {
         await waitFor(() => expect(assign).toHaveBeenCalledWith("https://sandbox.example/authorize"));
     });
 
+    it("explains that a direct portal visit starts a fresh standalone launch", async () => {
+        render(<SmartImportPage />);
+
+        expect(await screen.findByText(/no ehr launch context is active/i)).toBeInTheDocument();
+        expect(screen.getByText(/does not reuse a previously selected sandbox patient or encounter/i)).toBeInTheDocument();
+    });
+
     it("makes an idempotent import outcome explicit", async () => {
         setSearchParams("ticket=single-use-ticket-value-that-is-long-enough");
         post.mockResolvedValue({

--- a/apps/clinician-portal/src/__tests__/smart-import-review-panel.test.tsx
+++ b/apps/clinician-portal/src/__tests__/smart-import-review-panel.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { get, post } = vi.hoisted(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+}));
+
+vi.mock("react-redux", () => ({
+    useSelector: () => "local-clinician-token",
+}));
+
+vi.mock("@/services/api", () => ({
+    api: { get, post },
+}));
+
+import { SmartImportReviewPanel } from "@/components/features/smart-import-review-panel";
+
+const reviewResponse = {
+    patient_id: "patient-1",
+    review_state: "pending_review" as const,
+    facts: [
+        {
+            id: "fact-1",
+            fact_type: "medication",
+            subject_type: "medication",
+            value: { name: "Metformin", status: "active", dosage: "500 mg daily" },
+            uncertainty: ["Dose form was not supplied."],
+            review_state: "pending_review" as const,
+            created_at: "2026-08-28T00:00:00Z",
+            source: {
+                issuer: "https://sandbox.example/fhir",
+                resource_type: "MedicationRequest",
+                external_resource_id: "med-1",
+                version_id: "2",
+                mapping_warnings: ["Frequency was not supplied."],
+                validation_errors: [],
+            },
+        },
+    ],
+    total_count: 1,
+    state_counts: { pending_review: 1, approved: 0, rejected: 0 },
+    fact_type_counts: { medication: 1 },
+    offset: 0,
+    limit: 25,
+};
+
+describe("SMART import review panel", () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    beforeEach(() => {
+        get.mockReset();
+        post.mockReset();
+        get.mockResolvedValue(reviewResponse);
+    });
+
+    it("shows mapped candidate fields and keeps the original source behind an explicit action", async () => {
+        render(<SmartImportReviewPanel patientId="patient-1" />);
+
+        expect(await screen.findByText("Metformin")).toBeInTheDocument();
+        expect(screen.getByText("MedicationRequest · med-1 · version 2")).toBeInTheDocument();
+        expect(screen.getByText(/frequency was not supplied/i)).toBeInTheDocument();
+        expect(screen.getByText(/does not overwrite the local record/i)).toBeInTheDocument();
+        expect(get).toHaveBeenCalledWith(
+            "/api/v1/smart/patients/patient-1/facts?review_state=pending_review&offset=0&limit=25",
+            { token: "local-clinician-token" },
+        );
+
+        get.mockResolvedValueOnce({
+            ...reviewResponse.facts[0].source,
+            raw_resource: { resourceType: "MedicationRequest", id: "med-1" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /source/i }));
+
+        await waitFor(() => {
+            expect(get).toHaveBeenLastCalledWith(
+                "/api/v1/smart/patients/patient-1/facts/fact-1/source",
+                { token: "local-clinician-token" },
+            );
+        });
+        expect(
+            await screen.findByText((_, element) =>
+                element?.tagName === "PRE" && element.textContent?.includes('"resourceType": "MedicationRequest"') === true,
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it("submits explicit review actions as JSON request bodies", async () => {
+        render(<SmartImportReviewPanel patientId="patient-1" />);
+
+        await screen.findByText("Metformin");
+        post.mockResolvedValue({});
+        fireEvent.click(screen.getByRole("button", { name: /^approve$/i }));
+
+        await waitFor(() => {
+            expect(post).toHaveBeenCalledWith(
+                "/api/v1/smart/patients/patient-1/facts/fact-1/approve",
+                {},
+                { token: "local-clinician-token" },
+            );
+        });
+    });
+});

--- a/apps/clinician-portal/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/patients/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
     HiOutlineDocumentText,
     HiOutlineExclamationTriangle,
     HiOutlineIdentification,
+    HiOutlineLink,
     HiOutlineSparkles,
 } from "react-icons/hi2";
 import { Card, Skeleton } from "@/components/ui";
@@ -19,6 +20,7 @@ import { AdherenceChart } from "@/components/features/adherence-chart";
 import { SymptomTimeline } from "@/components/features/symptom-timeline";
 import { ChatTranscript } from "@/components/features/chat-transcript";
 import { PatientDocumentsPanel } from "@/components/features/patient-documents-panel";
+import { SmartImportReviewPanel } from "@/components/features/smart-import-review-panel";
 import {
     loadPatientDeepDive,
     triggerSoapNote,
@@ -28,10 +30,11 @@ import type { AppDispatch, RootState } from "@/store/store";
 
 // ── Tab types ─────────────────────────────────────────────────────────────────
 
-type TabId = "profile" | "adherence" | "symptoms" | "chat" | "soap" | "documents";
+type TabId = "profile" | "imports" | "adherence" | "symptoms" | "chat" | "soap" | "documents";
 
 const TABS: Array<{ id: TabId; label: string; icon: typeof HiOutlineIdentification }> = [
     { id: "profile", label: "Profile", icon: HiOutlineIdentification },
+    { id: "imports", label: "SMART imports", icon: HiOutlineLink },
     { id: "adherence", label: "Adherence", icon: HiOutlineBeaker },
     { id: "symptoms", label: "Symptoms", icon: HiOutlineExclamationTriangle },
     { id: "chat", label: "Chat Transcript", icon: HiOutlineChatBubbleLeftRight },
@@ -232,6 +235,8 @@ function PatientDeepDivePageContent() {
 
             {/* Tab panels */}
             <Card padding="lg">
+                {activeTab === "imports" && <SmartImportReviewPanel patientId={patientId} />}
+
                 {/* ── Profile ── */}
                 {activeTab === "profile" && (
                     <div

--- a/apps/clinician-portal/src/app/(dashboard)/smart-import/page.tsx
+++ b/apps/clinician-portal/src/app/(dashboard)/smart-import/page.tsx
@@ -174,14 +174,20 @@ export default function SmartImportPage() {
                         control whether this sandbox import can begin.
                     </div>
                 ) : (
-                    <Input
-                        id="smart-issuer"
-                        label="SMART issuer"
-                        value={issuer}
-                        disabled={starting}
-                        onChange={(event) => setIssuer(event.target.value)}
-                        autoComplete="off"
-                    />
+                    <>
+                        <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+                            No EHR launch context is active. This starts a fresh SMART sandbox session and does
+                            not reuse a previously selected sandbox patient or encounter.
+                        </div>
+                        <Input
+                            id="smart-issuer"
+                            label="SMART issuer"
+                            value={issuer}
+                            disabled={starting}
+                            onChange={(event) => setIssuer(event.target.value)}
+                            autoComplete="off"
+                        />
+                    </>
                 )}
                 {error && <p role="alert" className="text-sm text-red-700">{error}</p>}
                 {launchStatus && (
@@ -233,7 +239,7 @@ export default function SmartImportPage() {
                             </li>
                         ))}
                     </ul>
-                    <Button variant="secondary" onClick={() => router.push(`/patients/${handoff.import_record.patient_id}`)}>
+                    <Button variant="secondary" onClick={() => router.push(`/patients/${handoff.import_record.patient_id}?tab=imports`)}>
                         Open patient review
                     </Button>
                 </Card>

--- a/apps/clinician-portal/src/components/features/smart-import-review-panel.tsx
+++ b/apps/clinician-portal/src/components/features/smart-import-review-panel.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+    HiOutlineArrowPath,
+    HiOutlineCheckCircle,
+    HiOutlineChevronLeft,
+    HiOutlineChevronRight,
+    HiOutlineDocumentMagnifyingGlass,
+    HiOutlineExclamationCircle,
+    HiOutlinePencilSquare,
+    HiOutlineXCircle,
+} from "react-icons/hi2";
+import { useSelector } from "react-redux";
+import { Card, Modal, Skeleton } from "@/components/ui";
+import { api } from "@/services/api";
+import type { RootState } from "@/store/store";
+
+type ReviewState = "pending_review" | "approved" | "rejected";
+
+interface ReviewSource {
+    issuer: string;
+    resource_type: string;
+    external_resource_id?: string | null;
+    version_id?: string | null;
+    mapping_warnings: string[];
+    validation_errors: string[];
+}
+
+interface ReviewFact {
+    id: string;
+    fact_type: string;
+    subject_type: string;
+    value: Record<string, unknown>;
+    uncertainty: string[];
+    review_state: ReviewState;
+    created_at: string;
+    source?: ReviewSource | null;
+}
+
+interface ReviewResponse {
+    patient_id: string;
+    review_state: ReviewState;
+    facts: ReviewFact[];
+    total_count: number;
+    state_counts: Record<string, number>;
+    fact_type_counts: Record<string, number>;
+    offset: number;
+    limit: number;
+}
+
+interface SourceDetail extends ReviewSource {
+    raw_resource: Record<string, unknown>;
+}
+
+const PAGE_SIZE = 25;
+
+const FACT_LABELS: Record<string, string> = {
+    patient_demographics: "Patient demographics",
+    encounter: "Encounter",
+    condition: "Condition",
+    allergy: "Allergy or intolerance",
+    medication: "Medication",
+    observation: "Observation",
+    diagnostic_report: "Diagnostic report",
+    procedure: "Procedure",
+    care_plan: "Care plan",
+    document_reference: "Document reference",
+};
+
+const FACT_FIELDS: Record<string, Array<[string, string]>> = {
+    patient_demographics: [["name", "Name"], ["birthDate", "Date of birth"], ["gender", "Administrative gender"]],
+    encounter: [["status", "Status"], ["class", "Class"], ["type", "Type"], ["period", "Period"]],
+    condition: [["name", "Condition"], ["clinical_status", "Clinical status"], ["onset", "Onset"]],
+    allergy: [["allergen", "Allergen"], ["clinical_status", "Clinical status"], ["reactions", "Reactions"]],
+    medication: [["name", "Medication"], ["status", "Status"], ["dosage", "Dosage instructions"]],
+    observation: [["code", "Observation"], ["value", "Value"], ["effective", "Effective"], ["status", "Status"]],
+    diagnostic_report: [["code", "Report"], ["conclusion", "Conclusion"], ["status", "Status"]],
+    procedure: [["code", "Procedure"], ["status", "Status"], ["performed", "Performed"]],
+    care_plan: [["title", "Title"], ["description", "Description"], ["status", "Status"], ["intent", "Intent"]],
+    document_reference: [["type", "Type"], ["description", "Description"], ["date", "Document date"], ["status", "Status"]],
+};
+
+function formatValue(value: unknown): string {
+    if (value === null || value === undefined || value === "") return "Not supplied";
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value);
+    if (Array.isArray(value)) return value.length ? value.map(formatValue).join("; ") : "Not supplied";
+    if (typeof value === "object") {
+        const record = value as Record<string, unknown>;
+        if (typeof record.text === "string") return record.text;
+        if (typeof record.display === "string") return record.display;
+        if (typeof record.code === "string") return record.code;
+        if (typeof record.start === "string" || typeof record.end === "string") {
+            return [record.start, record.end].filter(Boolean).join(" to ");
+        }
+        return JSON.stringify(record);
+    }
+    return String(value);
+}
+
+function stateLabel(state: ReviewState): string {
+    return state === "pending_review" ? "Pending review" : state === "approved" ? "Approved" : "Rejected";
+}
+
+function stateClass(state: ReviewState): string {
+    if (state === "approved") return "bg-emerald-100 text-emerald-800";
+    if (state === "rejected") return "bg-rose-100 text-rose-800";
+    return "bg-amber-100 text-amber-800";
+}
+
+function FactDetails({ fact }: { fact: ReviewFact }) {
+    const fields = FACT_FIELDS[fact.fact_type] ?? Object.keys(fact.value).map((key) => [key, key] as [string, string]);
+    return (
+        <dl className="grid gap-x-5 gap-y-2 sm:grid-cols-2">
+            {fields.map(([key, label]) => (
+                <div key={key}>
+                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+                    <dd className="mt-0.5 break-words text-sm text-slate-800">{formatValue(fact.value[key])}</dd>
+                </div>
+            ))}
+        </dl>
+    );
+}
+
+export function SmartImportReviewPanel({ patientId }: { patientId: string }) {
+    const token = useSelector((state: RootState) => state.auth.accessToken);
+    const [reviewState, setReviewState] = useState<ReviewState>("pending_review");
+    const [offset, setOffset] = useState(0);
+    const [review, setReview] = useState<ReviewResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [busyFactId, setBusyFactId] = useState<string | null>(null);
+    const [rejecting, setRejecting] = useState<ReviewFact | null>(null);
+    const [correcting, setCorrecting] = useState<ReviewFact | null>(null);
+    const [note, setNote] = useState("");
+    const [correctedValue, setCorrectedValue] = useState("");
+    const [source, setSource] = useState<{ factId: string; detail: SourceDetail } | null>(null);
+
+    const load = useCallback(async () => {
+        if (!token) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await api.get<ReviewResponse>(
+                `/api/v1/smart/patients/${patientId}/facts?review_state=${reviewState}&offset=${offset}&limit=${PAGE_SIZE}`,
+                { token },
+            );
+            setReview(response);
+        } catch (loadError) {
+            setError(loadError instanceof Error ? loadError.message : "Unable to load imported records.");
+        } finally {
+            setLoading(false);
+        }
+    }, [offset, patientId, reviewState, token]);
+
+    useEffect(() => {
+        void load();
+    }, [load]);
+
+    async function approve(fact: ReviewFact) {
+        if (!token) return;
+        setBusyFactId(fact.id);
+        setError(null);
+        try {
+            await api.post(`/api/v1/smart/patients/${patientId}/facts/${fact.id}/approve`, {}, { token });
+            await load();
+        } catch (reviewError) {
+            setError(reviewError instanceof Error ? reviewError.message : "Unable to approve imported fact.");
+        } finally {
+            setBusyFactId(null);
+        }
+    }
+
+    async function reject() {
+        if (!token || !rejecting || !note.trim()) return;
+        setBusyFactId(rejecting.id);
+        setError(null);
+        try {
+            await api.post(
+                `/api/v1/smart/patients/${patientId}/facts/${rejecting.id}/reject`,
+                { note: note.trim() },
+                { token },
+            );
+            setRejecting(null);
+            setNote("");
+            await load();
+        } catch (reviewError) {
+            setError(reviewError instanceof Error ? reviewError.message : "Unable to reject imported fact.");
+        } finally {
+            setBusyFactId(null);
+        }
+    }
+
+    async function correct() {
+        if (!token || !correcting || !note.trim()) return;
+        let value: Record<string, unknown>;
+        try {
+            value = JSON.parse(correctedValue) as Record<string, unknown>;
+        } catch {
+            setError("Corrected value must be valid JSON.");
+            return;
+        }
+        if (!value || Array.isArray(value)) {
+            setError("Corrected value must be a JSON object.");
+            return;
+        }
+        setBusyFactId(correcting.id);
+        setError(null);
+        try {
+            await api.post(
+                `/api/v1/smart/patients/${patientId}/facts/${correcting.id}/correct`,
+                { value, note: note.trim() },
+                { token },
+            );
+            setCorrecting(null);
+            setCorrectedValue("");
+            setNote("");
+            await load();
+        } catch (reviewError) {
+            setError(reviewError instanceof Error ? reviewError.message : "Unable to correct imported fact.");
+        } finally {
+            setBusyFactId(null);
+        }
+    }
+
+    async function inspectSource(fact: ReviewFact) {
+        if (!token) return;
+        setBusyFactId(fact.id);
+        setError(null);
+        try {
+            const detail = await api.get<SourceDetail>(
+                `/api/v1/smart/patients/${patientId}/facts/${fact.id}/source`,
+                { token },
+            );
+            setSource({ factId: fact.id, detail });
+        } catch (sourceError) {
+            setError(sourceError instanceof Error ? sourceError.message : "Unable to load source FHIR resource.");
+        } finally {
+            setBusyFactId(null);
+        }
+    }
+
+    const total = review?.total_count ?? 0;
+    const start = total ? offset + 1 : 0;
+    const end = Math.min(offset + PAGE_SIZE, total);
+
+    return (
+        <section className="space-y-5" aria-labelledby="smart-import-review-heading">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                    <p className="text-sm font-medium text-blue-700">External-record reconciliation</p>
+                    <h2 className="mt-1 text-xl font-bold text-slate-900" id="smart-import-review-heading">SMART import review</h2>
+                    <p className="mt-1 max-w-3xl text-sm text-slate-600">
+                        Review mapped sandbox facts with resource-level provenance. Approval records a clinician decision; it does not overwrite the local record.
+                    </p>
+                </div>
+                <button className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50" onClick={() => void load()} type="button">
+                    <HiOutlineArrowPath className="h-4 w-4" /> Refresh
+                </button>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+                {(["pending_review", "approved", "rejected"] as ReviewState[]).map((state) => (
+                    <button
+                        aria-pressed={reviewState === state}
+                        className={`rounded-xl border p-4 text-left transition ${reviewState === state ? "border-blue-500 bg-blue-50" : "border-slate-200 bg-white hover:border-slate-300"}`}
+                        key={state}
+                        onClick={() => { setReviewState(state); setOffset(0); }}
+                        type="button"
+                    >
+                        <p className="text-sm text-slate-600">{stateLabel(state)}</p>
+                        <p className="mt-1 text-2xl font-bold text-slate-900">{review?.state_counts[state] ?? 0}</p>
+                    </button>
+                ))}
+            </div>
+
+            {error && <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800" role="alert">{error}</div>}
+
+            <Card className="overflow-hidden px-0 py-0" padding="sm">
+                <div className="flex flex-col gap-2 border-b border-slate-200 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h3 className="font-semibold text-slate-900">{stateLabel(reviewState)} imported facts</h3>
+                        <p className="text-sm text-slate-500">{total} facts in this review state. Source data remains synthetic and read-only.</p>
+                    </div>
+                    {review && Object.keys(review.fact_type_counts).length > 0 && <p className="text-xs text-slate-500">Mapped types: {Object.keys(review.fact_type_counts).map((value) => FACT_LABELS[value] ?? value).join(", ")}</p>}
+                </div>
+
+                {loading ? (
+                    <div className="space-y-4 p-5">{Array.from({ length: 3 }).map((_, index) => <Skeleton className="h-44 w-full" key={index} />)}</div>
+                ) : review?.facts.length === 0 ? (
+                    <div className="flex min-h-48 flex-col items-center justify-center px-5 py-10 text-center">
+                        <HiOutlineCheckCircle className="h-10 w-10 text-emerald-500" />
+                        <p className="mt-3 font-semibold text-slate-900">No {stateLabel(reviewState).toLowerCase()} imported facts</p>
+                        <p className="mt-1 text-sm text-slate-600">A new SMART import will appear here as clinician-review candidates.</p>
+                    </div>
+                ) : (
+                    <div className="divide-y divide-slate-200">
+                        {review?.facts.map((fact) => (
+                            <article className="space-y-4 px-5 py-5" key={fact.id}>
+                                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                                    <div>
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <h4 className="font-semibold text-slate-900">{FACT_LABELS[fact.fact_type] ?? fact.fact_type}</h4>
+                                            <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${stateClass(fact.review_state)}`}>{stateLabel(fact.review_state)}</span>
+                                        </div>
+                                        <p className="mt-1 text-xs text-slate-500">
+                                            {fact.source ? `${fact.source.resource_type}${fact.source.external_resource_id ? ` · ${fact.source.external_resource_id}` : ""}${fact.source.version_id ? ` · version ${fact.source.version_id}` : ""}` : "Source metadata unavailable"}
+                                        </p>
+                                    </div>
+                                    <div className="flex flex-wrap gap-2">
+                                        <button className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60" disabled={busyFactId === fact.id || !fact.source} onClick={() => void inspectSource(fact)} type="button"><HiOutlineDocumentMagnifyingGlass className="h-4 w-4" /> Source</button>
+                                        {fact.review_state === "pending_review" && <>
+                                            <button className="inline-flex items-center gap-1 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-60" disabled={busyFactId === fact.id} onClick={() => void approve(fact)} type="button"><HiOutlineCheckCircle className="h-4 w-4" /> Approve</button>
+                                            <button className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60" disabled={busyFactId === fact.id} onClick={() => { setCorrecting(fact); setCorrectedValue(JSON.stringify(fact.value, null, 2)); setNote(""); }} type="button"><HiOutlinePencilSquare className="h-4 w-4" /> Correct</button>
+                                            <button className="inline-flex items-center gap-1 rounded-lg border border-rose-200 px-3 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-50 disabled:opacity-60" disabled={busyFactId === fact.id} onClick={() => { setRejecting(fact); setNote(""); }} type="button"><HiOutlineXCircle className="h-4 w-4" /> Reject</button>
+                                        </>}
+                                    </div>
+                                </div>
+                                <FactDetails fact={fact} />
+                                {fact.uncertainty.length > 0 && <div className="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800"><HiOutlineExclamationCircle className="mr-1 inline h-4 w-4" />{fact.uncertainty.join(" ")}</div>}
+                                {fact.source && (fact.source.mapping_warnings.length > 0 || fact.source.validation_errors.length > 0) && <div className="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">{[...fact.source.mapping_warnings, ...fact.source.validation_errors].join(" ")}</div>}
+                            </article>
+                        ))}
+                    </div>
+                )}
+                {total > PAGE_SIZE && <div className="flex items-center justify-between border-t border-slate-200 px-5 py-4 text-sm text-slate-600"><span>{start}–{end} of {total}</span><div className="flex gap-2"><button aria-label="Previous imported facts" className="rounded-lg border border-slate-200 p-2 disabled:opacity-40" disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))} type="button"><HiOutlineChevronLeft className="h-4 w-4" /></button><button aria-label="Next imported facts" className="rounded-lg border border-slate-200 p-2 disabled:opacity-40" disabled={offset + PAGE_SIZE >= total} onClick={() => setOffset(offset + PAGE_SIZE)} type="button"><HiOutlineChevronRight className="h-4 w-4" /></button></div></div>}
+            </Card>
+
+            <Modal onClose={() => { if (!busyFactId) { setRejecting(null); setNote(""); } }} open={Boolean(rejecting)} title="Reject imported fact">
+                <div className="space-y-4"><p className="text-sm text-slate-600">Record why this imported candidate should not be used. The original source remains in the audit trail.</p><label className="block text-sm font-medium text-slate-700">Rejection note<textarea className="mt-2 min-h-28 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm" onChange={(event) => setNote(event.target.value)} value={note} /></label><div className="flex justify-end gap-3"><button className="rounded-lg border border-slate-200 px-4 py-2 text-sm" onClick={() => setRejecting(null)} type="button">Cancel</button><button className="rounded-lg bg-rose-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60" disabled={!note.trim() || busyFactId !== null} onClick={() => void reject()} type="button">{busyFactId ? "Saving…" : "Confirm rejection"}</button></div></div>
+            </Modal>
+
+            <Modal onClose={() => { if (!busyFactId) { setCorrecting(null); setNote(""); } }} open={Boolean(correcting)} title="Correct imported fact">
+                <div className="space-y-4"><p className="text-sm text-slate-600">Edit the mapped candidate, not the original FHIR source. The change remains pending review and is audited.</p><label className="block text-sm font-medium text-slate-700">Corrected value (JSON)<textarea className="mt-2 min-h-48 w-full rounded-xl border border-slate-300 px-3 py-2 font-mono text-xs" onChange={(event) => setCorrectedValue(event.target.value)} value={correctedValue} /></label><label className="block text-sm font-medium text-slate-700">Correction note<textarea className="mt-2 min-h-24 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm" onChange={(event) => setNote(event.target.value)} value={note} /></label><div className="flex justify-end gap-3"><button className="rounded-lg border border-slate-200 px-4 py-2 text-sm" onClick={() => setCorrecting(null)} type="button">Cancel</button><button className="rounded-lg bg-blue-700 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60" disabled={!note.trim() || busyFactId !== null} onClick={() => void correct()} type="button">{busyFactId ? "Saving…" : "Save corrected candidate"}</button></div></div>
+            </Modal>
+
+            <Modal onClose={() => setSource(null)} open={Boolean(source)} title="Original SMART FHIR source">
+                {source && <div className="space-y-3"><p className="text-sm text-slate-600">{source.detail.resource_type}{source.detail.external_resource_id ? ` · ${source.detail.external_resource_id}` : ""}{source.detail.version_id ? ` · version ${source.detail.version_id}` : ""}</p><pre className="max-h-[60vh] overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-100">{JSON.stringify(source.detail.raw_resource, null, 2)}</pre></div>}
+            </Modal>
+        </section>
+    );
+}

--- a/backend/src/app/models/fhir_import.py
+++ b/backend/src/app/models/fhir_import.py
@@ -9,6 +9,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, HttpUrl, field_validator
 
+from app.models.clinical_fact import ClinicalFactRead, ClinicalFactReviewState
+
 
 class FhirImportStatus(StrEnum):
     PENDING = "pending"
@@ -70,6 +72,55 @@ class FhirImportResourceRead(BaseModel):
     validation_errors: list[str] = Field(default_factory=list)
     mapping_warnings: list[str] = Field(default_factory=list)
     created_at: datetime
+
+
+class FhirReviewSourceRead(BaseModel):
+    """Minimal, clinician-facing lineage for one imported candidate fact."""
+
+    issuer: str
+    resource_type: str
+    external_resource_id: str | None = None
+    version_id: str | None = None
+    mapping_warnings: list[str] = Field(default_factory=list)
+    validation_errors: list[str] = Field(default_factory=list)
+
+
+class FhirReviewSourceDetailRead(FhirReviewSourceRead):
+    """The original synthetic FHIR envelope for clinician source inspection."""
+
+    raw_resource: dict[str, Any]
+
+
+class FhirReviewFactRead(ClinicalFactRead):
+    """A pending or reviewed fact with the source envelope that produced it."""
+
+    source: FhirReviewSourceRead | None = None
+
+
+class FhirPatientReviewRead(BaseModel):
+    """A paginated, clinician-authorized SMART import review view."""
+
+    patient_id: UUID
+    review_state: ClinicalFactReviewState
+    facts: list[FhirReviewFactRead] = Field(default_factory=list)
+    total_count: int = 0
+    state_counts: dict[str, int] = Field(default_factory=dict)
+    fact_type_counts: dict[str, int] = Field(default_factory=dict)
+    offset: int = 0
+    limit: int = 25
+
+
+class ClinicalFactReviewRequest(BaseModel):
+    """A clinician's explicit review decision without any clinical-value mutation."""
+
+    note: str | None = Field(default=None, max_length=2000)
+
+
+class ClinicalFactCorrectionRequest(BaseModel):
+    """A corrected candidate value and the reason for the correction."""
+
+    value: dict[str, Any] = Field(default_factory=dict)
+    note: str = Field(min_length=1, max_length=2000)
 
 
 class SmartHandoffRedeemRequest(BaseModel):

--- a/backend/src/app/routers/smart.py
+++ b/backend/src/app/routers/smart.py
@@ -14,7 +14,12 @@ from app.core.exceptions import ValidationError
 from app.core.security import require_role
 from app.db.connection import get_db
 from app.models.auth import CurrentUser
+from app.models.clinical_fact import ClinicalFactReviewState
 from app.models.fhir_import import (
+    ClinicalFactCorrectionRequest,
+    ClinicalFactReviewRequest,
+    FhirPatientReviewRead,
+    FhirReviewSourceDetailRead,
     SmartHandoffRedeemRequest,
     SmartHandoffRedeemResponse,
     SmartImportRead,
@@ -23,6 +28,7 @@ from app.models.fhir_import import (
 )
 from app.services.clinical_fact_service import ClinicalFactService
 from app.services.fhir_audit_export_service import FhirAuditExportService
+from app.services.fhir_import_review_service import FhirImportReviewService
 from app.services.smart_launch_service import SmartLaunchService
 
 router = APIRouter()
@@ -35,6 +41,10 @@ def _service(db: Client = Depends(get_db)) -> SmartLaunchService:
 
 def _fhir_audit_export_service(db: Client = Depends(get_db)) -> FhirAuditExportService:
     return FhirAuditExportService(db)
+
+
+def _fhir_import_review_service(db: Client = Depends(get_db)) -> FhirImportReviewService:
+    return FhirImportReviewService(db)
 
 
 @router.post(
@@ -87,23 +97,25 @@ async def list_imports(
     return service.list_imports(clinician_id=user.id, patient_id=patient_id)
 
 
-@router.get("/patients/{patient_id}/facts")
+@router.get("/patients/{patient_id}/facts", response_model=FhirPatientReviewRead)
 async def list_pending_facts(
     patient_id: UUID,
+    review_state: ClinicalFactReviewState = Query(default=ClinicalFactReviewState.PENDING_REVIEW),
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=25, ge=1, le=50),
     user: CurrentUser = Depends(_clinician_dep),
     service: SmartLaunchService = Depends(_service),
-    db: Client = Depends(get_db),
-) -> Any:
+    review_service: FhirImportReviewService = Depends(_fhir_import_review_service),
+) -> FhirPatientReviewRead:
     service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
-    response = (
-        db.table("clinical_facts")
-        .select("*")
-        .eq("patient_id", str(patient_id))
-        .eq("review_state", "pending_review")
-        .order("created_at", desc=True)
-        .execute()
+    return FhirPatientReviewRead.model_validate(
+        review_service.list_facts(
+            patient_id=patient_id,
+            review_state=review_state,
+            offset=offset,
+            limit=limit,
+        )
     )
-    return response.data or []
 
 
 @router.get("/patients/{patient_id}/facts/{fact_id}/lineage")
@@ -116,6 +128,23 @@ async def fact_lineage(
 ) -> Any:
     service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
     return ClinicalFactService(db).get_lineage(fact_id, patient_id)
+
+
+@router.get(
+    "/patients/{patient_id}/facts/{fact_id}/source", response_model=FhirReviewSourceDetailRead
+)
+async def fact_source(
+    patient_id: UUID,
+    fact_id: UUID,
+    user: CurrentUser = Depends(_clinician_dep),
+    service: SmartLaunchService = Depends(_service),
+    review_service: FhirImportReviewService = Depends(_fhir_import_review_service),
+) -> FhirReviewSourceDetailRead:
+    service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
+    source = review_service.get_source(fact_id=fact_id, patient_id=patient_id)
+    if source is None:
+        raise ValidationError("FHIR source is unavailable for this clinical fact")
+    return FhirReviewSourceDetailRead.model_validate(source)
 
 
 @router.get("/patients/{patient_id}/facts/{fact_id}/fhir-audit")
@@ -135,41 +164,44 @@ async def fact_fhir_audit(
 async def approve_fact(
     patient_id: UUID,
     fact_id: UUID,
-    note: str | None = Query(default=None, max_length=2000),
+    request: ClinicalFactReviewRequest,
     user: CurrentUser = Depends(_clinician_dep),
     service: SmartLaunchService = Depends(_service),
     db: Client = Depends(get_db),
 ) -> Any:
     service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
-    return ClinicalFactService(db).approve(fact_id, patient_id, reviewer_id=user.id, note=note)
+    return ClinicalFactService(db).approve(
+        fact_id, patient_id, reviewer_id=user.id, note=request.note
+    )
 
 
 @router.post("/patients/{patient_id}/facts/{fact_id}/reject")
 async def reject_fact(
     patient_id: UUID,
     fact_id: UUID,
-    note: str = Query(min_length=1, max_length=2000),
+    request: ClinicalFactReviewRequest,
     user: CurrentUser = Depends(_clinician_dep),
     service: SmartLaunchService = Depends(_service),
     db: Client = Depends(get_db),
 ) -> Any:
     service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
-    return ClinicalFactService(db).reject(fact_id, patient_id, reviewer_id=user.id, note=note)
+    return ClinicalFactService(db).reject(
+        fact_id, patient_id, reviewer_id=user.id, note=request.note or ""
+    )
 
 
 @router.post("/patients/{patient_id}/facts/{fact_id}/correct")
 async def correct_fact(
     patient_id: UUID,
     fact_id: UUID,
-    value: dict[str, Any],
-    note: str = Query(min_length=1, max_length=2000),
+    request: ClinicalFactCorrectionRequest,
     user: CurrentUser = Depends(_clinician_dep),
     service: SmartLaunchService = Depends(_service),
     db: Client = Depends(get_db),
 ) -> Any:
-    if not value:
+    if not request.value:
         raise ValidationError("Corrected fact value is required")
     service.ensure_assignment(clinician_id=user.id, patient_id=patient_id)
     return ClinicalFactService(db).correct(
-        fact_id, patient_id, actor_id=user.id, value=value, note=note
+        fact_id, patient_id, actor_id=user.id, value=request.value, note=request.note
     )

--- a/backend/src/app/services/fhir_import_review_service.py
+++ b/backend/src/app/services/fhir_import_review_service.py
@@ -1,0 +1,199 @@
+"""Clinician-facing review reads for provenance-backed SMART candidates."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, cast
+from uuid import UUID
+
+from supabase import Client
+
+from app.models.clinical_fact import ClinicalFactReviewState
+
+
+class FhirImportReviewService:
+    """Read mapped FHIR candidates without changing their clinical review state."""
+
+    _FHIR_ENVELOPE_PREFIX = "fhir_import_resources/"
+
+    def __init__(self, db: Client) -> None:
+        self.db = db
+
+    def list_facts(
+        self,
+        *,
+        patient_id: UUID,
+        review_state: ClinicalFactReviewState,
+        offset: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        """Return one review-state page plus small, patient-scoped review counts."""
+        metadata_result = (
+            self.db.table("clinical_facts")
+            .select("fact_type, review_state")
+            .eq("patient_id", str(patient_id))
+            .execute()
+        )
+        metadata = cast(list[dict[str, Any]], metadata_result.data or [])
+        visible_metadata = [
+            row
+            for row in metadata
+            if row.get("review_state") != ClinicalFactReviewState.DELETED.value
+        ]
+        state_counts = Counter(str(row.get("review_state", "unknown")) for row in visible_metadata)
+        fact_type_counts = Counter(str(row.get("fact_type", "unknown")) for row in visible_metadata)
+
+        page_result = (
+            self.db.table("clinical_facts")
+            .select("*")
+            .eq("patient_id", str(patient_id))
+            .eq("review_state", review_state.value)
+            .order("created_at", desc=True)
+            .range(offset, offset + limit - 1)
+            .execute()
+        )
+        facts = cast(list[dict[str, Any]], page_result.data or [])
+        sources = self._sources_for_facts(facts)
+
+        return {
+            "patient_id": str(patient_id),
+            "review_state": review_state.value,
+            "facts": [{**fact, "source": sources.get(str(fact.get("id")))} for fact in facts],
+            "total_count": state_counts.get(review_state.value, 0),
+            "state_counts": dict(state_counts),
+            "fact_type_counts": dict(fact_type_counts),
+            "offset": offset,
+            "limit": limit,
+        }
+
+    def _sources_for_facts(self, facts: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        fact_ids = [str(row["id"]) for row in facts if row.get("id")]
+        if not fact_ids:
+            return {}
+        citations_result = (
+            self.db.table("evidence_citations")
+            .select("fact_id, provenance_id")
+            .in_("fact_id", fact_ids)
+            .execute()
+        )
+        citations = cast(list[dict[str, Any]], citations_result.data or [])
+        provenance_by_fact = {
+            str(row["fact_id"]): str(row["provenance_id"])
+            for row in citations
+            if row.get("fact_id") and row.get("provenance_id")
+        }
+        provenance_ids = sorted(set(provenance_by_fact.values()))
+        if not provenance_ids:
+            return {}
+        provenance_result = (
+            self.db.table("source_provenances")
+            .select("id, source_system, source_reference")
+            .in_("id", provenance_ids)
+            .execute()
+        )
+        provenances = cast(list[dict[str, Any]], provenance_result.data or [])
+        provenance_by_id = {str(row["id"]): row for row in provenances if row.get("id")}
+        envelope_ids = sorted(
+            {
+                str(row["source_reference"])[len(self._FHIR_ENVELOPE_PREFIX) :]
+                for row in provenances
+                if isinstance(row.get("source_reference"), str)
+                and str(row["source_reference"]).startswith(self._FHIR_ENVELOPE_PREFIX)
+            }
+        )
+        if not envelope_ids:
+            return {}
+        envelope_result = (
+            self.db.table("fhir_import_resources")
+            .select(
+                "id, issuer, resource_type, external_resource_id, version_id, mapping_warnings, validation_errors"
+            )
+            .in_("id", envelope_ids)
+            .execute()
+        )
+        envelopes = cast(list[dict[str, Any]], envelope_result.data or [])
+        envelope_by_id = {str(row["id"]): row for row in envelopes if row.get("id")}
+
+        result: dict[str, dict[str, Any]] = {}
+        for fact_id, provenance_id in provenance_by_fact.items():
+            provenance = provenance_by_id.get(provenance_id)
+            if not provenance:
+                continue
+            source_reference = provenance.get("source_reference")
+            if not isinstance(source_reference, str) or not source_reference.startswith(
+                self._FHIR_ENVELOPE_PREFIX
+            ):
+                continue
+            envelope = envelope_by_id.get(source_reference[len(self._FHIR_ENVELOPE_PREFIX) :])
+            if not envelope:
+                continue
+            result[fact_id] = {
+                "issuer": envelope.get("issuer") or provenance.get("source_system"),
+                "resource_type": envelope.get("resource_type") or "FHIR resource",
+                "external_resource_id": envelope.get("external_resource_id"),
+                "version_id": envelope.get("version_id"),
+                "mapping_warnings": envelope.get("mapping_warnings") or [],
+                "validation_errors": envelope.get("validation_errors") or [],
+            }
+        return result
+
+    def get_source(self, *, fact_id: UUID, patient_id: UUID) -> dict[str, Any] | None:
+        """Return one original FHIR envelope only after the caller authorizes the fact."""
+        fact_result = (
+            self.db.table("clinical_facts")
+            .select("id")
+            .eq("id", str(fact_id))
+            .eq("patient_id", str(patient_id))
+            .single()
+            .execute()
+        )
+        if not fact_result.data:
+            return None
+        citation_result = (
+            self.db.table("evidence_citations")
+            .select("provenance_id")
+            .eq("fact_id", str(fact_id))
+            .execute()
+        )
+        citations = cast(list[dict[str, Any]], citation_result.data or [])
+        provenance_id = next(
+            (str(row["provenance_id"]) for row in citations if row.get("provenance_id")), None
+        )
+        if provenance_id is None:
+            return None
+        provenance_result = (
+            self.db.table("source_provenances")
+            .select("source_system, source_reference")
+            .eq("id", provenance_id)
+            .single()
+            .execute()
+        )
+        provenance = cast(dict[str, Any] | None, provenance_result.data)
+        if provenance is None:
+            return None
+        source_reference = provenance.get("source_reference")
+        if not isinstance(source_reference, str) or not source_reference.startswith(
+            self._FHIR_ENVELOPE_PREFIX
+        ):
+            return None
+        envelope_result = (
+            self.db.table("fhir_import_resources")
+            .select(
+                "issuer, resource_type, external_resource_id, version_id, mapping_warnings, validation_errors, raw_resource"
+            )
+            .eq("id", source_reference[len(self._FHIR_ENVELOPE_PREFIX) :])
+            .single()
+            .execute()
+        )
+        envelope = cast(dict[str, Any] | None, envelope_result.data)
+        if not envelope:
+            return None
+        return {
+            "issuer": envelope.get("issuer") or provenance.get("source_system"),
+            "resource_type": envelope.get("resource_type") or "FHIR resource",
+            "external_resource_id": envelope.get("external_resource_id"),
+            "version_id": envelope.get("version_id"),
+            "mapping_warnings": envelope.get("mapping_warnings") or [],
+            "validation_errors": envelope.get("validation_errors") or [],
+            "raw_resource": envelope.get("raw_resource") or {},
+        }

--- a/backend/src/app/services/fhir_import_service.py
+++ b/backend/src/app/services/fhir_import_service.py
@@ -221,7 +221,9 @@ class FhirImportService:
                 fact_type=mapped["fact_type"],
                 subject_type=resource_type,
                 value=mapped["value"],
-                confidence_band=ConfidenceBand.HIGH,
+                # Direct FHIR transport preserves the source faithfully, but it
+                # does not establish clinical certainty or approval locally.
+                confidence_band=ConfidenceBand.UNKNOWN,
                 uncertainty=["Imported data requires clinician review before clinical use."],
                 provenance=SourceProvenanceCreate(
                     artifact_type=SourceArtifactType.FHIR_RESOURCE,

--- a/backend/tests/integration/routers/test_smart_api.py
+++ b/backend/tests/integration/routers/test_smart_api.py
@@ -11,7 +11,12 @@ import pytest
 
 from app.main import app
 from app.models.auth import CurrentUser
-from app.routers.smart import _clinician_dep, _fhir_audit_export_service, _service
+from app.routers.smart import (
+    _clinician_dep,
+    _fhir_audit_export_service,
+    _fhir_import_review_service,
+    _service,
+)
 
 
 @pytest.fixture
@@ -34,6 +39,14 @@ def clinician() -> CurrentUser:
 def fhir_audit_export_service() -> MagicMock:
     service = MagicMock()
     app.dependency_overrides[_fhir_audit_export_service] = lambda: service
+    yield service
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def fhir_import_review_service() -> MagicMock:
+    service = MagicMock()
+    app.dependency_overrides[_fhir_import_review_service] = lambda: service
     yield service
     app.dependency_overrides.clear()
 
@@ -124,5 +137,64 @@ def test_fact_fhir_audit_requires_assignment_and_returns_generated_resources(
         clinician_id=clinician.id, patient_id=patient_id
     )
     fhir_audit_export_service.export_for_fact.assert_called_once_with(
+        fact_id=fact_id, patient_id=patient_id
+    )
+
+
+def test_fact_review_and_source_routes_require_assignment_and_keep_raw_source_explicit(
+    client, smart_service, fhir_import_review_service, clinician
+) -> None:
+    patient_id = uuid4()
+    fact_id = uuid4()
+    fhir_import_review_service.list_facts.return_value = {
+        "patient_id": str(patient_id),
+        "review_state": "pending_review",
+        "facts": [
+            {
+                "id": str(fact_id),
+                "patient_id": str(patient_id),
+                "fact_type": "medication",
+                "subject_type": "medication",
+                "value": {"name": "Metformin"},
+                "confidence_band": "unknown",
+                "review_state": "pending_review",
+                "created_at": "2026-08-28T00:00:00Z",
+                "updated_at": "2026-08-28T00:00:00Z",
+                "source": {
+                    "issuer": "https://sandbox.example/fhir",
+                    "resource_type": "MedicationRequest",
+                    "mapping_warnings": [],
+                    "validation_errors": [],
+                },
+            }
+        ],
+        "total_count": 1,
+        "state_counts": {"pending_review": 1},
+        "fact_type_counts": {"medication": 1},
+        "offset": 0,
+        "limit": 25,
+    }
+    fhir_import_review_service.get_source.return_value = {
+        "issuer": "https://sandbox.example/fhir",
+        "resource_type": "MedicationRequest",
+        "mapping_warnings": [],
+        "validation_errors": [],
+        "raw_resource": {"resourceType": "MedicationRequest", "id": "med-1"},
+    }
+
+    review_response = client.get(f"/api/v1/smart/patients/{patient_id}/facts")
+
+    assert review_response.status_code == 200
+    assert "raw_resource" not in review_response.json()["facts"][0]["source"]
+    fhir_import_review_service.list_facts.assert_called_once()
+    smart_service.ensure_assignment.assert_called_once_with(
+        clinician_id=clinician.id, patient_id=patient_id
+    )
+
+    source_response = client.get(f"/api/v1/smart/patients/{patient_id}/facts/{fact_id}/source")
+
+    assert source_response.status_code == 200
+    assert source_response.json()["raw_resource"]["id"] == "med-1"
+    fhir_import_review_service.get_source.assert_called_once_with(
         fact_id=fact_id, patient_id=patient_id
     )

--- a/backend/tests/unit/services/test_fhir_import_review_service.py
+++ b/backend/tests/unit/services/test_fhir_import_review_service.py
@@ -1,0 +1,161 @@
+"""Tests for the clinician-facing SMART import review projection."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from app.models.clinical_fact import ClinicalFactReviewState
+from app.services.fhir_import_review_service import FhirImportReviewService
+
+PATIENT_ID = UUID("00000000-0000-0000-0000-000000000111")
+PENDING_FACT_ID = "00000000-0000-0000-0000-000000000222"
+APPROVED_FACT_ID = "00000000-0000-0000-0000-000000000333"
+DELETED_FACT_ID = "00000000-0000-0000-0000-000000000444"
+PROVENANCE_ID = "00000000-0000-0000-0000-000000000555"
+RESOURCE_ID = "00000000-0000-0000-0000-000000000666"
+
+
+class Result:
+    def __init__(self, data: Any) -> None:
+        self.data = data
+
+
+class Table:
+    def __init__(self, name: str, store: dict[str, list[dict[str, Any]]]) -> None:
+        self.name = name
+        self.store = store
+        self.filters: list[tuple[str, set[str]]] = []
+        self.return_single = False
+        self.slice: tuple[int, int] | None = None
+
+    def select(self, *_fields: str) -> Table:
+        return self
+
+    def eq(self, column: str, value: Any) -> Table:
+        self.filters.append((column, {str(value)}))
+        return self
+
+    def in_(self, column: str, values: list[str]) -> Table:
+        self.filters.append((column, {str(value) for value in values}))
+        return self
+
+    def order(self, *_args: Any, **_kwargs: Any) -> Table:
+        return self
+
+    def range(self, start: int, end: int) -> Table:
+        self.slice = (start, end)
+        return self
+
+    def single(self) -> Table:
+        self.return_single = True
+        return self
+
+    def execute(self) -> Result:
+        rows = [
+            row
+            for row in self.store.get(self.name, [])
+            if all(str(row.get(column)) in values for column, values in self.filters)
+        ]
+        if self.slice is not None:
+            start, end = self.slice
+            rows = rows[start : end + 1]
+        if self.return_single:
+            return Result(rows[0] if rows else None)
+        return Result(rows)
+
+
+class Database:
+    def __init__(self, store: dict[str, list[dict[str, Any]]]) -> None:
+        self.store = store
+
+    def table(self, name: str) -> Table:
+        return Table(name, self.store)
+
+
+def fact(fact_id: str, review_state: str, fact_type: str = "medication") -> dict[str, Any]:
+    return {
+        "id": fact_id,
+        "patient_id": str(PATIENT_ID),
+        "fact_type": fact_type,
+        "subject_type": fact_type,
+        "value": {"name": "Metformin", "status": "active"},
+        "confidence_score": None,
+        "confidence_band": "unknown",
+        "uncertainty": [],
+        "review_state": review_state,
+        "created_at": "2026-08-28T00:00:00Z",
+        "updated_at": "2026-08-28T00:00:00Z",
+    }
+
+
+def database() -> Database:
+    return Database(
+        {
+            "clinical_facts": [
+                fact(PENDING_FACT_ID, "pending_review"),
+                fact(APPROVED_FACT_ID, "approved", "condition"),
+                fact(DELETED_FACT_ID, "deleted", "observation"),
+            ],
+            "evidence_citations": [
+                {"fact_id": PENDING_FACT_ID, "provenance_id": PROVENANCE_ID},
+            ],
+            "source_provenances": [
+                {
+                    "id": PROVENANCE_ID,
+                    "source_system": "https://sandbox.example/fhir",
+                    "source_reference": f"fhir_import_resources/{RESOURCE_ID}",
+                }
+            ],
+            "fhir_import_resources": [
+                {
+                    "id": RESOURCE_ID,
+                    "issuer": "https://sandbox.example/fhir",
+                    "resource_type": "MedicationRequest",
+                    "external_resource_id": "med-123",
+                    "version_id": "7",
+                    "mapping_warnings": ["Dose frequency was not supplied."],
+                    "validation_errors": [],
+                    "raw_resource": {"resourceType": "MedicationRequest", "id": "med-123"},
+                }
+            ],
+        }
+    )
+
+
+def test_review_projection_shows_candidate_fields_and_source_metadata_without_raw_resource() -> (
+    None
+):
+    service = FhirImportReviewService(database())  # type: ignore[arg-type]
+
+    review = service.list_facts(
+        patient_id=PATIENT_ID,
+        review_state=ClinicalFactReviewState.PENDING_REVIEW,
+        offset=0,
+        limit=25,
+    )
+
+    assert review["total_count"] == 1
+    assert review["state_counts"] == {"pending_review": 1, "approved": 1}
+    assert review["fact_type_counts"] == {"medication": 1, "condition": 1}
+    assert review["facts"][0]["value"] == {"name": "Metformin", "status": "active"}
+    assert review["facts"][0]["source"] == {
+        "issuer": "https://sandbox.example/fhir",
+        "resource_type": "MedicationRequest",
+        "external_resource_id": "med-123",
+        "version_id": "7",
+        "mapping_warnings": ["Dose frequency was not supplied."],
+        "validation_errors": [],
+    }
+    assert "raw_resource" not in review["facts"][0]["source"]
+
+
+def test_original_resource_is_available_only_from_the_explicit_source_read() -> None:
+    service = FhirImportReviewService(database())  # type: ignore[arg-type]
+
+    source = service.get_source(fact_id=UUID(PENDING_FACT_ID), patient_id=PATIENT_ID)
+
+    assert source is not None
+    assert source["raw_resource"] == {"resourceType": "MedicationRequest", "id": "med-123"}
+    assert service.get_source(fact_id=UUID(APPROVED_FACT_ID), patient_id=PATIENT_ID) is None
+    assert service.get_source(fact_id=UUID(PENDING_FACT_ID), patient_id=UUID(int=999)) is None

--- a/backend/tests/unit/services/test_fhir_import_service.py
+++ b/backend/tests/unit/services/test_fhir_import_service.py
@@ -93,6 +93,7 @@ def test_supported_resources_become_pending_provenance_backed_facts() -> None:
 
     assert result == {"resources_persisted": 2, "candidate_facts_created": 2, "warnings": []}
     assert {row["review_state"] for row in db.store["clinical_facts"]} == {"pending_review"}
+    assert {row["confidence_band"] for row in db.store["clinical_facts"]} == {"unknown"}
     assert len(db.store["source_provenances"]) == 2
     assert all(row["artifact_type"] == "fhir_resource" for row in db.store["source_provenances"])
     assert len(db.store["clinical_fact_audit_events"]) == 2

--- a/docs/clinical-facts-provenance.md
+++ b/docs/clinical-facts-provenance.md
@@ -54,3 +54,13 @@ excludes clinical-fact values, evidence excerpts, reviewer notes, and private re
 The route first verifies the requesting clinician's existing care-team assignment. It
 does not create a FHIR server endpoint, change local review state, or grant authority to
 an external SMART identity.
+
+## SMART candidate review
+
+The clinician portal exposes SMART-imported candidates in a separate patient-level
+review tab. It shows the mapped candidate, explicit review state, source issuer and
+resource version, and recorded mapping or validation warnings. The original FHIR JSON
+is available only through a separate, care-team-authorized source request; it is not
+included in the ordinary candidate list. See
+[`smart-fhir-review-mapping.md`](smart-fhir-review-mapping.md) for the resource-to-field
+contract and the EHR-initiated versus standalone launch behavior.

--- a/docs/smart-fhir-review-mapping.md
+++ b/docs/smart-fhir-review-mapping.md
@@ -1,0 +1,77 @@
+# SMART FHIR import review mapping
+
+MediAgent uses the SMART Health IT public R4 sandbox only with synthetic data.
+An external resource is imported as a provenance-backed **candidate**, never as
+an automatic update to the local patient record. Clinician review is required
+before a candidate can be approved.
+
+## What clinicians see
+
+The patient detail page has a **SMART imports** tab. It separates candidates
+from the existing local profile and shows the following for each candidate:
+
+- mapped fields that can be reviewed without interpreting the original payload;
+- review state, uncertainty, and any validation or mapping warning;
+- source issuer, FHIR resource type, external resource identifier, and version;
+- the original FHIR JSON only after the clinician explicitly chooses **Source**.
+
+Approval, correction, and rejection are recorded in the existing clinical-fact
+audit trail. Imported candidates begin with **unknown** clinical confidence:
+structured source fidelity is not a clinical assessment. Approval does not overwrite existing local medications,
+conditions, allergies, or demographics. A correction changes only the pending
+candidate and preserves the original resource envelope.
+
+## Supported R4-compatible resource mappings
+
+| FHIR resource | Candidate type | Clinician-visible mapped fields | Deliberately not inferred |
+| --- | --- | --- | --- |
+| `Patient` | `patient_demographics` | name, birth date, administrative gender | identity match, account creation, local demographic overwrite |
+| `Encounter` | `encounter` | status, class, type, period | billing interpretation or care-team assignment |
+| `Condition` | `condition` | condition name, clinical status, onset | diagnostic certainty beyond the source |
+| `AllergyIntolerance` | `allergy` | allergen, clinical status, reactions | severity if the source does not state it |
+| `MedicationRequest`, `MedicationStatement` | `medication` | medication name, status, dosage instructions | medication reconciliation or an active local prescription |
+| `Observation` | `observation` | code, value, effective time, status | trend or clinical interpretation |
+| `DiagnosticReport` | `diagnostic_report` | report code, conclusion, status | a diagnosis based on report text |
+| `Procedure` | `procedure` | procedure code, status, performed time | outcome or follow-up plan |
+| `CarePlan` | `care_plan` | title, description, status, intent | acceptance as a local plan of care |
+| `DocumentReference` | `document_reference` | type, description, date, status | document download, OCR, or new local document storage |
+
+Unsupported resource types are preserved in the import envelope with a warning
+but do not create a candidate fact. Missing or partial source fields are shown
+as `Not supplied`; the review UI does not manufacture a value.
+
+## Two valid launch paths
+
+### EHR-initiated launch
+
+1. The sandbox EHR selects a patient and practitioner, then opens
+   `https://clinician.mediagent.live/smart-import` with its `iss` and opaque
+   `launch` context.
+2. A locally signed-in clinician selects an already assigned local synthetic
+   patient. This local selection is an import target, not an external patient
+   match.
+3. MediAgent starts a server-side authorization-code flow with PKCE, then the
+   sandbox redirects to the backend callback.
+4. The backend exchanges the code, reads the permitted external resources,
+   stores original envelopes, and creates pending candidates.
+5. The portal redeems a short-lived handoff ticket and opens SMART import
+   review.
+
+The return to the sandbox after the first portal visit is expected: the EHR
+launch supplies context, while the authorization-code flow separately obtains
+the scoped read permission.
+
+### Standalone launch from the portal
+
+Opening `/smart-import` with no query string does **not** reuse an old EHR
+selection. After the clinician chooses a local patient and presses **Launch
+sandbox import**, MediAgent starts a fresh standalone SMART authorization. The
+sandbox then supplies its own patient and encounter launch context. The same
+candidate/provenance/review rules apply.
+
+## Standards references
+
+- [SMART App Launch](https://www.hl7.org/fhir/smart-app-launch/app-launch.html)
+- [SMART scopes and launch context](https://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html)
+- [FHIR R4 Provenance](https://www.hl7.org/fhir/R4/provenance.html)
+- [FHIR R4 AuditEvent](https://www.hl7.org/fhir/R4/auditevent.html)

--- a/docs/supabase_setup_guide.md
+++ b/docs/supabase_setup_guide.md
@@ -26,7 +26,7 @@ Apply every SQL file through the repository migration ledger against an empty de
 
 Copy the URI rather than assembling it: the pooler tenant, host, and password encoding are project-specific. The Session Pooler supports IPv4 clients and is required here because the migration command maintains a session while applying each SQL file.
 
-This currently applies migrations `001` through `025`, including canonical clinical facts (`017`), SMART/FHIR import envelopes (`018`), clinical-action approval controls (`019`), database-security hardening (`020`), and the least-privilege server-only grants used by the synthetic fixture, A2A retry worker, patient feed, reminder schedules, and adherence statistics (`021`–`025`). The history contains two `011` filenames; the migration ledger uses full filenames and checksums, making the ordering unambiguous.
+This currently applies migrations `001` through `028`, including canonical clinical facts (`017`), SMART/FHIR import envelopes (`018`), clinical-action approval controls (`019`), database-security hardening (`020`), and the least-privilege server-only grants used by the synthetic fixture, A2A retry worker, patient feed, reminder schedules, adherence statistics, SMART import review, and clinician review reads (`021`–`028`). The history contains two `011` filenames; the migration ledger uses full filenames and checksums, making the ordering unambiguous.
 
 ## Configure SMART staging
 


### PR DESCRIPTION
## Summary
- add a patient-level SMART imports tab for pending, approved, and rejected candidate facts
- show mapped FHIR fields, mapping/validation warnings, source metadata, and original-resource inspection on demand
- add clinician review actions with notes and corrections; candidates remain separate from approved local truth
- clarify standalone SMART launch behavior and document the R4 mapping boundary
- retain imported candidates at unknown clinical confidence until clinician review

## Verification
- backend/.venv/bin/pytest --no-cov (731 passed)
- backend Ruff, formatting, mypy, migration validation
- clinician portal: 76 tests passed, lint, typecheck, webpack production build

## Checklist
- [x] I have read `CONTRIBUTING.md` and `.agent/CODING_STANDARDS.md`.
- [x] My code follows the architecture in `.agent/ARCHITECTURE.md`.
- [x] I ran required lint checks for touched surfaces (`ruff` / `eslint`).
- [x] I ran required type/test checks for touched surfaces (`mypy` / `pytest` / frontend tests/build).
- [x] I added or updated tests for changed behavior, or documented why tests are not applicable.
- [x] I verified no secrets or credentials were added (including `.env*`, keys, tokens, service-account files).
- [x] I listed manual verification steps below.

## Manual verification
1. Sign in as the assigned clinician and open a patient’s **SMART imports** tab.
2. Confirm pending candidates show mapping details, source metadata, warnings, and the original resource only after selecting **Source**.
3. Approve, reject, and correct a candidate with notes; verify local approved records are not silently overwritten.
4. Start a standalone SMART sandbox launch; confirm it creates a new authorization session rather than reusing prior EHR context.

No migration or staging write is required for this PR.